### PR TITLE
fix(modal): modal 修复 Modal 默认写死宽度的问题

### DIFF
--- a/components/modal/Modal.web.tsx
+++ b/components/modal/Modal.web.tsx
@@ -62,7 +62,7 @@ export default class Modal extends React.Component<ModalProps, any> {
 
     // transparent 模式下, 内容默认居中
     const rootStyle = transparent ? assign({
-      width: '5.4rem',
+      minWidth: '5.4rem',
       height: 'auto',
     }, style) : assign({
       width: '100%',


### PR DESCRIPTION
First of all, thanks for your contribution! :-)

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

现在 Modal 通过内联 style 写死了 4.5rem 的宽度，业务上也无法覆盖。
建议改成 min-width 达到同样效果（更好的方式是不是通过内置的 class
来定义？）

这样业务上需要更宽的 Modal 可以定义：

```css
.am-modal {
  width: 90%;
  max-width: 640px;
}
```