### PR TITLE
Fix popup: hide previous instance before creating a new one

### DIFF
--- a/components/popup/index.web.tsx
+++ b/components/popup/index.web.tsx
@@ -94,6 +94,7 @@ export default class Popup {
     };
   }
   static show = (content, config) => {
+    Popup.hide();
     ins.defaultInstance = create('0', config, content, (iId) => {
       if (iId === '0') {
         ins.defaultInstance = null;


### PR DESCRIPTION
调用 `Popup.show()` 多次的话，会出现多个 Popup。
多个 Popup 应该用 `Popup.newInstance()`。`Popup.show()` 只应该有一个 Popup。
所以应该先隐藏之前的实例，再创建新的。