### PR TITLE
fix hashHistory/browserHistory change, comp state dont update

### DIFF
--- a/components/action-sheet/index.web.tsx
+++ b/components/action-sheet/index.web.tsx
@@ -25,6 +25,9 @@ function createActionSheet(flag, config, callback) {
   document.body.appendChild(div);
 
   queue.push(close);
+  ['hashchange', 'popstate'].map((event) => {
+    window.addEventListener(event, close, false);
+  });
 
   function close() {
     if (div) {
@@ -36,6 +39,11 @@ function createActionSheet(flag, config, callback) {
         queue.splice(index, 1);
       }
     }
+
+    ['hashchange', 'popstate'].map((event) => {
+      window.removeEventListener(event, close, false);
+    });
+
   }
 
   function cb(index, rowIndex = 0) {

--- a/components/modal/alert.web.tsx
+++ b/components/modal/alert.web.tsx
@@ -18,9 +18,15 @@ export default function (...args) {
   let div: any = document.createElement('div');
   document.body.appendChild(div);
 
+  ['hashchange', 'popstate'].map((event) => {
+    window.addEventListener(event, close, false);
+  });
   function close() {
     ReactDOM.unmountComponentAtNode(div);
     div.parentNode.removeChild(div);
+    ['hashchange', 'popstate'].map((event) => {
+      window.removeEventListener(event, close, false);
+    });
   }
 
   const footer = actions.map((button) => {

--- a/components/modal/prompt.web.tsx
+++ b/components/modal/prompt.web.tsx
@@ -77,9 +77,15 @@ export default function (...args) {
   let div: any = document.createElement('div');
   document.body.appendChild(div);
 
+  ['hashchange', 'popstate'].map((event) => {
+    window.addEventListener(event, close, false);
+  });
   function close() {
     ReactDOM.unmountComponentAtNode(div);
     div.parentNode.removeChild(div);
+    ['hashchange', 'popstate'].map((event) => {
+      window.addEventListener(event, close, false);
+    });
   }
 
   function getArgs(func) {

--- a/components/popup/index.web.tsx
+++ b/components/popup/index.web.tsx
@@ -16,6 +16,9 @@ function create(instanceId, config, content, afterClose = (_x: any) => { }) {
   let div: any = document.createElement('div');
   document.body.appendChild(div);
 
+  ['hashchange', 'popstate'].map((event) => {
+    window.addEventListener(event, close, false);
+  });
   function close() {
     if (div) {
       ReactDOM.unmountComponentAtNode(div);
@@ -23,6 +26,9 @@ function create(instanceId, config, content, afterClose = (_x: any) => { }) {
       div = null;
     }
     afterClose(instanceId);
+    ['hashchange', 'popstate'].map((event) => {
+      window.addEventListener(event, close, false);
+    });
   }
 
   let transName = 'am-slide-down';

--- a/components/toast/index.web.tsx
+++ b/components/toast/index.web.tsx
@@ -45,14 +45,23 @@ function notice(content, type, duration = 3, onClose) {
       </div>
     ),
     onClose: () => {
-      if (onClose) {
-        onClose();
-      }
-      instance.destroy();
-      instance = null;
-      messageInstance = null;
+      close();
     },
   });
+  ['hashchange', 'popstate'].map((event) => {
+    window.addEventListener(event, close, false);
+  });
+  function close() {
+    if (onClose) {
+      onClose();
+    }
+    instance.destroy();
+    instance = null;
+    messageInstance = null;
+    ['hashchange', 'popstate'].map((event) => {
+      window.removeEventListener(event, close, false);
+    });
+  }
 }
 
 export default {


### PR DESCRIPTION
在使用react-router(or other front-end router)，hashchange/popstate路由改变的时候(浏览器前进后退/webview后退)，acion-sheet/modal/popup/toast(动态append到body的组件)不会关闭，覆盖了其他组件
gif:
![](https://raw.githubusercontent.com/coderwin/__/master/src/asserts/antdm.gif)