### PR TITLE
fix(RN-Grid) 修复Grid onClick点击失效的BUG

### DIFF
--- a/components/grid/index.tsx
+++ b/components/grid/index.tsx
@@ -28,8 +28,8 @@ export default class Grid extends React.Component<GridProps, any> {
     const dataLength = data && data.length || 0;
     const rowCount = Math.ceil(dataLength / columnNum);
 
-    const renderItem = this.props.renderItem || ((dataItem: DataItem) => (
-      <Flex direction="column" justify="center" style={{ flex: 1 }}>
+    const renderItem = this.props.renderItem || ((dataItem: DataItem, index: number) => (
+      <Flex direction="column" justify="center" style={{ flex: 1 }} onPress={() => onClick(dataItem, index)}>
         {React.isValidElement(dataItem.icon) ?
         dataItem.icon : (<Image source={{ uri: dataItem.icon }} style={styles.icon} />)}
         <Text style={styles.text}>{dataItem.text}</Text>


### PR DESCRIPTION
issues: https://github.com/ant-design/ant-design-mobile/issues/755

问题：Grid onClick点击失效

原因：Grid 由FlexItem 与Flex组件包裹着，onClick事件绑定在外层的FlexItem组件上，所以点击时调用的内层的Flex组件的默认onPress函数。

已通过DEMO证明，两个TouchableWithoutFeedback，分别加上onPress函数，点击时只有最里面的那个TouchableWithoutFeedback的onPress函数会被调用。
**但是不清楚之前的RN会不会也是这样，所以保留了原有的操作**

DEMO RN版本：0.40.0

DEMO代码：https://gist.github.com/Lxxyx/3043b1120943c6abe93914727d4323a7
点击时输出：Inner TouchableWithoutFeedback
