### PR TITLE
Button缺少className声明

### DIFF
--- a/components/button/PropsType.tsx
+++ b/components/button/PropsType.tsx
@@ -11,6 +11,7 @@ interface ButtonProps {
   loading?: boolean;
   icon?: any;
   prefixCls?: string;
+  className?: string;
   /** rn only */
   onPressIn?: (x: any) => void;
   onPressOut?: (x: any) => void;

--- a/components/button/index.md
+++ b/components/button/index.md
@@ -27,6 +27,7 @@ source: design
 | loading (`WEB only`)	   | 设置按钮载入状态	  | boolean	 | false |
 | icon (`WEB only`)  | 可以是 Icon 组件里包含的 icon 的名字，也可以是 require 本地 svg 图标 (注意：loading 设置后此项设置失效) | string/require(./local.svg) | -  |
 | prefixCls (`WEB only`) |  class前缀 | string | `am-button` |
+| className (`WEB only`) |  样式类名 | string | 无 |
 | onPressIn (`RN only`)   | 同 RN TouchableHighlight onPressIn | (e: Object): void |   无  |
 | onPressOut (`RN only`)    | 同 RN TouchableHighlight onPressOut | (e: Object): void |   无  |
 | onShowUnderlay (`RN only`)    | 同 RN TouchableHighlight onShowUnderlay | (e: Object): void |   无  |


### PR DESCRIPTION
`prefixCls `,`className `都是class前缀
但prefixCls特殊一点，文档可以补充得详细点，我不太会表达就没动

```
    const wrapCls = {
      [className as string]: className,
      [prefixCls as string]: true,
      [`${prefixCls}-primary`]: type === 'primary',
      [`${prefixCls}-ghost`]: type === 'ghost',
      [`${prefixCls}-warning`]: type === 'warning',
      [`${prefixCls}-small`]: size === 'small',
      [`${prefixCls}-inline`]: inline,
      [`${prefixCls}-across`]: across,
      [`${prefixCls}-disabled`]: disabled,
      [`${prefixCls}-loading`]: loading,
    };
```
