### PR TITLE
fix(input-item): clear bug on pc. close #830

### DIFF
--- a/components/input-item/index.web.tsx
+++ b/components/input-item/index.web.tsx
@@ -119,7 +119,7 @@ class InputItem extends React.Component<InputItemProps, any> {
       this.setState({
         focus: false,
       });
-    }, 100);
+    }, 200);
     if (!('focused' in this.props)) {
       this.setState({
         focused: false,
@@ -269,7 +269,7 @@ class InputItem extends React.Component<InputItemProps, any> {
         {clear && editable && !disabled && (value && value.length > 0) ?
           <div
             className={`${prefixCls}-clear`}
-            onTouchStart={() => { this.clearInput();}}
+            onClick={this.clearInput}
           />
           : null}
         {error ? (<div className={`${prefixCls}-error-extra`} onClick={this.onErrorClick} />) : null}


### PR DESCRIPTION
ref: #830 

- `onTouchStart`在PC上无效
- 时间增大到200是因为，100ms, 会先blur -> rerender -> clear icon 消失 --> 等不到 clear 的 onClick执行 （这个方案还是不够好 @pigcan ）

First of all, thanks for your contribution! :-)

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.
