### PR TITLE
Picker tsx error

### DIFF
--- a/components/picker/PropsType.tsx
+++ b/components/picker/PropsType.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { IPopupCascaderProps } from 'rmc-cascader/lib/Popup';
 import { CascaderValue } from 'rmc-cascader/lib/CascaderTypes';
+import { IPopupPickerProps } from 'rmc-picker/lib/PopupPickerTypes';
 
-interface Props extends IPopupCascaderProps {
+interface Props extends IPopupPickerProps {
   data: any;
   cascade?: boolean;
   value?: Array<string|number>;
@@ -10,6 +10,7 @@ interface Props extends IPopupCascaderProps {
   cols?: number;
   extra?: string;
   children?: any;
+  onChange?: (date?: CascaderValue) => void;
   /** web only */
   pickerPrefixCls?: string;
   popupPrefixCls?: string;


### PR DESCRIPTION
不好意思，自己挖的坑自己填

`IPopupCascaderProps`里`cascader`是必填项，`Picker`里内置了cascader，一般不需要传进去，不是必填项

又因为不确定你们typescript用的版本，就手动写了`IPartialPopupCascaderProps`

`2.1`支持`Partial`，声明可以写成
```
type IPartialPopupCascaderProps = Partial<IPopupCascaderProps>
```

