### PR TITLE
fix-search-bar-style

### DIFF
--- a/components/search-bar/style/index.less
+++ b/components/search-bar/style/index.less
@@ -126,6 +126,7 @@
         }
       }
       .@{searchPrefixCls}-synthetic-ph {
+        box-sizing: content-box;
         padding-left: 30px;
         width: auto;
       }


### PR DESCRIPTION
如果
```
* {
  box-sizing: border-box;
}
```

`SearchBar`onFocus时长度变短了，会显示不完整

这里应该确定盒子模型不被污染吧

First of all, thanks for your contribution! :-)

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.
