### PR TITLE
fix(SearchBar): onBlur before onClick, cause android can not clear.

### DIFF
--- a/components/search-bar/index.web.tsx
+++ b/components/search-bar/index.web.tsx
@@ -116,15 +116,16 @@ export default class SearchBar extends React.Component<SearchBarProps, SearchBar
   };
 
   onBlur = () => {
-    this.setState({
-      focus: false,
-    });
-    if (!('focused' in this.props)) {
+    setTimeout(() => {
       this.setState({
-        focused: false,
+        focus: false,
       });
-    }
-
+      if (!('focused' in this.props)) {
+        this.setState({
+          focused: false,
+        });
+      }
+    }, 0);
     if (this.props.onBlur) {
       this.props.onBlur();
     }


### PR DESCRIPTION
修复Android 上无法clear的bug：
- onBlur 先 focus = false
- rerender, clear icon 被 hidden
- 由于移动端click 300 ms 延迟，click 得不到触发


First of all, thanks for your contribution! :-)

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.
