### PR TITLE
fix readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,4 +56,4 @@ http://mobile.ant.design/kitchen-sink/
 
 ## Contributing
 
-We welcome all contributions, please read our [CONTRIBUTING.md](https://github.com/ant-design/ant-design-mobile/blob/master/.github/CONTRIBUTING.en-US.md) first. You can submit any ideas as [pull requests](https://github.com/ant-design/ant-design-mobile/pulls) or as a [GitHub issue](https://github.com/ant-design/ant-design-mobile/issues). If you'd like to improve code, check out the [Development Instruction](https://github.com/ant-design/ant-design-mobile/blob/master/development.en-US.md) and have a good time! :)
+We welcome all contributions, please read our [CONTRIBUTING.md](https://github.com/ant-design/ant-design-mobile/blob/master/.github/CONTRIBUTING.md) first. You can submit any ideas as [pull requests](https://github.com/ant-design/ant-design-mobile/pulls) or as a [GitHub issue](https://github.com/ant-design/ant-design-mobile/issues). If you'd like to improve code, check out the [Development Instruction](https://github.com/ant-design/ant-design-mobile/blob/master/development.en-US.md) and have a good time! :)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -41,7 +41,7 @@ http://mobile.ant.design/kitchen-sink/
 
 ## 安装 & 使用
 
-[introduce](docs/react/introduce.zh-CN.md#安装)
+[介绍](docs/react/introduce.zh-CN.md#安装)
 
 ## 浏览器支持
 


### PR DESCRIPTION
中文说明里有一句英文，English readme link `.github/CONTRIBUTING.en-US.md` is not exists.

* [x] Make sure you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.