### PR TITLE
Fix React v15.5.0 new deprecation warnings

### DIFF
--- a/components/carousel/index.web.tsx
+++ b/components/carousel/index.web.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import classNames from 'classnames';
 import ReactCarousel from 'nuka-carousel';
 import assign from 'object-assign';
@@ -46,7 +47,7 @@ export default class Carousel extends React.Component<CarouselProps, any> {
     const current = this.state.selectedIndex;
     if (props.dots) {
       Decorators = [{
-        component: React.createClass({
+        component: createReactClass({
           render() {
             const { slideCount, slidesToScroll } = this.props;
             const arr: number[] = [];

--- a/components/date-picker/index.tsx
+++ b/components/date-picker/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import PopupDatePicker from 'rmc-date-picker/lib/Popup';
 import PopupStyles from '../picker/styles';
 import { formatFn, getProps as getDefaultProps, getDefaultDate } from './utils';
@@ -16,7 +17,7 @@ export default class DatePicker extends React.Component<tsPropsType, any> {
   }, getDefaultProps());
 
   static contextTypes = {
-    antLocale: React.PropTypes.object,
+    antLocale: PropTypes.object,
   };
 
   render() {

--- a/components/date-picker/index.web.tsx
+++ b/components/date-picker/index.web.tsx
@@ -1,5 +1,6 @@
 /* eslint no-console:0 */
 import React from 'react';
+import PropTypes from 'prop-types';
 import PopupDatePicker from 'rmc-date-picker/lib/Popup';
 import RCDatePicker from 'rmc-date-picker/lib/DatePicker';
 import { formatFn, getProps, getDefaultDate } from './utils';
@@ -20,7 +21,7 @@ export default class DatePicker extends React.Component<tsPropsType, any> {
   static defaultProps = getDefaultProps();
 
   static contextTypes = {
-    antLocale: React.PropTypes.object,
+    antLocale: PropTypes.object,
   };
 
   render() {

--- a/components/locale-provider/index.tsx
+++ b/components/locale-provider/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 export interface LocaleProviderProps {
   locale: {
@@ -10,11 +11,11 @@ export interface LocaleProviderProps {
 
 export default class LocaleProvider extends React.Component<LocaleProviderProps, any> {
   static propTypes = {
-    locale: React.PropTypes.object,
+    locale: PropTypes.object,
   };
 
   static childContextTypes = {
-    antLocale: React.PropTypes.object,
+    antLocale: PropTypes.object,
   };
 
   getChildContext() {

--- a/components/menu/index.tsx
+++ b/components/menu/index.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { MenuProps } from './PropsType';
 
-const Menu = React.createClass<MenuProps, any>({
+const Menu = createReactClass<MenuProps, any>({
   render() {
     return <div>TODO for react-native</div>;
   },

--- a/components/nav-bar/index.tsx
+++ b/components/nav-bar/index.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import NavBarProps from './PropsType';
 
-const NavBar = React.createClass<NavBarProps, any>({
+const NavBar = createReactClass<NavBarProps, any>({
   render() {
     return <div>TODO for react-native</div>;
   },

--- a/components/notice-bar/Marquee.tsx
+++ b/components/notice-bar/Marquee.tsx
@@ -5,6 +5,7 @@
 */
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import ReactDOM from 'react-dom';
 import assign from 'object-assign';
 
@@ -18,7 +19,7 @@ export interface MarqueeProp {
   fps?: number;
 }
 
-const Marquee = React.createClass<MarqueeProp, any>({
+const Marquee = createReactClass<MarqueeProp, any>({
   getDefaultProps() {
     return {
       text: '',

--- a/components/pagination/index.tsx
+++ b/components/pagination/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { View, Text } from 'react-native';
 import Button from '../button';
 import Flex from '../flex';
@@ -18,7 +19,7 @@ export default class Pagination extends React.Component<PaginationProps, any> {
   };
 
  static contextTypes = {
-    antLocale: React.PropTypes.object,
+    antLocale: PropTypes.object,
   };
 
   constructor(props) {

--- a/components/pagination/index.web.tsx
+++ b/components/pagination/index.web.tsx
@@ -1,5 +1,6 @@
 /* tslint:disable:jsx-no-multiline-js */
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Button from '../button';
 import Flex from '../flex';
@@ -16,7 +17,7 @@ export default class Pagination extends React.Component<PaginationProps, any> {
   };
 
   static contextTypes = {
-    antLocale: React.PropTypes.object,
+    antLocale: PropTypes.object,
   };
 
   constructor(props) {

--- a/components/range/index.tsx
+++ b/components/range/index.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import RangeProps from './PropsType';
 
-const Range = React.createClass<RangeProps, any>({
+const Range = createReactClass<RangeProps, any>({
   render() {
     return <div>TODO for react-native</div>;
   },

--- a/components/refresh-control/demo/basic.tsx
+++ b/components/refresh-control/demo/basic.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { StyleSheet, View, Text, ScrollView, TouchableWithoutFeedback } from 'react-native';
 import { RefreshControl } from 'antd-mobile';
 
@@ -36,7 +37,7 @@ class Row extends React.Component<any, any> {
   }
 }
 
-export default React.createClass({
+export default createReactClass({
   getInitialState() {
     return {
       isRefreshing: false,

--- a/components/search-bar/demo/basic.tsx
+++ b/components/search-bar/demo/basic.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { View, Alert } from 'react-native';
 import { SearchBar } from 'antd-mobile';
 
-export default React.createClass({
+export default createReactClass({
   getInitialState() {
     return {
       value: '美食',

--- a/components/table/index.tsx
+++ b/components/table/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 
-const Table = React.createClass<any, any>({
+const Table = createReactClass<any, any>({
   render() {
     return <div>TODO for react-native</div>;
   },

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "array-tree-filter": "~1.0.0",
     "babel-runtime": "6.x",
     "classnames": "~2.2.1",
+    "create-react-class": "^15.5.2",
     "moment": "~2.18.1",
     "normalize.css": "^6.0.0",
     "nuka-carousel": "~2.0.4",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "nuka-carousel": "~2.0.4",
     "object-assign": "~4.1.0",
     "omit.js": "~0.1.0",
+    "prop-types": "^15.5.8",
     "rc-checkbox": "~2.0.0",
     "rc-collapse": "~1.7.0",
     "rc-dialog": "~6.5.7",

--- a/site/desktop/src/template/Content/ComponentDoc.jsx
+++ b/site/desktop/src/template/Content/ComponentDoc.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import DocumentTitle from 'react-document-title';
 import classNames from 'classnames';
 import { FormattedMessage } from 'react-intl';
@@ -10,7 +11,7 @@ import Demo from './Demo';
 
 export default class ComponentDoc extends React.Component {
   static contextTypes = {
-    intl: React.PropTypes.object,
+    intl: PropTypes.object,
   }
 
   constructor(props) {

--- a/site/desktop/src/template/Content/Demo.jsx
+++ b/site/desktop/src/template/Content/Demo.jsx
@@ -1,12 +1,13 @@
 /* eslint react/no-danger: 0 */
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { FormattedMessage } from 'react-intl';
 import { Button, Modal, Radio } from 'antd';
 
 export default class Demo extends React.Component {
   static contextTypes = {
-    intl: React.PropTypes.object,
+    intl: PropTypes.object,
   }
 
   state = {

--- a/site/desktop/src/template/Content/MainContent.jsx
+++ b/site/desktop/src/template/Content/MainContent.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Link } from 'bisheng/router';
 import Menu from 'antd/lib/menu';
 import Row from 'antd/lib/row';
@@ -11,7 +12,7 @@ const SubMenu = Menu.SubMenu;
 
 export default class MainContent extends React.Component {
   static contextTypes = {
-    intl: React.PropTypes.object.isRequired,
+    intl: PropTypes.object.isRequired,
   }
 
   componentDidMount() {

--- a/site/desktop/src/template/Layout/Header.jsx
+++ b/site/desktop/src/template/Layout/Header.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Link } from 'bisheng/router';
 import { FormattedMessage } from 'react-intl';
 import enquire from 'enquire.js';
@@ -12,8 +13,8 @@ const Option = Select.Option;
 
 export default class Header extends React.Component {
   static contextTypes = {
-    router: React.PropTypes.object.isRequired,
-    intl: React.PropTypes.object.isRequired,
+    router: PropTypes.object.isRequired,
+    intl: PropTypes.object.isRequired,
   }
 
   constructor(props) {

--- a/site/desktop/src/template/Layout/index.jsx
+++ b/site/desktop/src/template/Layout/index.jsx
@@ -1,4 +1,5 @@
 import React, { cloneElement } from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import { addLocaleData, IntlProvider } from 'react-intl';
 import Header from './Header';
@@ -19,7 +20,7 @@ if (typeof window !== 'undefined') {
 
 export default class Layout extends React.Component {
   static contextTypes = {
-    router: React.PropTypes.object.isRequired,
+    router: PropTypes.object.isRequired,
   };
   constructor(props) {
     super(props);


### PR DESCRIPTION
React v15.5.0 extracted `React.PropTypes` and `React.createClass` into their own packages. Usage of these two modules will result in console errors.

See: https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html

This PR migrates components to new styles according to official guide above.
