### PR TITLE
Make List.Item ssr friendly

### DIFF
--- a/components/accordion/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/accordion/__tests__/__snapshots__/demo.test.web.js.snap
@@ -100,6 +100,7 @@ exports[`renders ./components/accordion/demo/basic.md correctly 1`] = `
                 </div>
                 <div
                   class="am-list-ripple"
+                  style="display:none;"
                 />
               </div>
               <div
@@ -116,6 +117,7 @@ exports[`renders ./components/accordion/demo/basic.md correctly 1`] = `
                 </div>
                 <div
                   class="am-list-ripple"
+                  style="display:none;"
                 />
               </div>
               <div
@@ -132,6 +134,7 @@ exports[`renders ./components/accordion/demo/basic.md correctly 1`] = `
                 </div>
                 <div
                   class="am-list-ripple"
+                  style="display:none;"
                 />
               </div>
             </div>

--- a/components/accordion/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/accordion/__tests__/__snapshots__/demo.test.web.js.snap
@@ -99,7 +99,7 @@ exports[`renders ./components/accordion/demo/basic.md correctly 1`] = `
                   </div>
                 </div>
                 <div
-                  class="am-list-riple"
+                  class="am-list-ripple"
                 />
               </div>
               <div
@@ -115,7 +115,7 @@ exports[`renders ./components/accordion/demo/basic.md correctly 1`] = `
                   </div>
                 </div>
                 <div
-                  class="am-list-riple"
+                  class="am-list-ripple"
                 />
               </div>
               <div
@@ -131,7 +131,7 @@ exports[`renders ./components/accordion/demo/basic.md correctly 1`] = `
                   </div>
                 </div>
                 <div
-                  class="am-list-riple"
+                  class="am-list-ripple"
                 />
               </div>
             </div>

--- a/components/accordion/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/accordion/__tests__/__snapshots__/demo.test.web.js.snap
@@ -98,6 +98,9 @@ exports[`renders ./components/accordion/demo/basic.md correctly 1`] = `
                     Content 1
                   </div>
                 </div>
+                <div
+                  class="am-list-riple"
+                />
               </div>
               <div
                 class="am-list-item am-list-item-middle"
@@ -111,6 +114,9 @@ exports[`renders ./components/accordion/demo/basic.md correctly 1`] = `
                     Content 2
                   </div>
                 </div>
+                <div
+                  class="am-list-riple"
+                />
               </div>
               <div
                 class="am-list-item am-list-item-middle"
@@ -124,6 +130,9 @@ exports[`renders ./components/accordion/demo/basic.md correctly 1`] = `
                     Content 3
                   </div>
                 </div>
+                <div
+                  class="am-list-riple"
+                />
               </div>
             </div>
           </div>

--- a/components/badge/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/badge/__tests__/__snapshots__/demo.test.web.js.snap
@@ -42,7 +42,7 @@ exports[`renders ./components/badge/demo/basic.md correctly 1`] = `
         />
       </div>
       <div
-        class="am-list-riple"
+        class="am-list-ripple"
       />
     </div>
     <div
@@ -81,7 +81,7 @@ exports[`renders ./components/badge/demo/basic.md correctly 1`] = `
         />
       </div>
       <div
-        class="am-list-riple"
+        class="am-list-ripple"
       />
     </div>
     <div
@@ -110,7 +110,7 @@ exports[`renders ./components/badge/demo/basic.md correctly 1`] = `
         </div>
       </div>
       <div
-        class="am-list-riple"
+        class="am-list-ripple"
       />
     </div>
     <div
@@ -139,7 +139,7 @@ exports[`renders ./components/badge/demo/basic.md correctly 1`] = `
         </div>
       </div>
       <div
-        class="am-list-riple"
+        class="am-list-ripple"
       />
     </div>
     <div
@@ -177,7 +177,7 @@ exports[`renders ./components/badge/demo/basic.md correctly 1`] = `
         />
       </div>
       <div
-        class="am-list-riple"
+        class="am-list-ripple"
       />
     </div>
     <div
@@ -243,7 +243,7 @@ exports[`renders ./components/badge/demo/basic.md correctly 1`] = `
         </div>
       </div>
       <div
-        class="am-list-riple"
+        class="am-list-ripple"
       />
     </div>
     <div
@@ -289,7 +289,7 @@ exports[`renders ./components/badge/demo/basic.md correctly 1`] = `
         </div>
       </div>
       <div
-        class="am-list-riple"
+        class="am-list-ripple"
       />
     </div>
   </div>

--- a/components/badge/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/badge/__tests__/__snapshots__/demo.test.web.js.snap
@@ -41,6 +41,9 @@ exports[`renders ./components/badge/demo/basic.md correctly 1`] = `
           class="am-list-arrow am-list-arrow-horizontal"
         />
       </div>
+      <div
+        class="am-list-riple"
+      />
     </div>
     <div
       class="am-list-item am-list-item-middle"
@@ -77,6 +80,9 @@ exports[`renders ./components/badge/demo/basic.md correctly 1`] = `
           class="am-list-arrow am-list-arrow-horizontal"
         />
       </div>
+      <div
+        class="am-list-riple"
+      />
     </div>
     <div
       class="am-list-item am-list-item-middle"
@@ -103,6 +109,9 @@ exports[`renders ./components/badge/demo/basic.md correctly 1`] = `
           </span>
         </div>
       </div>
+      <div
+        class="am-list-riple"
+      />
     </div>
     <div
       class="special-badge am-list-item am-list-item-middle"
@@ -129,6 +138,9 @@ exports[`renders ./components/badge/demo/basic.md correctly 1`] = `
           </span>
         </div>
       </div>
+      <div
+        class="am-list-riple"
+      />
     </div>
     <div
       class="am-list-item am-list-item-middle"
@@ -164,6 +176,9 @@ exports[`renders ./components/badge/demo/basic.md correctly 1`] = `
           class="am-list-arrow am-list-arrow-horizontal"
         />
       </div>
+      <div
+        class="am-list-riple"
+      />
     </div>
     <div
       class="am-list-item am-list-item-middle"
@@ -227,6 +242,9 @@ exports[`renders ./components/badge/demo/basic.md correctly 1`] = `
           </span>
         </div>
       </div>
+      <div
+        class="am-list-riple"
+      />
     </div>
     <div
       class="am-list-item am-list-item-middle"
@@ -270,6 +288,9 @@ exports[`renders ./components/badge/demo/basic.md correctly 1`] = `
           </span>
         </div>
       </div>
+      <div
+        class="am-list-riple"
+      />
     </div>
   </div>
 </div>

--- a/components/badge/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/badge/__tests__/__snapshots__/demo.test.web.js.snap
@@ -43,6 +43,7 @@ exports[`renders ./components/badge/demo/basic.md correctly 1`] = `
       </div>
       <div
         class="am-list-ripple"
+        style="display:none;"
       />
     </div>
     <div
@@ -82,6 +83,7 @@ exports[`renders ./components/badge/demo/basic.md correctly 1`] = `
       </div>
       <div
         class="am-list-ripple"
+        style="display:none;"
       />
     </div>
     <div
@@ -111,6 +113,7 @@ exports[`renders ./components/badge/demo/basic.md correctly 1`] = `
       </div>
       <div
         class="am-list-ripple"
+        style="display:none;"
       />
     </div>
     <div
@@ -140,6 +143,7 @@ exports[`renders ./components/badge/demo/basic.md correctly 1`] = `
       </div>
       <div
         class="am-list-ripple"
+        style="display:none;"
       />
     </div>
     <div
@@ -178,6 +182,7 @@ exports[`renders ./components/badge/demo/basic.md correctly 1`] = `
       </div>
       <div
         class="am-list-ripple"
+        style="display:none;"
       />
     </div>
     <div
@@ -244,6 +249,7 @@ exports[`renders ./components/badge/demo/basic.md correctly 1`] = `
       </div>
       <div
         class="am-list-ripple"
+        style="display:none;"
       />
     </div>
     <div
@@ -290,6 +296,7 @@ exports[`renders ./components/badge/demo/basic.md correctly 1`] = `
       </div>
       <div
         class="am-list-ripple"
+        style="display:none;"
       />
     </div>
   </div>

--- a/components/button/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/button/__tests__/__snapshots__/demo.test.web.js.snap
@@ -150,6 +150,9 @@ exports[`renders ./components/button/demo/complex.md correctly 1`] = `
           </a>
         </div>
       </div>
+      <div
+        class="am-list-riple"
+      />
     </div>
     <div
       class="am-list-item am-list-item-middle"
@@ -180,6 +183,9 @@ exports[`renders ./components/button/demo/complex.md correctly 1`] = `
           </a>
         </div>
       </div>
+      <div
+        class="am-list-riple"
+      />
     </div>
   </div>
 </div>

--- a/components/button/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/button/__tests__/__snapshots__/demo.test.web.js.snap
@@ -151,7 +151,7 @@ exports[`renders ./components/button/demo/complex.md correctly 1`] = `
         </div>
       </div>
       <div
-        class="am-list-riple"
+        class="am-list-ripple"
       />
     </div>
     <div
@@ -184,7 +184,7 @@ exports[`renders ./components/button/demo/complex.md correctly 1`] = `
         </div>
       </div>
       <div
-        class="am-list-riple"
+        class="am-list-ripple"
       />
     </div>
   </div>

--- a/components/button/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/button/__tests__/__snapshots__/demo.test.web.js.snap
@@ -152,6 +152,7 @@ exports[`renders ./components/button/demo/complex.md correctly 1`] = `
       </div>
       <div
         class="am-list-ripple"
+        style="display:none;"
       />
     </div>
     <div
@@ -185,6 +186,7 @@ exports[`renders ./components/button/demo/complex.md correctly 1`] = `
       </div>
       <div
         class="am-list-ripple"
+        style="display:none;"
       />
     </div>
   </div>

--- a/components/checkbox/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/checkbox/__tests__/__snapshots__/demo.test.web.js.snap
@@ -46,6 +46,7 @@ exports[`renders ./components/checkbox/demo/basic.md correctly 1`] = `
         </div>
         <div
           class="am-list-ripple"
+          style="display:none;"
         />
       </div>
       <div
@@ -81,6 +82,7 @@ exports[`renders ./components/checkbox/demo/basic.md correctly 1`] = `
         </div>
         <div
           class="am-list-ripple"
+          style="display:none;"
         />
       </div>
       <div
@@ -116,6 +118,7 @@ exports[`renders ./components/checkbox/demo/basic.md correctly 1`] = `
         </div>
         <div
           class="am-list-ripple"
+          style="display:none;"
         />
       </div>
       <div
@@ -159,6 +162,7 @@ exports[`renders ./components/checkbox/demo/basic.md correctly 1`] = `
         </div>
         <div
           class="am-list-ripple"
+          style="display:none;"
         />
       </div>
     </div>

--- a/components/checkbox/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/checkbox/__tests__/__snapshots__/demo.test.web.js.snap
@@ -44,6 +44,9 @@ exports[`renders ./components/checkbox/demo/basic.md correctly 1`] = `
             博士
           </div>
         </div>
+        <div
+          class="am-list-riple"
+        />
       </div>
       <div
         class="am-checkbox-item am-list-item am-list-item-middle"
@@ -76,6 +79,9 @@ exports[`renders ./components/checkbox/demo/basic.md correctly 1`] = `
             本科
           </div>
         </div>
+        <div
+          class="am-list-riple"
+        />
       </div>
       <div
         class="am-checkbox-item am-list-item am-list-item-middle"
@@ -108,6 +114,9 @@ exports[`renders ./components/checkbox/demo/basic.md correctly 1`] = `
             高中
           </div>
         </div>
+        <div
+          class="am-list-riple"
+        />
       </div>
       <div
         class="am-checkbox-item am-checkbox-item-disabled am-list-item am-list-item-middle"
@@ -148,6 +157,9 @@ exports[`renders ./components/checkbox/demo/basic.md correctly 1`] = `
             </div>
           </div>
         </div>
+        <div
+          class="am-list-riple"
+        />
       </div>
     </div>
   </div>

--- a/components/checkbox/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/checkbox/__tests__/__snapshots__/demo.test.web.js.snap
@@ -45,7 +45,7 @@ exports[`renders ./components/checkbox/demo/basic.md correctly 1`] = `
           </div>
         </div>
         <div
-          class="am-list-riple"
+          class="am-list-ripple"
         />
       </div>
       <div
@@ -80,7 +80,7 @@ exports[`renders ./components/checkbox/demo/basic.md correctly 1`] = `
           </div>
         </div>
         <div
-          class="am-list-riple"
+          class="am-list-ripple"
         />
       </div>
       <div
@@ -115,7 +115,7 @@ exports[`renders ./components/checkbox/demo/basic.md correctly 1`] = `
           </div>
         </div>
         <div
-          class="am-list-riple"
+          class="am-list-ripple"
         />
       </div>
       <div
@@ -158,7 +158,7 @@ exports[`renders ./components/checkbox/demo/basic.md correctly 1`] = `
           </div>
         </div>
         <div
-          class="am-list-riple"
+          class="am-list-ripple"
         />
       </div>
     </div>

--- a/components/date-picker/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/date-picker/__tests__/__snapshots__/demo.test.web.js.snap
@@ -32,6 +32,7 @@ exports[`renders ./components/date-picker/demo/basic.md correctly 1`] = `
           </div>
           <div
             class="am-list-ripple"
+            style="display:none;"
           />
         </div>
       </div>
@@ -58,6 +59,7 @@ exports[`renders ./components/date-picker/demo/basic.md correctly 1`] = `
           </div>
           <div
             class="am-list-ripple"
+            style="display:none;"
           />
         </div>
       </div>
@@ -84,6 +86,7 @@ exports[`renders ./components/date-picker/demo/basic.md correctly 1`] = `
           </div>
           <div
             class="am-list-ripple"
+            style="display:none;"
           />
         </div>
       </div>
@@ -110,6 +113,7 @@ exports[`renders ./components/date-picker/demo/basic.md correctly 1`] = `
           </div>
           <div
             class="am-list-ripple"
+            style="display:none;"
           />
         </div>
       </div>
@@ -136,6 +140,7 @@ exports[`renders ./components/date-picker/demo/basic.md correctly 1`] = `
           </div>
           <div
             class="am-list-ripple"
+            style="display:none;"
           />
         </div>
       </div>
@@ -158,6 +163,7 @@ exports[`renders ./components/date-picker/demo/basic.md correctly 1`] = `
         </div>
         <div
           class="am-list-ripple"
+          style="display:none;"
         />
       </div>
       <div>

--- a/components/date-picker/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/date-picker/__tests__/__snapshots__/demo.test.web.js.snap
@@ -30,6 +30,9 @@ exports[`renders ./components/date-picker/demo/basic.md correctly 1`] = `
               class="am-list-arrow am-list-arrow-horizontal"
             />
           </div>
+          <div
+            class="am-list-riple"
+          />
         </div>
       </div>
       <div>
@@ -53,6 +56,9 @@ exports[`renders ./components/date-picker/demo/basic.md correctly 1`] = `
               class="am-list-arrow am-list-arrow-horizontal"
             />
           </div>
+          <div
+            class="am-list-riple"
+          />
         </div>
       </div>
       <div>
@@ -76,6 +82,9 @@ exports[`renders ./components/date-picker/demo/basic.md correctly 1`] = `
               class="am-list-arrow am-list-arrow-horizontal"
             />
           </div>
+          <div
+            class="am-list-riple"
+          />
         </div>
       </div>
       <div>
@@ -99,6 +108,9 @@ exports[`renders ./components/date-picker/demo/basic.md correctly 1`] = `
               class="am-list-arrow am-list-arrow-horizontal"
             />
           </div>
+          <div
+            class="am-list-riple"
+          />
         </div>
       </div>
       <div>
@@ -122,6 +134,9 @@ exports[`renders ./components/date-picker/demo/basic.md correctly 1`] = `
               class="am-list-arrow am-list-arrow-horizontal"
             />
           </div>
+          <div
+            class="am-list-riple"
+          />
         </div>
       </div>
       <div
@@ -141,6 +156,9 @@ exports[`renders ./components/date-picker/demo/basic.md correctly 1`] = `
             class="am-list-extra"
           />
         </div>
+        <div
+          class="am-list-riple"
+        />
       </div>
       <div>
         <div

--- a/components/date-picker/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/date-picker/__tests__/__snapshots__/demo.test.web.js.snap
@@ -31,7 +31,7 @@ exports[`renders ./components/date-picker/demo/basic.md correctly 1`] = `
             />
           </div>
           <div
-            class="am-list-riple"
+            class="am-list-ripple"
           />
         </div>
       </div>
@@ -57,7 +57,7 @@ exports[`renders ./components/date-picker/demo/basic.md correctly 1`] = `
             />
           </div>
           <div
-            class="am-list-riple"
+            class="am-list-ripple"
           />
         </div>
       </div>
@@ -83,7 +83,7 @@ exports[`renders ./components/date-picker/demo/basic.md correctly 1`] = `
             />
           </div>
           <div
-            class="am-list-riple"
+            class="am-list-ripple"
           />
         </div>
       </div>
@@ -109,7 +109,7 @@ exports[`renders ./components/date-picker/demo/basic.md correctly 1`] = `
             />
           </div>
           <div
-            class="am-list-riple"
+            class="am-list-ripple"
           />
         </div>
       </div>
@@ -135,7 +135,7 @@ exports[`renders ./components/date-picker/demo/basic.md correctly 1`] = `
             />
           </div>
           <div
-            class="am-list-riple"
+            class="am-list-ripple"
           />
         </div>
       </div>
@@ -157,7 +157,7 @@ exports[`renders ./components/date-picker/demo/basic.md correctly 1`] = `
           />
         </div>
         <div
-          class="am-list-riple"
+          class="am-list-ripple"
         />
       </div>
       <div>

--- a/components/drawer/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/drawer/__tests__/__snapshots__/demo.test.web.js.snap
@@ -64,6 +64,9 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
                 Category
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -84,6 +87,9 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
                 Category1
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -104,6 +110,9 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
                 Category2
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -124,6 +133,9 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
                 Category3
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -144,6 +156,9 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
                 Category4
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -164,6 +179,9 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
                 Category5
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -184,6 +202,9 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
                 Category6
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -204,6 +225,9 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
                 Category7
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -224,6 +248,9 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
                 Category8
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -244,6 +271,9 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
                 Category9
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -264,6 +294,9 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
                 Category10
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -284,6 +317,9 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
                 Category11
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -304,6 +340,9 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
                 Category12
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -324,6 +363,9 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
                 Category13
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -344,6 +386,9 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
                 Category14
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -364,6 +409,9 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
                 Category15
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -384,6 +432,9 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
                 Category16
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -404,6 +455,9 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
                 Category17
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -424,6 +478,9 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
                 Category18
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -444,6 +501,9 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
                 Category19
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
         </div>
       </div>
@@ -529,6 +589,9 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
                 Category
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -549,6 +612,9 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
                 Category1
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -569,6 +635,9 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
                 Category2
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -589,6 +658,9 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
                 Category3
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -609,6 +681,9 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
                 Category4
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -629,6 +704,9 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
                 Category5
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -649,6 +727,9 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
                 Category6
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -669,6 +750,9 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
                 Category7
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -689,6 +773,9 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
                 Category8
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -709,6 +796,9 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
                 Category9
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -729,6 +819,9 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
                 Category10
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -749,6 +842,9 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
                 Category11
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -769,6 +865,9 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
                 Category12
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -789,6 +888,9 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
                 Category13
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -809,6 +911,9 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
                 Category14
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -829,6 +934,9 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
                 Category15
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -849,6 +957,9 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
                 Category16
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -869,6 +980,9 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
                 Category17
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -889,6 +1003,9 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
                 Category18
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -909,6 +1026,9 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
                 Category19
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
         </div>
       </div>

--- a/components/drawer/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/drawer/__tests__/__snapshots__/demo.test.web.js.snap
@@ -66,6 +66,7 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -89,6 +90,7 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -112,6 +114,7 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -135,6 +138,7 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -158,6 +162,7 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -181,6 +186,7 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -204,6 +210,7 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -227,6 +234,7 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -250,6 +258,7 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -273,6 +282,7 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -296,6 +306,7 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -319,6 +330,7 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -342,6 +354,7 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -365,6 +378,7 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -388,6 +402,7 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -411,6 +426,7 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -434,6 +450,7 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -457,6 +474,7 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -480,6 +498,7 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -503,6 +522,7 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
         </div>
@@ -591,6 +611,7 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -614,6 +635,7 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -637,6 +659,7 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -660,6 +683,7 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -683,6 +707,7 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -706,6 +731,7 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -729,6 +755,7 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -752,6 +779,7 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -775,6 +803,7 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -798,6 +827,7 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -821,6 +851,7 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -844,6 +875,7 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -867,6 +899,7 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -890,6 +923,7 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -913,6 +947,7 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -936,6 +971,7 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -959,6 +995,7 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -982,6 +1019,7 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -1005,6 +1043,7 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -1028,6 +1067,7 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
         </div>

--- a/components/drawer/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/drawer/__tests__/__snapshots__/demo.test.web.js.snap
@@ -65,7 +65,7 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -88,7 +88,7 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -111,7 +111,7 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -134,7 +134,7 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -157,7 +157,7 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -180,7 +180,7 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -203,7 +203,7 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -226,7 +226,7 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -249,7 +249,7 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -272,7 +272,7 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -295,7 +295,7 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -318,7 +318,7 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -341,7 +341,7 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -364,7 +364,7 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -387,7 +387,7 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -410,7 +410,7 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -433,7 +433,7 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -456,7 +456,7 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -479,7 +479,7 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -502,7 +502,7 @@ exports[`renders ./components/drawer/demo/basic.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
         </div>
@@ -590,7 +590,7 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -613,7 +613,7 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -636,7 +636,7 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -659,7 +659,7 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -682,7 +682,7 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -705,7 +705,7 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -728,7 +728,7 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -751,7 +751,7 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -774,7 +774,7 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -797,7 +797,7 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -820,7 +820,7 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -843,7 +843,7 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -866,7 +866,7 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -889,7 +889,7 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -912,7 +912,7 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -935,7 +935,7 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -958,7 +958,7 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -981,7 +981,7 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -1004,7 +1004,7 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -1027,7 +1027,7 @@ exports[`renders ./components/drawer/demo/dock.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
         </div>

--- a/components/input-item/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/input-item/__tests__/__snapshots__/demo.test.web.js.snap
@@ -65,6 +65,9 @@ exports[`renders ./components/input-item/demo/basic.md correctly 1`] = `
             </div>
           </div>
         </div>
+        <div
+          class="am-list-riple"
+        />
       </div>
     </div>
   </div>

--- a/components/input-item/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/input-item/__tests__/__snapshots__/demo.test.web.js.snap
@@ -66,7 +66,7 @@ exports[`renders ./components/input-item/demo/basic.md correctly 1`] = `
           </div>
         </div>
         <div
-          class="am-list-riple"
+          class="am-list-ripple"
         />
       </div>
     </div>

--- a/components/input-item/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/input-item/__tests__/__snapshots__/demo.test.web.js.snap
@@ -67,6 +67,7 @@ exports[`renders ./components/input-item/demo/basic.md correctly 1`] = `
         </div>
         <div
           class="am-list-ripple"
+          style="display:none;"
         />
       </div>
     </div>

--- a/components/list-view/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/list-view/__tests__/__snapshots__/demo.test.web.js.snap
@@ -139,6 +139,9 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
                 </div>
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
         </div>
         <div
@@ -156,6 +159,9 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
                 安徽省
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -169,6 +175,9 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
                 安徽省0
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -182,6 +191,9 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
                 安徽省1
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -195,6 +207,9 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
                 安徽省2
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -208,6 +223,9 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
                 安徽省3
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -221,6 +239,9 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
                 安徽省4
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -234,6 +255,9 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
                 安徽省5
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -247,6 +271,9 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
                 安徽省6
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -260,6 +287,9 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
                 安徽省7
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -273,6 +303,9 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
                 安徽省8
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -286,6 +319,9 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
                 安徽省9
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
         </div>
         <div
@@ -307,6 +343,9 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
                 </div>
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
         </div>
         <div
@@ -324,6 +363,9 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
                 北京市
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -337,6 +379,9 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
                 北京市0
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -350,6 +395,9 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
                 北京市1
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -363,6 +411,9 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
                 北京市2
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -376,6 +427,9 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
                 北京市3
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -389,6 +443,9 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
                 北京市4
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -402,6 +459,9 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
                 北京市5
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -415,6 +475,9 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
                 北京市6
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -428,6 +491,9 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
                 北京市7
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
         </div>
       </div>
@@ -619,6 +685,9 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                       </div>
                     </div>
                   </div>
+                  <div
+                    class="am-list-riple"
+                  />
                 </div>
               </div>
             </div>
@@ -638,6 +707,9 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                   安徽省
                 </div>
               </div>
+              <div
+                class="am-list-riple"
+              />
             </div>
             <div
               class="am-list-item am-list-item-middle"
@@ -651,6 +723,9 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                   安徽省0
                 </div>
               </div>
+              <div
+                class="am-list-riple"
+              />
             </div>
             <div
               class="am-list-item am-list-item-middle"
@@ -664,6 +739,9 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                   安徽省1
                 </div>
               </div>
+              <div
+                class="am-list-riple"
+              />
             </div>
             <div
               class="am-list-item am-list-item-middle"
@@ -677,6 +755,9 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                   安徽省2
                 </div>
               </div>
+              <div
+                class="am-list-riple"
+              />
             </div>
             <div
               class="am-list-item am-list-item-middle"
@@ -690,6 +771,9 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                   安徽省3
                 </div>
               </div>
+              <div
+                class="am-list-riple"
+              />
             </div>
             <div
               class="am-list-item am-list-item-middle"
@@ -703,6 +787,9 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                   安徽省4
                 </div>
               </div>
+              <div
+                class="am-list-riple"
+              />
             </div>
             <div
               class="am-list-item am-list-item-middle"
@@ -716,6 +803,9 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                   安徽省5
                 </div>
               </div>
+              <div
+                class="am-list-riple"
+              />
             </div>
             <div
               class="am-list-item am-list-item-middle"
@@ -729,6 +819,9 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                   安徽省6
                 </div>
               </div>
+              <div
+                class="am-list-riple"
+              />
             </div>
             <div
               class="am-list-item am-list-item-middle"
@@ -742,6 +835,9 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                   安徽省7
                 </div>
               </div>
+              <div
+                class="am-list-riple"
+              />
             </div>
             <div
               class="am-list-item am-list-item-middle"
@@ -755,6 +851,9 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                   安徽省8
                 </div>
               </div>
+              <div
+                class="am-list-riple"
+              />
             </div>
             <div
               class="am-list-item am-list-item-middle"
@@ -768,6 +867,9 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                   安徽省9
                 </div>
               </div>
+              <div
+                class="am-list-riple"
+              />
             </div>
           </div>
           <div>
@@ -797,6 +899,9 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                       </div>
                     </div>
                   </div>
+                  <div
+                    class="am-list-riple"
+                  />
                 </div>
               </div>
             </div>
@@ -816,6 +921,9 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                   北京市
                 </div>
               </div>
+              <div
+                class="am-list-riple"
+              />
             </div>
             <div
               class="am-list-item am-list-item-middle"
@@ -829,6 +937,9 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                   北京市0
                 </div>
               </div>
+              <div
+                class="am-list-riple"
+              />
             </div>
             <div
               class="am-list-item am-list-item-middle"
@@ -842,6 +953,9 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                   北京市1
                 </div>
               </div>
+              <div
+                class="am-list-riple"
+              />
             </div>
             <div
               class="am-list-item am-list-item-middle"
@@ -855,6 +969,9 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                   北京市2
                 </div>
               </div>
+              <div
+                class="am-list-riple"
+              />
             </div>
             <div
               class="am-list-item am-list-item-middle"
@@ -868,6 +985,9 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                   北京市3
                 </div>
               </div>
+              <div
+                class="am-list-riple"
+              />
             </div>
             <div
               class="am-list-item am-list-item-middle"
@@ -881,6 +1001,9 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                   北京市4
                 </div>
               </div>
+              <div
+                class="am-list-riple"
+              />
             </div>
             <div
               class="am-list-item am-list-item-middle"
@@ -894,6 +1017,9 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                   北京市5
                 </div>
               </div>
+              <div
+                class="am-list-riple"
+              />
             </div>
             <div
               class="am-list-item am-list-item-middle"
@@ -907,6 +1033,9 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                   北京市6
                 </div>
               </div>
+              <div
+                class="am-list-riple"
+              />
             </div>
             <div
               class="am-list-item am-list-item-middle"
@@ -920,6 +1049,9 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                   北京市7
                 </div>
               </div>
+              <div
+                class="am-list-riple"
+              />
             </div>
           </div>
         </div>

--- a/components/list-view/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/list-view/__tests__/__snapshots__/demo.test.web.js.snap
@@ -140,7 +140,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
         </div>
@@ -160,7 +160,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -176,7 +176,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -192,7 +192,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -208,7 +208,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -224,7 +224,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -240,7 +240,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -256,7 +256,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -272,7 +272,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -288,7 +288,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -304,7 +304,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -320,7 +320,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
         </div>
@@ -344,7 +344,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
         </div>
@@ -364,7 +364,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -380,7 +380,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -396,7 +396,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -412,7 +412,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -428,7 +428,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -444,7 +444,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -460,7 +460,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -476,7 +476,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -492,7 +492,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
         </div>
@@ -686,7 +686,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                     </div>
                   </div>
                   <div
-                    class="am-list-riple"
+                    class="am-list-ripple"
                   />
                 </div>
               </div>
@@ -708,7 +708,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                 </div>
               </div>
               <div
-                class="am-list-riple"
+                class="am-list-ripple"
               />
             </div>
             <div
@@ -724,7 +724,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                 </div>
               </div>
               <div
-                class="am-list-riple"
+                class="am-list-ripple"
               />
             </div>
             <div
@@ -740,7 +740,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                 </div>
               </div>
               <div
-                class="am-list-riple"
+                class="am-list-ripple"
               />
             </div>
             <div
@@ -756,7 +756,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                 </div>
               </div>
               <div
-                class="am-list-riple"
+                class="am-list-ripple"
               />
             </div>
             <div
@@ -772,7 +772,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                 </div>
               </div>
               <div
-                class="am-list-riple"
+                class="am-list-ripple"
               />
             </div>
             <div
@@ -788,7 +788,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                 </div>
               </div>
               <div
-                class="am-list-riple"
+                class="am-list-ripple"
               />
             </div>
             <div
@@ -804,7 +804,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                 </div>
               </div>
               <div
-                class="am-list-riple"
+                class="am-list-ripple"
               />
             </div>
             <div
@@ -820,7 +820,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                 </div>
               </div>
               <div
-                class="am-list-riple"
+                class="am-list-ripple"
               />
             </div>
             <div
@@ -836,7 +836,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                 </div>
               </div>
               <div
-                class="am-list-riple"
+                class="am-list-ripple"
               />
             </div>
             <div
@@ -852,7 +852,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                 </div>
               </div>
               <div
-                class="am-list-riple"
+                class="am-list-ripple"
               />
             </div>
             <div
@@ -868,7 +868,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                 </div>
               </div>
               <div
-                class="am-list-riple"
+                class="am-list-ripple"
               />
             </div>
           </div>
@@ -900,7 +900,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                     </div>
                   </div>
                   <div
-                    class="am-list-riple"
+                    class="am-list-ripple"
                   />
                 </div>
               </div>
@@ -922,7 +922,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                 </div>
               </div>
               <div
-                class="am-list-riple"
+                class="am-list-ripple"
               />
             </div>
             <div
@@ -938,7 +938,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                 </div>
               </div>
               <div
-                class="am-list-riple"
+                class="am-list-ripple"
               />
             </div>
             <div
@@ -954,7 +954,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                 </div>
               </div>
               <div
-                class="am-list-riple"
+                class="am-list-ripple"
               />
             </div>
             <div
@@ -970,7 +970,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                 </div>
               </div>
               <div
-                class="am-list-riple"
+                class="am-list-ripple"
               />
             </div>
             <div
@@ -986,7 +986,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                 </div>
               </div>
               <div
-                class="am-list-riple"
+                class="am-list-ripple"
               />
             </div>
             <div
@@ -1002,7 +1002,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                 </div>
               </div>
               <div
-                class="am-list-riple"
+                class="am-list-ripple"
               />
             </div>
             <div
@@ -1018,7 +1018,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                 </div>
               </div>
               <div
-                class="am-list-riple"
+                class="am-list-ripple"
               />
             </div>
             <div
@@ -1034,7 +1034,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                 </div>
               </div>
               <div
-                class="am-list-riple"
+                class="am-list-ripple"
               />
             </div>
             <div
@@ -1050,7 +1050,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                 </div>
               </div>
               <div
-                class="am-list-riple"
+                class="am-list-ripple"
               />
             </div>
           </div>

--- a/components/list-view/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/list-view/__tests__/__snapshots__/demo.test.web.js.snap
@@ -141,6 +141,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
         </div>
@@ -161,6 +162,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -177,6 +179,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -193,6 +196,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -209,6 +213,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -225,6 +230,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -241,6 +247,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -257,6 +264,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -273,6 +281,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -289,6 +298,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -305,6 +315,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -321,6 +332,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
         </div>
@@ -345,6 +357,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
         </div>
@@ -365,6 +378,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -381,6 +395,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -397,6 +412,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -413,6 +429,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -429,6 +446,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -445,6 +463,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -461,6 +480,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -477,6 +497,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -493,6 +514,7 @@ exports[`renders ./components/list-view/demo/idxed.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
         </div>
@@ -687,6 +709,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                   </div>
                   <div
                     class="am-list-ripple"
+                    style="display:none;"
                   />
                 </div>
               </div>
@@ -709,6 +732,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
               </div>
               <div
                 class="am-list-ripple"
+                style="display:none;"
               />
             </div>
             <div
@@ -725,6 +749,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
               </div>
               <div
                 class="am-list-ripple"
+                style="display:none;"
               />
             </div>
             <div
@@ -741,6 +766,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
               </div>
               <div
                 class="am-list-ripple"
+                style="display:none;"
               />
             </div>
             <div
@@ -757,6 +783,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
               </div>
               <div
                 class="am-list-ripple"
+                style="display:none;"
               />
             </div>
             <div
@@ -773,6 +800,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
               </div>
               <div
                 class="am-list-ripple"
+                style="display:none;"
               />
             </div>
             <div
@@ -789,6 +817,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
               </div>
               <div
                 class="am-list-ripple"
+                style="display:none;"
               />
             </div>
             <div
@@ -805,6 +834,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
               </div>
               <div
                 class="am-list-ripple"
+                style="display:none;"
               />
             </div>
             <div
@@ -821,6 +851,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
               </div>
               <div
                 class="am-list-ripple"
+                style="display:none;"
               />
             </div>
             <div
@@ -837,6 +868,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
               </div>
               <div
                 class="am-list-ripple"
+                style="display:none;"
               />
             </div>
             <div
@@ -853,6 +885,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
               </div>
               <div
                 class="am-list-ripple"
+                style="display:none;"
               />
             </div>
             <div
@@ -869,6 +902,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
               </div>
               <div
                 class="am-list-ripple"
+                style="display:none;"
               />
             </div>
           </div>
@@ -901,6 +935,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
                   </div>
                   <div
                     class="am-list-ripple"
+                    style="display:none;"
                   />
                 </div>
               </div>
@@ -923,6 +958,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
               </div>
               <div
                 class="am-list-ripple"
+                style="display:none;"
               />
             </div>
             <div
@@ -939,6 +975,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
               </div>
               <div
                 class="am-list-ripple"
+                style="display:none;"
               />
             </div>
             <div
@@ -955,6 +992,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
               </div>
               <div
                 class="am-list-ripple"
+                style="display:none;"
               />
             </div>
             <div
@@ -971,6 +1009,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
               </div>
               <div
                 class="am-list-ripple"
+                style="display:none;"
               />
             </div>
             <div
@@ -987,6 +1026,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
               </div>
               <div
                 class="am-list-ripple"
+                style="display:none;"
               />
             </div>
             <div
@@ -1003,6 +1043,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
               </div>
               <div
                 class="am-list-ripple"
+                style="display:none;"
               />
             </div>
             <div
@@ -1019,6 +1060,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
               </div>
               <div
                 class="am-list-ripple"
+                style="display:none;"
               />
             </div>
             <div
@@ -1035,6 +1077,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
               </div>
               <div
                 class="am-list-ripple"
+                style="display:none;"
               />
             </div>
             <div
@@ -1051,6 +1094,7 @@ exports[`renders ./components/list-view/demo/idxed-sticky.md correctly 1`] = `
               </div>
               <div
                 class="am-list-ripple"
+                style="display:none;"
               />
             </div>
           </div>

--- a/components/list/ListItem.web.tsx
+++ b/components/list/ListItem.web.tsx
@@ -81,7 +81,7 @@ class ListItem extends React.Component<ListItemProps, any> {
 
     const {
       prefixCls, className, activeStyle, error, align, wrap, disabled,
-      children, multipleLine, thumb, extra, arrow, onClick, platform, ...restProps} = this.props;
+      children, multipleLine, thumb, extra, arrow, onClick, ...restProps} = this.props;
 
     const { coverRipleStyle, RipleClicked } = this.state;
     const wrapCls = {
@@ -112,7 +112,6 @@ class ListItem extends React.Component<ListItemProps, any> {
       [`${prefixCls}-arrow-vertical-up`]: arrow === 'up',
     });
 
-    const isAndroid = platform === 'android' || (platform === 'cross' && !!navigator.userAgent.match(/Android/i));
     const content = <div
       {...restProps}
       onClick={(ev) => {
@@ -128,7 +127,7 @@ class ListItem extends React.Component<ListItemProps, any> {
         {extra !== undefined && <div className={`${prefixCls}-extra`}>{extra}</div>}
         {arrow && <div className={arrowCls} />}
       </div>
-      {isAndroid && <div style={coverRipleStyle} className={ripleCls} />}
+      <div style={coverRipleStyle} className={ripleCls} />
     </div>;
 
     return (

--- a/components/list/ListItem.web.tsx
+++ b/components/list/ListItem.web.tsx
@@ -28,8 +28,8 @@ class ListItem extends React.Component<ListItemProps, any> {
   constructor(props) {
     super(props);
     this.state = {
-      coverRipleStyle: {},
-      RipleClicked: false,
+      coverRippleStyle: {},
+      RippleClicked: false,
     };
   }
 
@@ -49,24 +49,24 @@ class ListItem extends React.Component<ListItemProps, any> {
         this.debounceTimeout = null;
       }
       let Item = ev.currentTarget;
-      let RipleWidth = Math.max(Item.offsetHeight, Item.offsetWidth);
+      let RippleWidth = Math.max(Item.offsetHeight, Item.offsetWidth);
       const ClientRect = ev.currentTarget.getBoundingClientRect();
       let pointX = ev.clientX - ClientRect.left - Item.offsetWidth / 2;
       let pointY = ev.clientY - ClientRect.top - Item.offsetWidth / 2;
-      const coverRipleStyle = {
-        width: `${RipleWidth}px`,
-        height: `${RipleWidth}px`,
+      const coverRippleStyle = {
+        width: `${RippleWidth}px`,
+        height: `${RippleWidth}px`,
         left: `${pointX}px`,
         top: `${pointY}px`,
       };
       this.setState({
-        coverRipleStyle,
-        RipleClicked: true,
+        coverRippleStyle,
+        RippleClicked: true,
       }, () => {
         this.debounceTimeout = setTimeout(() => {
           this.setState({
-            coverRipleStyle: {},
-            RipleClicked: false,
+            coverRippleStyle: {},
+            RippleClicked: false,
           });
         }, 1000);
       });
@@ -83,7 +83,7 @@ class ListItem extends React.Component<ListItemProps, any> {
       prefixCls, className, activeStyle, error, align, wrap, disabled,
       children, multipleLine, thumb, extra, arrow, onClick, ...restProps} = this.props;
 
-    const { coverRipleStyle, RipleClicked } = this.state;
+    const { coverRippleStyle, RippleClicked } = this.state;
     const wrapCls = {
       [className as string]: className,
       [`${prefixCls}-item`]: true,
@@ -94,9 +94,9 @@ class ListItem extends React.Component<ListItemProps, any> {
       [`${prefixCls}-item-bottom`]: align === 'bottom',
     };
 
-    const ripleCls = classNames({
-      [`${prefixCls}-riple`]: true,
-      [`${prefixCls}-riple-animate`]: RipleClicked,
+    const rippleCls = classNames({
+      [`${prefixCls}-ripple`]: true,
+      [`${prefixCls}-ripple-animate`]: RippleClicked,
     });
 
     const lineCls = classNames({
@@ -127,7 +127,7 @@ class ListItem extends React.Component<ListItemProps, any> {
         {extra !== undefined && <div className={`${prefixCls}-extra`}>{extra}</div>}
         {arrow && <div className={arrowCls} />}
       </div>
-      <div style={coverRipleStyle} className={ripleCls} />
+      <div style={coverRippleStyle} className={rippleCls} />
     </div>;
 
     return (

--- a/components/list/ListItem.web.tsx
+++ b/components/list/ListItem.web.tsx
@@ -28,7 +28,7 @@ class ListItem extends React.Component<ListItemProps, any> {
   constructor(props) {
     super(props);
     this.state = {
-      coverRippleStyle: {},
+      coverRippleStyle: { display: 'none' },
       RippleClicked: false,
     };
   }
@@ -65,7 +65,7 @@ class ListItem extends React.Component<ListItemProps, any> {
       }, () => {
         this.debounceTimeout = setTimeout(() => {
           this.setState({
-            coverRippleStyle: {},
+            coverRippleStyle: { display: 'none' },
             RippleClicked: false,
           });
         }, 1000);

--- a/components/list/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/list/__tests__/__snapshots__/demo.test.web.js.snap
@@ -30,6 +30,9 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
             内容内容
           </div>
         </div>
+        <div
+          class="am-list-riple"
+        />
       </div>
     </div>
   </div>
@@ -64,6 +67,9 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
             class="am-list-arrow am-list-arrow-horizontal"
           />
         </div>
+        <div
+          class="am-list-riple"
+        />
       </div>
       <div
         class="am-list-item am-list-item-middle"
@@ -116,6 +122,9 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
             class="am-list-arrow am-list-arrow-horizontal"
           />
         </div>
+        <div
+          class="am-list-riple"
+        />
       </div>
     </div>
   </div>
@@ -142,6 +151,9 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
             标题文字
           </div>
         </div>
+        <div
+          class="am-list-riple"
+        />
       </div>
       <div
         class="am-list-item am-list-item-middle"
@@ -158,6 +170,9 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
             class="am-list-arrow am-list-arrow-horizontal"
           />
         </div>
+        <div
+          class="am-list-riple"
+        />
       </div>
       <div
         class="am-list-item am-list-item-middle"
@@ -179,6 +194,9 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
             class="am-list-arrow am-list-arrow-horizontal"
           />
         </div>
+        <div
+          class="am-list-riple"
+        />
       </div>
       <div
         class="am-list-item am-list-item-top"
@@ -209,6 +227,9 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
             10:30
           </div>
         </div>
+        <div
+          class="am-list-riple"
+        />
       </div>
     </div>
   </div>
@@ -245,6 +266,9 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
             内容内容
           </div>
         </div>
+        <div
+          class="am-list-riple"
+        />
       </div>
     </div>
   </div>
@@ -281,6 +305,9 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
             class="am-list-arrow am-list-arrow-horizontal"
           />
         </div>
+        <div
+          class="am-list-riple"
+        />
       </div>
       <div
         class="am-list-item am-list-item-middle"
@@ -304,6 +331,9 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
             class="am-list-arrow am-list-arrow-horizontal"
           />
         </div>
+        <div
+          class="am-list-riple"
+        />
       </div>
     </div>
   </div>
@@ -331,6 +361,9 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
             单行模式，文字超长则隐藏；文本内容文本内容文本内容文本内容
           </div>
         </div>
+        <div
+          class="am-list-riple"
+        />
       </div>
       <div
         class="am-list-item am-list-item-middle"
@@ -344,6 +377,9 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
             多行模式，文字超长则换行；文本内容文本内容文本内容文本内容文本内容文本内容
           </div>
         </div>
+        <div
+          class="am-list-riple"
+        />
       </div>
       <div
         class="am-list-item am-list-item-top"
@@ -362,6 +398,9 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
             内容内容
           </div>
         </div>
+        <div
+          class="am-list-riple"
+        />
       </div>
       <div
         class="spe am-list-item am-list-item-middle"
@@ -383,6 +422,9 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
             class="am-list-arrow"
           />
         </div>
+        <div
+          class="am-list-riple"
+        />
       </div>
     </div>
   </div>
@@ -412,6 +454,9 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
             class="am-list-extra"
           />
         </div>
+        <div
+          class="am-list-riple"
+        />
       </div>
       <div
         class="am-list-item am-list-item-middle"
@@ -443,6 +488,9 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
             </select>
           </div>
         </div>
+        <div
+          class="am-list-riple"
+        />
       </div>
     </div>
   </div>
@@ -527,6 +575,9 @@ exports[`renders ./components/list/demo/form.md correctly 1`] = `
             </label>
           </div>
         </div>
+        <div
+          class="am-list-riple"
+        />
       </div>
       <div
         class="am-list-item am-list-item-middle"
@@ -572,6 +623,9 @@ exports[`renders ./components/list/demo/form.md correctly 1`] = `
             </div>
           </div>
         </div>
+        <div
+          class="am-list-riple"
+        />
       </div>
       <div
         class="am-list-item am-list-item-middle"
@@ -643,6 +697,9 @@ exports[`renders ./components/list/demo/form.md correctly 1`] = `
             </div>
           </div>
         </div>
+        <div
+          class="am-list-riple"
+        />
       </div>
       <div
         class="am-list-item am-list-item-middle"
@@ -672,6 +729,9 @@ exports[`renders ./components/list/demo/form.md correctly 1`] = `
             </a>
           </div>
         </div>
+        <div
+          class="am-list-riple"
+        />
       </div>
     </div>
     <div

--- a/components/list/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/list/__tests__/__snapshots__/demo.test.web.js.snap
@@ -32,6 +32,7 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
         </div>
         <div
           class="am-list-ripple"
+          style="display:none;"
         />
       </div>
     </div>
@@ -69,6 +70,7 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
         </div>
         <div
           class="am-list-ripple"
+          style="display:none;"
         />
       </div>
       <div
@@ -93,6 +95,7 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
         </div>
         <div
           class="am-list-ripple"
+          style="display:none;"
         />
       </div>
       <div
@@ -124,6 +127,7 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
         </div>
         <div
           class="am-list-ripple"
+          style="display:none;"
         />
       </div>
     </div>
@@ -153,6 +157,7 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
         </div>
         <div
           class="am-list-ripple"
+          style="display:none;"
         />
       </div>
       <div
@@ -172,6 +177,7 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
         </div>
         <div
           class="am-list-ripple"
+          style="display:none;"
         />
       </div>
       <div
@@ -196,6 +202,7 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
         </div>
         <div
           class="am-list-ripple"
+          style="display:none;"
         />
       </div>
       <div
@@ -229,6 +236,7 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
         </div>
         <div
           class="am-list-ripple"
+          style="display:none;"
         />
       </div>
     </div>
@@ -268,6 +276,7 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
         </div>
         <div
           class="am-list-ripple"
+          style="display:none;"
         />
       </div>
     </div>
@@ -307,6 +316,7 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
         </div>
         <div
           class="am-list-ripple"
+          style="display:none;"
         />
       </div>
       <div
@@ -333,6 +343,7 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
         </div>
         <div
           class="am-list-ripple"
+          style="display:none;"
         />
       </div>
     </div>
@@ -363,6 +374,7 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
         </div>
         <div
           class="am-list-ripple"
+          style="display:none;"
         />
       </div>
       <div
@@ -379,6 +391,7 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
         </div>
         <div
           class="am-list-ripple"
+          style="display:none;"
         />
       </div>
       <div
@@ -400,6 +413,7 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
         </div>
         <div
           class="am-list-ripple"
+          style="display:none;"
         />
       </div>
       <div
@@ -424,6 +438,7 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
         </div>
         <div
           class="am-list-ripple"
+          style="display:none;"
         />
       </div>
     </div>
@@ -456,6 +471,7 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
         </div>
         <div
           class="am-list-ripple"
+          style="display:none;"
         />
       </div>
       <div
@@ -490,6 +506,7 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
         </div>
         <div
           class="am-list-ripple"
+          style="display:none;"
         />
       </div>
     </div>
@@ -577,6 +594,7 @@ exports[`renders ./components/list/demo/form.md correctly 1`] = `
         </div>
         <div
           class="am-list-ripple"
+          style="display:none;"
         />
       </div>
       <div
@@ -625,6 +643,7 @@ exports[`renders ./components/list/demo/form.md correctly 1`] = `
         </div>
         <div
           class="am-list-ripple"
+          style="display:none;"
         />
       </div>
       <div
@@ -699,6 +718,7 @@ exports[`renders ./components/list/demo/form.md correctly 1`] = `
         </div>
         <div
           class="am-list-ripple"
+          style="display:none;"
         />
       </div>
       <div
@@ -731,6 +751,7 @@ exports[`renders ./components/list/demo/form.md correctly 1`] = `
         </div>
         <div
           class="am-list-ripple"
+          style="display:none;"
         />
       </div>
     </div>

--- a/components/list/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/list/__tests__/__snapshots__/demo.test.web.js.snap
@@ -31,7 +31,7 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
           </div>
         </div>
         <div
-          class="am-list-riple"
+          class="am-list-ripple"
         />
       </div>
     </div>
@@ -68,7 +68,7 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
           />
         </div>
         <div
-          class="am-list-riple"
+          class="am-list-ripple"
         />
       </div>
       <div
@@ -92,7 +92,7 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
           />
         </div>
         <div
-          class="am-list-riple"
+          class="am-list-ripple"
         />
       </div>
       <div
@@ -123,7 +123,7 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
           />
         </div>
         <div
-          class="am-list-riple"
+          class="am-list-ripple"
         />
       </div>
     </div>
@@ -152,7 +152,7 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
           </div>
         </div>
         <div
-          class="am-list-riple"
+          class="am-list-ripple"
         />
       </div>
       <div
@@ -171,7 +171,7 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
           />
         </div>
         <div
-          class="am-list-riple"
+          class="am-list-ripple"
         />
       </div>
       <div
@@ -195,7 +195,7 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
           />
         </div>
         <div
-          class="am-list-riple"
+          class="am-list-ripple"
         />
       </div>
       <div
@@ -228,7 +228,7 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
           </div>
         </div>
         <div
-          class="am-list-riple"
+          class="am-list-ripple"
         />
       </div>
     </div>
@@ -267,7 +267,7 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
           </div>
         </div>
         <div
-          class="am-list-riple"
+          class="am-list-ripple"
         />
       </div>
     </div>
@@ -306,7 +306,7 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
           />
         </div>
         <div
-          class="am-list-riple"
+          class="am-list-ripple"
         />
       </div>
       <div
@@ -332,7 +332,7 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
           />
         </div>
         <div
-          class="am-list-riple"
+          class="am-list-ripple"
         />
       </div>
     </div>
@@ -362,7 +362,7 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
           </div>
         </div>
         <div
-          class="am-list-riple"
+          class="am-list-ripple"
         />
       </div>
       <div
@@ -378,7 +378,7 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
           </div>
         </div>
         <div
-          class="am-list-riple"
+          class="am-list-ripple"
         />
       </div>
       <div
@@ -399,7 +399,7 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
           </div>
         </div>
         <div
-          class="am-list-riple"
+          class="am-list-ripple"
         />
       </div>
       <div
@@ -423,7 +423,7 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
           />
         </div>
         <div
-          class="am-list-riple"
+          class="am-list-ripple"
         />
       </div>
     </div>
@@ -455,7 +455,7 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
           />
         </div>
         <div
-          class="am-list-riple"
+          class="am-list-ripple"
         />
       </div>
       <div
@@ -489,7 +489,7 @@ exports[`renders ./components/list/demo/basic.md correctly 1`] = `
           </div>
         </div>
         <div
-          class="am-list-riple"
+          class="am-list-ripple"
         />
       </div>
     </div>
@@ -576,7 +576,7 @@ exports[`renders ./components/list/demo/form.md correctly 1`] = `
           </div>
         </div>
         <div
-          class="am-list-riple"
+          class="am-list-ripple"
         />
       </div>
       <div
@@ -624,7 +624,7 @@ exports[`renders ./components/list/demo/form.md correctly 1`] = `
           </div>
         </div>
         <div
-          class="am-list-riple"
+          class="am-list-ripple"
         />
       </div>
       <div
@@ -698,7 +698,7 @@ exports[`renders ./components/list/demo/form.md correctly 1`] = `
           </div>
         </div>
         <div
-          class="am-list-riple"
+          class="am-list-ripple"
         />
       </div>
       <div
@@ -730,7 +730,7 @@ exports[`renders ./components/list/demo/form.md correctly 1`] = `
           </div>
         </div>
         <div
-          class="am-list-riple"
+          class="am-list-ripple"
         />
       </div>
     </div>

--- a/components/list/style/index.less
+++ b/components/list/style/index.less
@@ -48,7 +48,7 @@
   overflow: hidden;
   .box-align;
   transition: background-color 200ms;
-  .@{listPrefixCls}-riple {
+  .@{listPrefixCls}-ripple {
     position: absolute;
     background: transparent;
     display: inline-block;
@@ -59,7 +59,7 @@
     cursor: pointer;
     border-radius: 100%;
     transform: scale(0);
-    &.@{listPrefixCls}-riple-animate {
+    &.@{listPrefixCls}-ripple-animate {
       background-color: hsla(0, 0%, 62%, .2);
       animation: ripple 1s linear;
     }

--- a/components/locale-provider/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/locale-provider/__tests__/__snapshots__/demo.test.web.js.snap
@@ -90,6 +90,9 @@ exports[`renders ./components/locale-provider/demo/basic.md correctly 1`] = `
                 class="am-list-arrow am-list-arrow-horizontal"
               />
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
         </div>
       </div>

--- a/components/locale-provider/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/locale-provider/__tests__/__snapshots__/demo.test.web.js.snap
@@ -92,6 +92,7 @@ exports[`renders ./components/locale-provider/demo/basic.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
         </div>

--- a/components/locale-provider/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/locale-provider/__tests__/__snapshots__/demo.test.web.js.snap
@@ -91,7 +91,7 @@ exports[`renders ./components/locale-provider/demo/basic.md correctly 1`] = `
               />
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
         </div>

--- a/components/menu/__tests__/__snapshots__/index.test.web.js.snap
+++ b/components/menu/__tests__/__snapshots__/index.test.web.js.snap
@@ -50,6 +50,9 @@ exports[`Menu level 1 renders correctly 1`] = `
                 </label>
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-radio-item am-list-item am-list-item-middle"
@@ -82,6 +85,9 @@ exports[`Menu level 1 renders correctly 1`] = `
                 </label>
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
         </div>
       </div>
@@ -120,6 +126,9 @@ exports[`Menu renders correctly 1`] = `
                 Item1
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
           <div
             class="am-list-item am-list-item-middle"
@@ -133,6 +142,9 @@ exports[`Menu renders correctly 1`] = `
                 Item2
               </div>
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
         </div>
       </div>

--- a/components/menu/__tests__/__snapshots__/index.test.web.js.snap
+++ b/components/menu/__tests__/__snapshots__/index.test.web.js.snap
@@ -51,7 +51,7 @@ exports[`Menu level 1 renders correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -86,7 +86,7 @@ exports[`Menu level 1 renders correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
         </div>
@@ -127,7 +127,7 @@ exports[`Menu renders correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
           <div
@@ -143,7 +143,7 @@ exports[`Menu renders correctly 1`] = `
               </div>
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
         </div>

--- a/components/menu/__tests__/__snapshots__/index.test.web.js.snap
+++ b/components/menu/__tests__/__snapshots__/index.test.web.js.snap
@@ -52,6 +52,7 @@ exports[`Menu level 1 renders correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -87,6 +88,7 @@ exports[`Menu level 1 renders correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
         </div>
@@ -128,6 +130,7 @@ exports[`Menu renders correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
           <div
@@ -144,6 +147,7 @@ exports[`Menu renders correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
         </div>

--- a/components/picker/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/picker/__tests__/__snapshots__/demo.test.web.js.snap
@@ -35,6 +35,7 @@ exports[`renders ./components/picker/demo/basic.md correctly 1`] = `
           </div>
           <div
             class="am-list-ripple"
+            style="display:none;"
           />
         </div>
       </div>
@@ -61,6 +62,7 @@ exports[`renders ./components/picker/demo/basic.md correctly 1`] = `
           </div>
           <div
             class="am-list-ripple"
+            style="display:none;"
           />
         </div>
       </div>
@@ -87,6 +89,7 @@ exports[`renders ./components/picker/demo/basic.md correctly 1`] = `
           </div>
           <div
             class="am-list-ripple"
+            style="display:none;"
           />
         </div>
       </div>
@@ -113,6 +116,7 @@ exports[`renders ./components/picker/demo/basic.md correctly 1`] = `
           </div>
           <div
             class="am-list-ripple"
+            style="display:none;"
           />
         </div>
       </div>

--- a/components/picker/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/picker/__tests__/__snapshots__/demo.test.web.js.snap
@@ -34,7 +34,7 @@ exports[`renders ./components/picker/demo/basic.md correctly 1`] = `
             />
           </div>
           <div
-            class="am-list-riple"
+            class="am-list-ripple"
           />
         </div>
       </div>
@@ -60,7 +60,7 @@ exports[`renders ./components/picker/demo/basic.md correctly 1`] = `
             />
           </div>
           <div
-            class="am-list-riple"
+            class="am-list-ripple"
           />
         </div>
       </div>
@@ -86,7 +86,7 @@ exports[`renders ./components/picker/demo/basic.md correctly 1`] = `
             />
           </div>
           <div
-            class="am-list-riple"
+            class="am-list-ripple"
           />
         </div>
       </div>
@@ -112,7 +112,7 @@ exports[`renders ./components/picker/demo/basic.md correctly 1`] = `
             />
           </div>
           <div
-            class="am-list-riple"
+            class="am-list-ripple"
           />
         </div>
       </div>

--- a/components/picker/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/picker/__tests__/__snapshots__/demo.test.web.js.snap
@@ -33,6 +33,9 @@ exports[`renders ./components/picker/demo/basic.md correctly 1`] = `
               class="am-list-arrow am-list-arrow-horizontal"
             />
           </div>
+          <div
+            class="am-list-riple"
+          />
         </div>
       </div>
       <div>
@@ -56,6 +59,9 @@ exports[`renders ./components/picker/demo/basic.md correctly 1`] = `
               class="am-list-arrow am-list-arrow-horizontal"
             />
           </div>
+          <div
+            class="am-list-riple"
+          />
         </div>
       </div>
       <div>
@@ -79,6 +85,9 @@ exports[`renders ./components/picker/demo/basic.md correctly 1`] = `
               class="am-list-arrow am-list-arrow-horizontal"
             />
           </div>
+          <div
+            class="am-list-riple"
+          />
         </div>
       </div>
       <div>
@@ -102,6 +111,9 @@ exports[`renders ./components/picker/demo/basic.md correctly 1`] = `
               class="am-list-arrow am-list-arrow-horizontal"
             />
           </div>
+          <div
+            class="am-list-riple"
+          />
         </div>
       </div>
       <div>

--- a/components/radio/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/radio/__tests__/__snapshots__/demo.test.web.js.snap
@@ -47,7 +47,7 @@ exports[`renders ./components/radio/demo/basic.md correctly 1`] = `
           </div>
         </div>
         <div
-          class="am-list-riple"
+          class="am-list-ripple"
         />
       </div>
       <div
@@ -82,7 +82,7 @@ exports[`renders ./components/radio/demo/basic.md correctly 1`] = `
           </div>
         </div>
         <div
-          class="am-list-riple"
+          class="am-list-ripple"
         />
       </div>
     </div>
@@ -135,7 +135,7 @@ exports[`renders ./components/radio/demo/basic.md correctly 1`] = `
           </div>
         </div>
         <div
-          class="am-list-riple"
+          class="am-list-ripple"
         />
       </div>
       <div
@@ -175,7 +175,7 @@ exports[`renders ./components/radio/demo/basic.md correctly 1`] = `
           </div>
         </div>
         <div
-          class="am-list-riple"
+          class="am-list-ripple"
         />
       </div>
     </div>
@@ -226,7 +226,7 @@ exports[`renders ./components/radio/demo/basic.md correctly 1`] = `
           </div>
         </div>
         <div
-          class="am-list-riple"
+          class="am-list-ripple"
         />
       </div>
       <div
@@ -262,7 +262,7 @@ exports[`renders ./components/radio/demo/basic.md correctly 1`] = `
           </div>
         </div>
         <div
-          class="am-list-riple"
+          class="am-list-ripple"
         />
       </div>
     </div>
@@ -316,7 +316,7 @@ exports[`renders ./components/radio/demo/basic.md correctly 1`] = `
           </div>
         </div>
         <div
-          class="am-list-riple"
+          class="am-list-ripple"
         />
       </div>
       <div
@@ -357,7 +357,7 @@ exports[`renders ./components/radio/demo/basic.md correctly 1`] = `
           </div>
         </div>
         <div
-          class="am-list-riple"
+          class="am-list-ripple"
         />
       </div>
     </div>

--- a/components/radio/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/radio/__tests__/__snapshots__/demo.test.web.js.snap
@@ -46,6 +46,9 @@ exports[`renders ./components/radio/demo/basic.md correctly 1`] = `
             </label>
           </div>
         </div>
+        <div
+          class="am-list-riple"
+        />
       </div>
       <div
         class="am-radio-item am-list-item am-list-item-middle"
@@ -78,6 +81,9 @@ exports[`renders ./components/radio/demo/basic.md correctly 1`] = `
             </label>
           </div>
         </div>
+        <div
+          class="am-list-riple"
+        />
       </div>
     </div>
   </div>
@@ -128,6 +134,9 @@ exports[`renders ./components/radio/demo/basic.md correctly 1`] = `
             </label>
           </div>
         </div>
+        <div
+          class="am-list-riple"
+        />
       </div>
       <div
         class="am-radio-item am-list-item am-list-item-middle"
@@ -165,6 +174,9 @@ exports[`renders ./components/radio/demo/basic.md correctly 1`] = `
             </label>
           </div>
         </div>
+        <div
+          class="am-list-riple"
+        />
       </div>
     </div>
   </div>
@@ -213,6 +225,9 @@ exports[`renders ./components/radio/demo/basic.md correctly 1`] = `
             </label>
           </div>
         </div>
+        <div
+          class="am-list-riple"
+        />
       </div>
       <div
         class="am-radio-item am-radio-item-disabled am-list-item am-list-item-middle"
@@ -246,6 +261,9 @@ exports[`renders ./components/radio/demo/basic.md correctly 1`] = `
             </label>
           </div>
         </div>
+        <div
+          class="am-list-riple"
+        />
       </div>
     </div>
   </div>
@@ -297,6 +315,9 @@ exports[`renders ./components/radio/demo/basic.md correctly 1`] = `
             </label>
           </div>
         </div>
+        <div
+          class="am-list-riple"
+        />
       </div>
       <div
         class="am-radio-item am-radio-item-disabled am-list-item am-list-item-middle"
@@ -335,6 +356,9 @@ exports[`renders ./components/radio/demo/basic.md correctly 1`] = `
             </label>
           </div>
         </div>
+        <div
+          class="am-list-riple"
+        />
       </div>
     </div>
   </div>

--- a/components/radio/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/radio/__tests__/__snapshots__/demo.test.web.js.snap
@@ -48,6 +48,7 @@ exports[`renders ./components/radio/demo/basic.md correctly 1`] = `
         </div>
         <div
           class="am-list-ripple"
+          style="display:none;"
         />
       </div>
       <div
@@ -83,6 +84,7 @@ exports[`renders ./components/radio/demo/basic.md correctly 1`] = `
         </div>
         <div
           class="am-list-ripple"
+          style="display:none;"
         />
       </div>
     </div>
@@ -136,6 +138,7 @@ exports[`renders ./components/radio/demo/basic.md correctly 1`] = `
         </div>
         <div
           class="am-list-ripple"
+          style="display:none;"
         />
       </div>
       <div
@@ -176,6 +179,7 @@ exports[`renders ./components/radio/demo/basic.md correctly 1`] = `
         </div>
         <div
           class="am-list-ripple"
+          style="display:none;"
         />
       </div>
     </div>
@@ -227,6 +231,7 @@ exports[`renders ./components/radio/demo/basic.md correctly 1`] = `
         </div>
         <div
           class="am-list-ripple"
+          style="display:none;"
         />
       </div>
       <div
@@ -263,6 +268,7 @@ exports[`renders ./components/radio/demo/basic.md correctly 1`] = `
         </div>
         <div
           class="am-list-ripple"
+          style="display:none;"
         />
       </div>
     </div>
@@ -317,6 +323,7 @@ exports[`renders ./components/radio/demo/basic.md correctly 1`] = `
         </div>
         <div
           class="am-list-ripple"
+          style="display:none;"
         />
       </div>
       <div
@@ -358,6 +365,7 @@ exports[`renders ./components/radio/demo/basic.md correctly 1`] = `
         </div>
         <div
           class="am-list-ripple"
+          style="display:none;"
         />
       </div>
     </div>

--- a/components/stepper/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/stepper/__tests__/__snapshots__/demo.test.web.js.snap
@@ -82,6 +82,9 @@ exports[`renders ./components/stepper/demo/basic.md correctly 1`] = `
           </div>
         </div>
       </div>
+      <div
+        class="am-list-riple"
+      />
     </div>
     <div
       class="am-list-item am-list-item-middle"
@@ -153,6 +156,9 @@ exports[`renders ./components/stepper/demo/basic.md correctly 1`] = `
           </div>
         </div>
       </div>
+      <div
+        class="am-list-riple"
+      />
     </div>
     <div
       class="am-list-item am-list-item-middle"
@@ -225,6 +231,9 @@ exports[`renders ./components/stepper/demo/basic.md correctly 1`] = `
           </div>
         </div>
       </div>
+      <div
+        class="am-list-riple"
+      />
     </div>
   </div>
 </div>

--- a/components/stepper/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/stepper/__tests__/__snapshots__/demo.test.web.js.snap
@@ -84,6 +84,7 @@ exports[`renders ./components/stepper/demo/basic.md correctly 1`] = `
       </div>
       <div
         class="am-list-ripple"
+        style="display:none;"
       />
     </div>
     <div
@@ -158,6 +159,7 @@ exports[`renders ./components/stepper/demo/basic.md correctly 1`] = `
       </div>
       <div
         class="am-list-ripple"
+        style="display:none;"
       />
     </div>
     <div
@@ -233,6 +235,7 @@ exports[`renders ./components/stepper/demo/basic.md correctly 1`] = `
       </div>
       <div
         class="am-list-ripple"
+        style="display:none;"
       />
     </div>
   </div>

--- a/components/stepper/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/stepper/__tests__/__snapshots__/demo.test.web.js.snap
@@ -83,7 +83,7 @@ exports[`renders ./components/stepper/demo/basic.md correctly 1`] = `
         </div>
       </div>
       <div
-        class="am-list-riple"
+        class="am-list-ripple"
       />
     </div>
     <div
@@ -157,7 +157,7 @@ exports[`renders ./components/stepper/demo/basic.md correctly 1`] = `
         </div>
       </div>
       <div
-        class="am-list-riple"
+        class="am-list-ripple"
       />
     </div>
     <div
@@ -232,7 +232,7 @@ exports[`renders ./components/stepper/demo/basic.md correctly 1`] = `
         </div>
       </div>
       <div
-        class="am-list-riple"
+        class="am-list-ripple"
       />
     </div>
   </div>

--- a/components/swipe-action/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/swipe-action/__tests__/__snapshots__/demo.test.web.js.snap
@@ -93,6 +93,7 @@ exports[`renders ./components/swipe-action/demo/basic.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
         </div>
@@ -184,6 +185,7 @@ exports[`renders ./components/swipe-action/demo/basic.md correctly 1`] = `
             </div>
             <div
               class="am-list-ripple"
+              style="display:none;"
             />
           </div>
         </div>

--- a/components/swipe-action/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/swipe-action/__tests__/__snapshots__/demo.test.web.js.snap
@@ -91,6 +91,9 @@ exports[`renders ./components/swipe-action/demo/basic.md correctly 1`] = `
                 class="am-list-arrow am-list-arrow-horizontal"
               />
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
         </div>
       </div>
@@ -179,6 +182,9 @@ exports[`renders ./components/swipe-action/demo/basic.md correctly 1`] = `
                 class="am-list-arrow am-list-arrow-horizontal"
               />
             </div>
+            <div
+              class="am-list-riple"
+            />
           </div>
         </div>
       </div>

--- a/components/swipe-action/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/swipe-action/__tests__/__snapshots__/demo.test.web.js.snap
@@ -92,7 +92,7 @@ exports[`renders ./components/swipe-action/demo/basic.md correctly 1`] = `
               />
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
         </div>
@@ -183,7 +183,7 @@ exports[`renders ./components/swipe-action/demo/basic.md correctly 1`] = `
               />
             </div>
             <div
-              class="am-list-riple"
+              class="am-list-ripple"
             />
           </div>
         </div>

--- a/components/switch/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/switch/__tests__/__snapshots__/demo.test.web.js.snap
@@ -41,6 +41,9 @@ exports[`renders ./components/switch/demo/basic.md correctly 1`] = `
           </label>
         </div>
       </div>
+      <div
+        class="am-list-riple"
+      />
     </div>
     <div
       class="am-list-item am-list-item-middle"
@@ -70,6 +73,9 @@ exports[`renders ./components/switch/demo/basic.md correctly 1`] = `
           </label>
         </div>
       </div>
+      <div
+        class="am-list-riple"
+      />
     </div>
     <div
       class="am-list-item am-list-item-middle"
@@ -100,6 +106,9 @@ exports[`renders ./components/switch/demo/basic.md correctly 1`] = `
           </label>
         </div>
       </div>
+      <div
+        class="am-list-riple"
+      />
     </div>
     <div
       class="am-list-item am-list-item-middle"
@@ -131,6 +140,9 @@ exports[`renders ./components/switch/demo/basic.md correctly 1`] = `
           </label>
         </div>
       </div>
+      <div
+        class="am-list-riple"
+      />
     </div>
     <div
       class="am-list-item am-list-item-middle"
@@ -160,6 +172,9 @@ exports[`renders ./components/switch/demo/basic.md correctly 1`] = `
           </label>
         </div>
       </div>
+      <div
+        class="am-list-riple"
+      />
     </div>
     <div
       class="am-list-item am-list-item-middle"
@@ -190,6 +205,9 @@ exports[`renders ./components/switch/demo/basic.md correctly 1`] = `
           </label>
         </div>
       </div>
+      <div
+        class="am-list-riple"
+      />
     </div>
   </div>
 </div>

--- a/components/switch/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/switch/__tests__/__snapshots__/demo.test.web.js.snap
@@ -42,7 +42,7 @@ exports[`renders ./components/switch/demo/basic.md correctly 1`] = `
         </div>
       </div>
       <div
-        class="am-list-riple"
+        class="am-list-ripple"
       />
     </div>
     <div
@@ -74,7 +74,7 @@ exports[`renders ./components/switch/demo/basic.md correctly 1`] = `
         </div>
       </div>
       <div
-        class="am-list-riple"
+        class="am-list-ripple"
       />
     </div>
     <div
@@ -107,7 +107,7 @@ exports[`renders ./components/switch/demo/basic.md correctly 1`] = `
         </div>
       </div>
       <div
-        class="am-list-riple"
+        class="am-list-ripple"
       />
     </div>
     <div
@@ -141,7 +141,7 @@ exports[`renders ./components/switch/demo/basic.md correctly 1`] = `
         </div>
       </div>
       <div
-        class="am-list-riple"
+        class="am-list-ripple"
       />
     </div>
     <div
@@ -173,7 +173,7 @@ exports[`renders ./components/switch/demo/basic.md correctly 1`] = `
         </div>
       </div>
       <div
-        class="am-list-riple"
+        class="am-list-ripple"
       />
     </div>
     <div
@@ -206,7 +206,7 @@ exports[`renders ./components/switch/demo/basic.md correctly 1`] = `
         </div>
       </div>
       <div
-        class="am-list-riple"
+        class="am-list-ripple"
       />
     </div>
   </div>

--- a/components/switch/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/switch/__tests__/__snapshots__/demo.test.web.js.snap
@@ -43,6 +43,7 @@ exports[`renders ./components/switch/demo/basic.md correctly 1`] = `
       </div>
       <div
         class="am-list-ripple"
+        style="display:none;"
       />
     </div>
     <div
@@ -75,6 +76,7 @@ exports[`renders ./components/switch/demo/basic.md correctly 1`] = `
       </div>
       <div
         class="am-list-ripple"
+        style="display:none;"
       />
     </div>
     <div
@@ -108,6 +110,7 @@ exports[`renders ./components/switch/demo/basic.md correctly 1`] = `
       </div>
       <div
         class="am-list-ripple"
+        style="display:none;"
       />
     </div>
     <div
@@ -142,6 +145,7 @@ exports[`renders ./components/switch/demo/basic.md correctly 1`] = `
       </div>
       <div
         class="am-list-ripple"
+        style="display:none;"
       />
     </div>
     <div
@@ -174,6 +178,7 @@ exports[`renders ./components/switch/demo/basic.md correctly 1`] = `
       </div>
       <div
         class="am-list-ripple"
+        style="display:none;"
       />
     </div>
     <div
@@ -207,6 +212,7 @@ exports[`renders ./components/switch/demo/basic.md correctly 1`] = `
       </div>
       <div
         class="am-list-ripple"
+        style="display:none;"
       />
     </div>
   </div>

--- a/components/textarea-item/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/textarea-item/__tests__/__snapshots__/demo.test.web.js.snap
@@ -66,7 +66,7 @@ exports[`renders ./components/textarea-item/demo/basic.md correctly 1`] = `
           </div>
         </div>
         <div
-          class="am-list-riple"
+          class="am-list-ripple"
         />
       </div>
     </div>

--- a/components/textarea-item/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/textarea-item/__tests__/__snapshots__/demo.test.web.js.snap
@@ -67,6 +67,7 @@ exports[`renders ./components/textarea-item/demo/basic.md correctly 1`] = `
         </div>
         <div
           class="am-list-ripple"
+          style="display:none;"
         />
       </div>
     </div>

--- a/components/textarea-item/__tests__/__snapshots__/demo.test.web.js.snap
+++ b/components/textarea-item/__tests__/__snapshots__/demo.test.web.js.snap
@@ -65,6 +65,9 @@ exports[`renders ./components/textarea-item/demo/basic.md correctly 1`] = `
             </div>
           </div>
         </div>
+        <div
+          class="am-list-riple"
+        />
       </div>
     </div>
   </div>


### PR DESCRIPTION
Remove platform detect code from List.Item#render()

This pr make List.Item render riple div on all device. But still show ripple effect on android only.

close #1200 

First of all, thanks for your contribution! :-)

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.
* [ ] Wait enough real device testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/1219)
<!-- Reviewable:end -->
