### PR TITLE
fix style tsx (temporary)

### DIFF
--- a/components/accordion/PropsType.tsx
+++ b/components/accordion/PropsType.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
 interface AccordionProps {
-  style?: React.CSSProperties;
+  styles?: any;
+  style?: any;
   /** below web only */
   className?: string;
   prefixCls?: string;
@@ -10,7 +11,6 @@ interface AccordionProps {
   openAnimation?: any;
   accordion?: boolean;
   onChange?: (x: any) => void;
-  styles?: any;
 }
 
 export default AccordionProps;

--- a/components/accordion/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/accordion/__tests__/__snapshots__/demo.test.js.snap
@@ -11,10 +11,13 @@ exports[`renders ./components/accordion/demo/basic.tsx correctly 1`] = `
 >
   <View
     style={
-      Object {
-        "borderTopColor": "#ddd",
-        "borderTopWidth": 0.5,
-      }
+      Array [
+        undefined,
+        Object {
+          "borderTopColor": "#ddd",
+          "borderTopWidth": 0.5,
+        },
+      ]
     }
   >
     <View>

--- a/components/accordion/__tests__/__snapshots__/index.test.js.snap
+++ b/components/accordion/__tests__/__snapshots__/index.test.js.snap
@@ -3,10 +3,13 @@
 exports[`Accordion renders correctly 1`] = `
 <View
   style={
-    Object {
-      "borderTopColor": "#ddd",
-      "borderTopWidth": 0.5,
-    }
+    Array [
+      undefined,
+      Object {
+        "borderTopColor": "#ddd",
+        "borderTopWidth": 0.5,
+      },
+    ]
   }
 >
   <View>

--- a/components/accordion/index.tsx
+++ b/components/accordion/index.tsx
@@ -65,7 +65,7 @@ class Accordion extends React.Component<AccordionProps, any> {
   }
 
   render() {
-    const { children, styles, defaultActiveKey, activeKey } = this.props;
+    const { children, style, styles, defaultActiveKey, activeKey } = this.props;
     let defaultActiveSection;
     let activeSection;
     const headers = React.Children.map(children, (child: any, index) => {
@@ -83,7 +83,7 @@ class Accordion extends React.Component<AccordionProps, any> {
     });
 
     return (
-      <View style={styles.container}>
+      <View style={[style, styles.container]}>
         <RNAccordion
           initiallyActiveSection={defaultActiveSection}
           activeSection={activeSection}

--- a/components/badge/PropsType.tsx
+++ b/components/badge/PropsType.tsx
@@ -4,7 +4,7 @@ interface BadgeProps {
   corner?: boolean;
   dot?: boolean;
   text?: any;
-  style?: {};
+  style?: any;
   /** rn only */
   styles?: any;
   /** web only */

--- a/components/flex/PropsType.tsx
+++ b/components/flex/PropsType.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 export interface FlexProps {
   /** web only */
   prefixCls?: string;
-  style?: React.CSSProperties;
+  style?: any;
   /** web only */
   className?: string;
   direction?: 'row'|'row-reverse'|'column'|'column-reverse';
@@ -27,7 +27,7 @@ export interface FlexItemProps {
   /** web only */
   prefixCls?: string;
   className?: string;
-  style?: React.CSSProperties;
+  style?: any;
   onClick?: (e?: any) => void;
   children?: any;
   /* touchableWithoutFeedback prop */

--- a/components/grid/PropsType.tsx
+++ b/components/grid/PropsType.tsx
@@ -17,7 +17,6 @@ export interface GridProps {
   renderItem?: (dataItem: DataItem | undefined, itemIndex: number) => React.ReactElement<any>;
   prefixCls?: string;
   className?: string;
-  style?: React.CSSProperties;
   /** rn only **/
   styles?: any;
 }

--- a/components/input-item/PropsType.tsx
+++ b/components/input-item/PropsType.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 
 interface InputItemProps {
+  style?: any;
   /** web only */
   prefixCls?: string;
   /** web only */
   prefixListCls?: string;
-  style?: React.CSSProperties;
   /** web only */
   className?: string;
   type?: 'text'|'bankCard'|'phone'|'password'|'number'|'idcard'|'digit';

--- a/components/list-view/PropsType.tsx
+++ b/components/list-view/PropsType.tsx
@@ -19,12 +19,12 @@ interface Props {
   renderScrollComponent?: Function;
   scrollRenderAheadDistance?: number;
   onChangeVisibleRows?: Function;
+  style?: any;
   /** below web only */
   className?: string;
   prefixCls?: string;
   listPrefixCls?: string;
   listViewPrefixCls?: string;
-  style?: React.CSSProperties;
   contentContainerStyle?: React.CSSProperties;
   renderBodyComponent?: Function;
   renderSectionBodyWrapper?: Function;

--- a/components/list/PropsType.tsx
+++ b/components/list/PropsType.tsx
@@ -1,9 +1,9 @@
 import React, { ReactNode } from 'react';
 
 export interface ListProps {
+  style?: any;
   /** web only */
   prefixCls?: string;
-  style?: React.CSSProperties;
   /** web only */
   className?: string;
   children?: any;
@@ -42,7 +42,7 @@ export interface ListItemProps {
 }
 
 export interface BriefProps {
-  style?: React.CSSProperties;
+  style?: any;
   children?: any;
   wrap?: boolean;
   /** rn only */

--- a/components/pagination/PropsType.tsx
+++ b/components/pagination/PropsType.tsx
@@ -5,7 +5,7 @@ interface PaginationPropTypes {
   className?: string;
   mode?: 'button' | 'number' | 'pointer';
   simple?: Boolean;
-  style?: React.CSSProperties;
+  style?: any;
   current: number;
   total: number;
   prevText?: string;

--- a/components/progress/PropsType.tsx
+++ b/components/progress/PropsType.tsx
@@ -4,7 +4,7 @@ interface ProgressProps {
   percent?: number;
   position?: 'fixed' | 'normal';
   unfilled?: 'show' | 'hide';
-  style?: React.CSSProperties;
+  style?: any;
   /** rn only */
   wrapWidth?: number;
   styles?: any;

--- a/components/radio/PropsType.tsx
+++ b/components/radio/PropsType.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 export interface RadioProps {
-  style?: React.CSSProperties;
+  style?: any;
   defaultChecked?: boolean;
   checked?: boolean;
   disabled?: boolean;

--- a/components/result/PropsType.tsx
+++ b/components/result/PropsType.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 interface ResultProps {
-  style?: React.CSSProperties;
+  style?: any;
   imgUrl?: string;
   img?: React.ReactNode;
   title?: React.ReactNode;

--- a/components/result/index.web.tsx
+++ b/components/result/index.web.tsx
@@ -12,7 +12,18 @@ export default class Result extends React.Component<ResultProps, any> {
   };
 
   render() {
-    const { prefixCls, className, img, imgUrl, title, message, buttonText, buttonClick, buttonType } = this.props;
+    const {
+      prefixCls,
+      className,
+      img,
+      imgUrl,
+      title,
+      message,
+      buttonText,
+      buttonClick,
+      buttonType,
+      style,
+    } = this.props;
     const wrapCls = classNames({
       [`${prefixCls}`]: true,
       [className as string]: className,
@@ -26,7 +37,7 @@ export default class Result extends React.Component<ResultProps, any> {
     }
 
     return (
-      <div className={wrapCls} role="alert">
+      <div className={wrapCls} style={style} role="alert">
         {imgContent}
         {title ? <div className={`${prefixCls}-title`}>{title}</div> : null}
         {message ? <div className={`${prefixCls}-message`}>{message}</div> : null}

--- a/components/search-bar/PropsType.tsx
+++ b/components/search-bar/PropsType.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 function noop() {}
 
 export interface SearchBarProps {
+  style?: any;
   defaultValue?: string;
   value?: string;
   placeholder?: string;
@@ -19,7 +20,6 @@ export interface SearchBarProps {
   focused?: boolean;
   /** web only */
   prefixCls?: string;
-  style?: React.CSSProperties;
   className?: string;
   onClear?: Function;
 }

--- a/components/search-bar/index.web.tsx
+++ b/components/search-bar/index.web.tsx
@@ -164,7 +164,7 @@ export default class SearchBar extends React.Component<SearchBarProps, SearchBar
   render() {
     const {
       prefixCls, showCancelButton, disabled, placeholder,
-      cancelText, className,
+      cancelText, className, style,
     } = this.props;
 
     const { value, focus } = this.state;
@@ -187,7 +187,7 @@ export default class SearchBar extends React.Component<SearchBarProps, SearchBar
     });
 
     return (
-      <form onSubmit={this.onSubmit} className={wrapCls} ref="searchInputContainer">
+      <form onSubmit={this.onSubmit} className={wrapCls} style={style} ref="searchInputContainer">
         <div className={`${prefixCls}-input`}>
           <div className={`${prefixCls}-synthetic-ph`} ref="syntheticPh">
             <span className={`${prefixCls}-synthetic-ph-container`} ref="syntheticPhContainer">

--- a/components/textarea-item/PropsType.tsx
+++ b/components/textarea-item/PropsType.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 
 interface TextAreaItemProps {
+  style?: any;
   /** web only */
   prefixCls?: string;
   /** web only */
   prefixListCls?: string;
   /** web only */
   className?: string;
-  style?: React.CSSProperties;
   title?: React.ReactNode;
   maxLength?: number;
   /** web only */

--- a/components/white-space/PropsType.tsx
+++ b/components/white-space/PropsType.tsx
@@ -6,7 +6,7 @@ export interface WhiteSpaceProps {
   /** web only */
   prefixCls?: string;
   /** web only */
-  style?: React.CSSProperties;
+  style?: any;
   /** web only */
   className?: string;
 }

--- a/components/wing-blank/PropsType.tsx
+++ b/components/wing-blank/PropsType.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export interface WingBlankProps {
   size?: 'sm'|'md'|'lg';
-  style?: React.CSSProperties;
+  style?: any;
   /** web only */
   prefixCls?: string;
   /** web only */


### PR DESCRIPTION
First of all, thanks for your contribution! :-)

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

<del>大致看了下所有组件样式字段的定义</del>
<del>web: `style: React.CSSProperties`</del>
<del>native: `styles: any`</del>

<del>目前有部分不是按照这个规则来的，web，native都用了style字段，导致用rn开发，tsc报错</del>
<del>* Flex</del>
<del>* WhiteSpace</del>
<del>* wing-blank</del>

<del>所以为了不造成break change，先改成style: any，在2.0里再把两个字段分开来</del>

<del>另外为什么不是`styles?: StyleSheet.Style`</del>

临时修复组件的style type

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/1262)
<!-- Reviewable:end -->
