### PR TITLE
【WIP】upgrade svg-sprite-loader to 2.0.6

### DIFF
--- a/components/action-sheet/demo/basic.md
+++ b/components/action-sheet/demo/basic.md
@@ -27,9 +27,9 @@ const iconList = [
   { icon: <img src="https://zos.alipayobjects.com/rmsportal/HCGowLrLFMFglxRAKjWd.png" />, title: '生活圈' },
   { icon: <img src="https://zos.alipayobjects.com/rmsportal/LeZNKxCTkLHDWsjFfqqn.png" />, title: '微信好友' },
   { icon: <img src="https://zos.alipayobjects.com/rmsportal/YHHFcpGxlvQIqCAvZdbw.png" />, title: 'QQ' },
-  { icon: <Icon type={require('./refresh.svg')} />, title: '刷新' },
-  { icon: <Icon type={require('./link.svg')} />, title: '链接' },
-  { icon: <Icon type={require('./complaints.svg')} />, title: '投诉' },
+  { icon: <Icon type={require('./refresh.svg').id} />, title: '刷新' },
+  { icon: <Icon type={require('./link.svg').id} />, title: '链接' },
+  { icon: <Icon type={require('./complaints.svg').id} />, title: '投诉' },
 ];
 
 class Test extends React.Component {

--- a/components/button/demo/basic.md
+++ b/components/button/demo/basic.md
@@ -21,7 +21,7 @@ const ButtonExample = () => (
         </Button>
         <Button className="btn" loading>loading button</Button>
         <Button className="btn" icon="check-circle-o">with icon</Button>
-        <Button className="btn" icon={require('!svg-sprite!./reload.svg')}>
+        <Button className="btn" icon={require('!svg-sprite!./reload.svg').id}>
           with local icon
         </Button>
 

--- a/components/icon/demo/basic.md
+++ b/components/icon/demo/basic.md
@@ -23,7 +23,7 @@ const Demo = () => {
     icon: (<Icon type={item} />),
     text: item,
   })).concat([{
-    icon: (<Icon type={require('./reload.svg')} />),
+    icon: (<Icon type={require('./reload.svg').id} />),
     text: '自定义图标',
   }]);
   return (

--- a/components/icon/index.en-US.md
+++ b/components/icon/index.en-US.md
@@ -99,9 +99,9 @@ const svgDirs = [
 
 ## 本地部署
 
-支持添加本地私有的 svg 图标，使用方式如`<Icon type={require('./reload.svg')} />`，此时需要在以上 `webpack.config.js` 的`svgDirs` 数组里加入本地图标路径，给 svg-sprite-loader 插件处理。
+支持添加本地私有的 svg 图标，使用方式如`<Icon type={require('./reload.svg').id} />`，此时需要在以上 `webpack.config.js` 的`svgDirs` 数组里加入本地图标路径，给 svg-sprite-loader 插件处理。
 
-> 还有一种不推荐但很简便的方式：`<Icon type={require('!svg-sprite!./reload.svg')} />`
+> 还有一种不推荐但很简便的方式：`<Icon type={require('!svg-sprite!./reload.svg').id} />`
 这样就不需要将本地 svg 文件所在路径加入到`svgDirs`数组里了，[详细参考 webpack loaders-in-require](http://webpack.github.io/docs/using-loaders.html#loaders-in-require)
 
 ## 如何使用 (RN 版)

--- a/components/icon/index.zh-CN.md
+++ b/components/icon/index.zh-CN.md
@@ -100,9 +100,9 @@ const svgDirs = [
 
 ## 本地部署
 
-支持添加本地私有的 svg 图标，使用方式如`<Icon type={require('./reload.svg')} />`，此时需要在以上 `webpack.config.js` 的`svgDirs` 数组里加入本地图标路径，给 svg-sprite-loader 插件处理。
+支持添加本地私有的 svg 图标，使用方式如`<Icon type={require('./reload.svg').id} />`，此时需要在以上 `webpack.config.js` 的`svgDirs` 数组里加入本地图标路径，给 svg-sprite-loader 插件处理。
 
-> 还有一种不推荐但很简便的方式：`<Icon type={require('!svg-sprite!./reload.svg')} />`
+> 还有一种不推荐但很简便的方式：`<Icon type={require('!svg-sprite!./reload.svg').id} />`
 这样就不需要将本地 svg 文件所在路径加入到`svgDirs`数组里了，[详细参考 webpack loaders-in-require](http://webpack.github.io/docs/using-loaders.html#loaders-in-require)
 
 ## 如何使用 (RN 版)

--- a/components/menu/demo/basic.md
+++ b/components/menu/demo/basic.md
@@ -133,7 +133,7 @@ class MenuExample extends React.Component {
           <NavBar
             leftContent="Menu"
             mode="light"
-            iconName={require('./menu.svg')}
+            iconName={require('./menu.svg').id}
             onLeftClick={this.handleClick}
             className="top-nav-bar"
           >

--- a/components/notice-bar/index.en-US.md
+++ b/components/notice-bar/index.en-US.md
@@ -17,6 +17,6 @@ Support WEB, React-Native.
 Properties | Descrition | Type | Default
 -----------|------------|------|--------
 | mode    | Type of NoticeBar, options: `closable` `link`   | String |  ''  |
-| icon    | To set the icon before notice  |  React.Element | `<Icon type={require('./trips.svg')} size="xxs" />`|
+| icon    | To set the icon before notice  |  React.Element | `<Icon type={require('./trips.svg').id} size="xxs" />`|
 | onClick    | A callback function, can be executed when you close the notice or click on the operating area   | (): void |   |
 | marqueeProps (`web only`) | marquee params       | Object | `{loop: false, leading: 500, trailing: 800, fps: 40, style: {}}`  |

--- a/components/notice-bar/index.web.tsx
+++ b/components/notice-bar/index.web.tsx
@@ -9,7 +9,7 @@ export default class NoticeBar extends React.Component<NoticeBarProps, any> {
   static defaultProps = {
     prefixCls: 'am-notice-bar',
     mode: '',
-    icon: <Icon type={require('./style/assets/trips.svg')} size="xxs" />,
+    icon: <Icon type={require('./style/assets/trips.svg').id} size="xxs" />,
     onClick() {},
   };
 

--- a/components/notice-bar/index.zh-CN.md
+++ b/components/notice-bar/index.zh-CN.md
@@ -17,6 +17,6 @@ subtitle: 通告栏
 属性 | 说明 | 类型 | 默认值
 ----|-----|------|------
 | mode    | 提示类型，可选`closable`,`link`   | String |  ''  |
-| icon    |  notice 前的图标  |  React.Element | `<Icon type={require('./trips.svg')} size="xxs" />`|
+| icon    |  notice 前的图标  |  React.Element | `<Icon type={require('./trips.svg').id} size="xxs" />`|
 | onClick    | 点击关闭或者操作区域的回调函数        | (): void |   |
 | marqueeProps (`web only`) | marquee 参数       | Object | `{loop: false, leading: 500, trailing: 800, fps: 40, style: {}}`  |

--- a/components/popover/demo/basic.md
+++ b/components/popover/demo/basic.md
@@ -39,9 +39,9 @@ class App extends React.Component {
         <Popover mask
           visible={this.state.visible}
           overlay={[
-            (<Item key="4" value="scan" icon={<Icon type={require('./scan.svg')} size="xs" />} data-seed="logId">扫一扫</Item>),
-            (<Item key="5" value="special" icon={<Icon type={require('./qrcode.svg')} size="xs" />} style={{ whiteSpace: 'nowrap' }}>我的二维码</Item>),
-            (<Item key="6" value="button ct" icon={<Icon type={require('./help.svg')} size="xs" />}>
+            (<Item key="4" value="scan" icon={<Icon type={require('./scan.svg').id} size="xs" />} data-seed="logId">扫一扫</Item>),
+            (<Item key="5" value="special" icon={<Icon type={require('./qrcode.svg').id} size="xs" />} style={{ whiteSpace: 'nowrap' }}>我的二维码</Item>),
+            (<Item key="6" value="button ct" icon={<Icon type={require('./help.svg').id} size="xs" />}>
               <span style={{ marginRight: 5 }}>帮助</span>
             </Item>),
           ]}

--- a/components/result/demo/basic.md
+++ b/components/result/demo/basic.md
@@ -12,7 +12,7 @@ import { Result, Icon, WhiteSpace } from 'antd-mobile';
 const ResultExample = () => (<div className="result-example">
   <div className="sub-title">支付成功</div>
   <Result
-    img={<Icon type={require('./alipay.svg')} className="icon" />}
+    img={<Icon type={require('./alipay.svg').id} className="icon" />}
     title="支付成功"
     message={<div><div style={{ fontSize: '0.72rem', color: '#000', lineHeight: 1 }}>998.00</div><del>1098元</del></div>}
   />
@@ -33,14 +33,14 @@ const ResultExample = () => (<div className="result-example">
   <WhiteSpace />
   <div className="sub-title">等待处理</div>
   <Result
-    img={<Icon type={require('./waiting.svg')} className="icon" />}
+    img={<Icon type={require('./waiting.svg').id} className="icon" />}
     title="等待处理"
     message="已提交申请，等待银行处理"
   />
   <WhiteSpace />
   <div className="sub-title">操作失败</div>
   <Result
-    img={<Icon type={require('./notice.svg')} className="icon" />}
+    img={<Icon type={require('./notice.svg').id} className="icon" />}
     title="无法完成操作"
     message="由于你的支付宝账户还未绑定淘宝账户请登请登录www.taobao.com"
   />

--- a/components/stepper/index.web.tsx
+++ b/components/stepper/index.web.tsx
@@ -23,8 +23,8 @@ export default class Stepper extends React.Component<StepProps, any> {
 
     return (
       <RcInputNumber
-        upHandler={<Icon type={require('./style/assets/plus.svg')} size="xxs" />}
-        downHandler={<Icon type={require('./style/assets/minus.svg')} size="xxs" />}
+        upHandler={<Icon type={require('./style/assets/plus.svg').id} size="xxs" />}
+        downHandler={<Icon type={require('./style/assets/minus.svg').id} size="xxs" />}
         {...restProps}
         ref="inputNumber"
         className={stepperClass}

--- a/components/steps/demo/basic.md
+++ b/components/steps/demo/basic.md
@@ -39,26 +39,26 @@ ReactDOM.render(
     <div className="sub-title">Customized status </div>
     <WhiteSpace size="lg" />
     <Steps>
-      <Step status="finish" title="Step 1" icon={<Icon type={require('./pay-circle.svg')} />} />
-      <Step status="process" title="Step 2" icon={<Icon type={require('./pay-circle.svg')} />} />
-      <Step status="error" title="Step 3" icon={<Icon type={require('./pay-circle.svg')} />} />
+      <Step status="finish" title="Step 1" icon={<Icon type={require('./pay-circle.svg').id} />} />
+      <Step status="process" title="Step 2" icon={<Icon type={require('./pay-circle.svg').id} />} />
+      <Step status="error" title="Step 3" icon={<Icon type={require('./pay-circle.svg').id} />} />
     </Steps>
 
     <div className="sub-title">Customized icon </div>
     <WhiteSpace size="lg" />
     <Steps current={1}>
-      <Step title="Step 1" icon={<Icon type={require('./pay-circle.svg')} />} description="This is description" />
-      <Step title="Step 2" icon={<Icon type={require('./pay-circle.svg')} />} description="This is description" />
-      <Step title="Step 3" icon={<Icon type={require('./pay-circle.svg')} />} description="This is description" />
+      <Step title="Step 1" icon={<Icon type={require('./pay-circle.svg').id} />} description="This is description" />
+      <Step title="Step 2" icon={<Icon type={require('./pay-circle.svg').id} />} description="This is description" />
+      <Step title="Step 3" icon={<Icon type={require('./pay-circle.svg').id} />} description="This is description" />
     </Steps>
 
     <div className="sub-title">Multiple steps </div>
     <WhiteSpace size="lg" />
     <Steps current={1}>
-      <Step title="Step 1" icon={<Icon type={require('./pay-circle.svg')} />} />
-      <Step title="Step 2" icon={<Icon type={require('./pay-circle.svg')} />} />
-      <Step title="Step 3" status="error" icon={<Icon type={require('./pay-circle.svg')} />} />
-      <Step title="Step 4" icon={<Icon type={require('./pay-circle.svg')} />} />
+      <Step title="Step 1" icon={<Icon type={require('./pay-circle.svg').id} />} />
+      <Step title="Step 2" icon={<Icon type={require('./pay-circle.svg').id} />} />
+      <Step title="Step 3" status="error" icon={<Icon type={require('./pay-circle.svg').id} />} />
+      <Step title="Step 4" icon={<Icon type={require('./pay-circle.svg').id} />} />
     </Steps>
   </WingBlank>
 , mountNode);

--- a/components/steps/demo/horizontal.md
+++ b/components/steps/demo/horizontal.md
@@ -33,9 +33,9 @@ ReactDOM.render(
     <div className="sub-title">Horizontal customized icon</div>
     <WhiteSpace />
     <Steps direction="horizontal">
-      <Step title="Step 1" icon={<Icon type={require('./pay-circle.svg')} />} />
-      <Step status="error" title="Step 2" icon={<Icon type={require('./pay-circle.svg')} />} />
-      <Step title="Step 3" icon={<Icon type={require('./pay-circle.svg')} />} />
+      <Step title="Step 1" icon={<Icon type={require('./pay-circle.svg').id} />} />
+      <Step status="error" title="Step 2" icon={<Icon type={require('./pay-circle.svg').id} />} />
+      <Step title="Step 3" icon={<Icon type={require('./pay-circle.svg').id} />} />
     </Steps>
     <div className="sub-title">Horizontal timeline mode</div>
     <WhiteSpace />

--- a/components/toast/index.web.tsx
+++ b/components/toast/index.web.tsx
@@ -36,7 +36,7 @@ function notice(content, type, duration = 3, onClose, mask = true) {
     style: {},
     content: !!iconType ? (
       <div className={`${prefixCls}-text ${prefixCls}-text-icon`} role="alert" aria-live="assertive">
-        <Icon type={iconType} size="lg" />
+        <Icon type={iconType.id || iconType} size="lg" />
         <div className={`${prefixCls}-text-info`}>{content}</div>
       </div>
     ) : (

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "react-native-mock": "^0.3.1",
     "react-native-router-flux": "~3.37.0",
     "react-test-renderer": "^15.4.2",
-    "svg-sprite-loader": "^0.3.0",
+    "svg-sprite-loader": "^2.0.6",
     "typescript": "~2.2.2",
     "typescript-babel-jest": "^1.0.1"
   },


### PR DESCRIPTION
Updated by @paranoidjk
https://github.com/ant-design/ant-design-mobile/commit/38e4ae2981807af30841bfe2b44bde413728f9ab?diff=unified
已经更新了文档，暂时先别升级，这个升级方案要仔细评估能否向下兼容，业务有太多依赖

```diff
-npm install svg-sprite-loader -D
+npm install svg-sprite-loader@0.3.1 -D
```

这个升级要仔细考虑， 如 https://github.com/ant-design/ant-design-mobile/issues/1283 所说

- antd-mobile 错误的把 svg-sprite-loader 作为了 devDeps（事实上也没法控制用户的loader版本）
- https://mobile.ant.design/components/icon#如何使用-(WEB-版) 这里的官方文档又没有指定版本
- 所以目前 svg-sprite-loader 的版本其实是在用户端控制的

我们要升级，必须要能做到新老配置都兼容

close https://github.com/ant-design/ant-design-mobile/issues/1283

- - -
First of all, thanks for your contribution! :-)

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [ ] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style. (Error: spawn node ENOENT)
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/1311)
<!-- Reviewable:end -->
