### PR TITLE
[SSR] check document before use it in Menu

### DIFF
--- a/components/menu/PropsType.tsx
+++ b/components/menu/PropsType.tsx
@@ -21,5 +21,5 @@ export interface MenuProps {
   value?: Array<string>;
   onChange?: Function;
   level?: number;
-  height?: number;
+  height?: number | string;
 }

--- a/components/menu/index.web.tsx
+++ b/components/menu/index.web.tsx
@@ -69,7 +69,8 @@ export default class Menu extends React.Component<MenuProps, any> {
     const subSelInitItem = subMenuData.filter(dataItem => dataItem.value === subValue);
 
     const heightStyle = {
-      height: `${Math.round(height || document.documentElement.clientHeight / 2)}px`,
+      height: height || (typeof document !== 'undefined' &&
+        `${Math.round(document.documentElement.clientHeight / 2)}px`),
       overflowY: 'scroll',
     };
 


### PR DESCRIPTION
This pr suppress `document is undefined` error in Menu SSR mode without height. But react still print a checksum warning. The height prop still required in SSR but pass jest test in node environment.

change height prop type to number | string so that allow user set css value

fix #1279 

First of all, thanks for your contribution! :-)

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/1337)
<!-- Reviewable:end -->
