### PR TITLE
[SSR] check navigator before use it in switch

### DIFF
--- a/components/switch/index.web.tsx
+++ b/components/switch/index.web.tsx
@@ -34,7 +34,8 @@ export default class Switch extends React.Component<SwitchProps, any> {
 
   render() {
     let { prefixCls, style, name, checked, disabled, className, platform } = this.props;
-    const isAndroid = platform === 'android' || (platform === 'cross' && !!navigator.userAgent.match(/Android/i));
+    const isAndroid = platform === 'android' ||
+      (platform === 'cross' && typeof navigator !== 'undefined' && !!navigator.userAgent.match(/Android/i));
     const wrapCls = classNames({
       [`${prefixCls}`]: true,
       [className as string]: className,


### PR DESCRIPTION
This pr resolve Switch SSR issue but not perfect. If user render Switch without platform prop. React will complain about checksum. That's means platform prop is required in SSR mode.

fix #1308 

First of all, thanks for your contribution! :-)

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/1338)
<!-- Reviewable:end -->
