### PR TITLE
move scrollintoview from input to index

### DIFF
--- a/components/input-item/Input.web.tsx
+++ b/components/input-item/Input.web.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 import omit from 'omit.js';
 
 class Input extends React.Component<React.ChangeTargetHTMLProps<HTMLInputElement>, any> {
-  scrollIntoViewTimeout: any;
-
   constructor(props) {
     super(props);
     this.state = {
@@ -22,13 +20,6 @@ class Input extends React.Component<React.ChangeTargetHTMLProps<HTMLInputElement
   componentDidMount() {
     if ((this.props.autoFocus || this.state.focused) && navigator.userAgent.indexOf('AlipayClient') > 0) {
       (this.refs as any).input.focus();
-    }
-  }
-
-  componentWillUnmount() {
-    if (this.scrollIntoViewTimeout) {
-      clearTimeout(this.scrollIntoViewTimeout);
-      this.scrollIntoViewTimeout = null;
     }
   }
 
@@ -60,13 +51,6 @@ class Input extends React.Component<React.ChangeTargetHTMLProps<HTMLInputElement
     const value = e.target.value;
     if (this.props.onFocus) {
       this.props.onFocus(value);
-    }
-    if (document.activeElement.tagName.toLowerCase() === 'input') {
-      this.scrollIntoViewTimeout = setTimeout(() => {
-        try {
-          (document.activeElement as any).scrollIntoViewIfNeeded();
-        } catch (e) { }
-      }, 100);
     }
   }
 

--- a/components/input-item/index.web.tsx
+++ b/components/input-item/index.web.tsx
@@ -35,6 +35,7 @@ class InputItem extends React.Component<InputItemProps, any> {
   };
 
   debounceTimeout: any;
+  scrollIntoViewTimeout: any;
 
   constructor(props) {
     super(props);
@@ -55,6 +56,10 @@ class InputItem extends React.Component<InputItemProps, any> {
     if (this.debounceTimeout) {
       clearTimeout(this.debounceTimeout);
       this.debounceTimeout = null;
+    }
+    if (this.scrollIntoViewTimeout) {
+      clearTimeout(this.scrollIntoViewTimeout);
+      this.scrollIntoViewTimeout = null;
     }
   }
 
@@ -98,6 +103,13 @@ class InputItem extends React.Component<InputItemProps, any> {
     this.setState({
       focus: true,
     });
+    if (document.activeElement.tagName.toLowerCase() === 'input') {
+      this.scrollIntoViewTimeout = setTimeout(() => {
+        try {
+          (document.activeElement as any).scrollIntoViewIfNeeded();
+        } catch (e) { }
+      }, 100);
+    }
     if (this.props.onFocus) {
       this.props.onFocus(value);
     }


### PR DESCRIPTION
- tiny 里只用到了 Input.web， 发现加了 scrollintoview 后反而导致键盘遮挡住输入框了

讨论： 要不把 scrollintoview 的这个逻辑交给用户自己来搞，不在组件里实现？

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/1401)
<!-- Reviewable:end -->
