### PR TITLE
To fix issue that the modal shows IOS style after click ok in android

### DIFF
--- a/components/modal/Modal.web.tsx
+++ b/components/modal/Modal.web.tsx
@@ -86,7 +86,7 @@ export default class Modal extends React.Component<ModalProps, any> {
     } = this.props;
 
     const isAndroid = platform === 'android' ||
-      (platform === 'cross' && this.props.visible && !!navigator.userAgent.match(/Android/i));
+      (platform === 'cross' && !!navigator.userAgent.match(/Android/i));
     const wrapCls = classNames({
       [className as string]: !!className,
       [`${prefixCls}-transparent`]: transparent,


### PR DESCRIPTION
the render function still triggered although the modal in closing(props.visible = false).
hence, using this.props.visible to calculate the current device is Android or not is not suitable.
Cause once the props.visible is false, this logical operation will always get false in 'cross platform' and then the modal will show in an IOS style.
I guess that put the props.visible into this logical operation is to save the RegEx calculating time when the modal invisible. However, this RegEx is too small to save time, let alone the opposite result caused by the introduced prop in some circumstance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/1432)
<!-- Reviewable:end -->
