### PR TITLE
allow multi element in children

### DIFF
--- a/components/flex/PropsType.tsx
+++ b/components/flex/PropsType.tsx
@@ -5,7 +5,7 @@ export interface FlexProps {
   wrap?: 'nowrap'|'wrap'|'wrap-reverse';
   justify?: 'start'|'end'|'center'|'between'|'around';
   align?: 'top'|'start'|'middle'|'center'|'bottom'|'end'|'baseline'|'stretch';
-  children?: JSX.Element;
+  children?: JSX.Element | JSX.Element[];
   disabled?: boolean;
 }
 

--- a/components/list/PropsType.tsx
+++ b/components/list/PropsType.tsx
@@ -4,7 +4,7 @@ import { NativeProps, WebProps } from '../baseType';
 export interface ListProps {
   renderHeader?: Function | JSX.Element;
   renderFooter?: Function | JSX.Element;
-  children?: JSX.Element;
+  children?: JSX.Element | JSX.Element[];
 }
 
 export interface ListWebProps extends WebProps, ListProps {


### PR DESCRIPTION
If set children type. We need allow element array.

```jsx
<Flex>
  <Flex.Item />
  <Flex.Item />
</Flex>
```
```bash
  Type '{ children: Element[]; }' is not assignable to type 'Readonly<FlexWebProps>'.
    Types of property 'children' are incompatible.
      Type 'Element[]' is not assignable to type 'Element | undefined'.
        Type 'Element[]' is not assignable to type 'Element'.
          Property 'type' is missing in type 'Element[]'.'
at: '241,13'
source: 'ts'
```

First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/1442)
<!-- Reviewable:end -->
