### PR TITLE
[TS] loose children type

### DIFF
--- a/components/flex/PropsType.tsx
+++ b/components/flex/PropsType.tsx
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react';
 import { NativeProps, WebProps } from '../baseType';
 
 export interface FlexProps {
@@ -23,7 +24,7 @@ export interface FlexNativeProps extends NativeProps, FlexProps {
 
 export interface FlexItemProps {
   disabled?: boolean;
-  children?: JSX.Element;
+  children?: ReactNode;
 }
 
 export interface FlexItemWebProps extends WebProps, FlexItemProps {

--- a/components/list/PropsType.tsx
+++ b/components/list/PropsType.tsx
@@ -24,9 +24,9 @@ export interface ListItemProps {
   align?: 'top'|'middle'|'bottom';
   disabled?: boolean;
   multipleLine?: boolean;
-  children?: JSX.Element;
+  children?: ReactNode;
   thumb?: ReactNode | null;
-  extra?: React.ReactNode;
+  extra?: ReactNode;
   arrow?: 'horizontal'|'down'|'up'|'empty'|'';
   wrap?: boolean;
 }
@@ -58,7 +58,7 @@ export interface ListItemNativeProps extends NativeProps, ListItemProps {
 }
 
 export interface BriefProps {
-  children?: JSX.Element;
+  children?: ReactNode;
   wrap?: boolean;
 }
 


### PR DESCRIPTION
ReactNode is a more loose type that allow string number boolean array and so on

ReactNode 是官方定义文件里用于 children 的类型，它包含了 Element | string | number | boolean | null | undefined 以及上述类型的数组形式，所有 JSX 语法允许的类型这里都有。除非有特殊理由要求 children 必须传入一个组件，否则都应该统一指定为 ReactNode。

另：`Flex.Item` 目前不生效，因为类型并没有导出，目前 `baseType.tsx` 里定义的 `WebProps` 不合理，如果现在导出这个类型的话，其他用到 `Flex` 的组件都无法通过 lint。

改动前：
```tsx
<List>
  <List.Item>
    <span>abc</span>
  </List.Item>
</List>
```

改动后：
```tsx
<List>
  <List.Item>
    Now: {Date.now()}
    <List.Item.Brief>
      123
    </List.Item.Brief>
  </List.Item>
</List>
```
First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/1445)
<!-- Reviewable:end -->
