### PR TITLE
Fix toast position bug

### DIFF
--- a/components/toast/style/index.less
+++ b/components/toast/style/index.less
@@ -10,6 +10,10 @@
   font-size: @font-size-base;
   text-align: center;
 
+  > span {
+    max-width: 50%;
+  }
+
   &&-mask {
     height: 100%;
     display: flex;
@@ -17,10 +21,6 @@
     align-items: center;
     left: 0;
     top: 0;
-
-    .@{toastPrefixCls}-notice {
-      max-width: 50%;
-    }
   }
 
   &&-nomask {


### PR DESCRIPTION
`span` 不能去掉，`component=""` 时会导致子节点无法正确渲染。

---

close #1389

Ralevent issues:

- https://github.com/ant-design/ant-design/issues/5869#issuecomment-313400042
- https://github.com/react-component/notification/issues/17

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/1541)
<!-- Reviewable:end -->
