### PR TITLE
View component from web, modify the warning:Unknown prop `Component` on <div> tag. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ npm-debug.log*
 !components/**/__tests__/*.js
 coverage
 /es/
+package-lock.json

--- a/components/view/index.web.tsx
+++ b/components/view/index.web.tsx
@@ -18,8 +18,7 @@ export default class View extends React.Component<any, any> {
       });
       props.style = style;
     }
-    const { Component } = props;
-    delete props.Component;
-    return <Component {...props}/>;
+    const { Component, ...restProps } = props;
+    return <Component {...restProps}/>;
   }
 }

--- a/components/view/index.web.tsx
+++ b/components/view/index.web.tsx
@@ -19,6 +19,7 @@ export default class View extends React.Component<any, any> {
       props.style = style;
     }
     const { Component } = props;
+    delete props.Component;
     return <Component {...props}/>;
   }
 }


### PR DESCRIPTION
I coding a h5 web using antd mobile, thinking to use in both h5 and app. so I choice antd-mobile's View component for layout.But there is a warning like this:
```
Warning: Unknown prop `Component` on <div> tag. Remove this prop from the element. For details, see https://fb.me/react-unknown-prop
    in div (created by View)
    in View (at Root.js:15)
    in Provider (at Root.js:14)
    in Root (at index.js:20)
    in AppContainer (at index.js:19)
```
I add one line to fix it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/1594)
<!-- Reviewable:end -->
