### PR TITLE
feat: remove rem and viewport scale staff

### DIFF
--- a/components/action-sheet/style/index.less
+++ b/components/action-sheet/style/index.less
@@ -82,12 +82,12 @@
 
       &-item {
         flex: none;
-        margin: 0 24px 0 0;
+        margin: 0 12px 0 0;
 
         &-icon {
           margin-bottom: @v-spacing-md;
-          width: 120px;
-          height: 120px;
+          width: 60px;
+          height: 60px;
           background-color: @fill-base;
           border-radius: @radius-sm;
           display: flex;
@@ -95,7 +95,7 @@
           align-items: center;
 
           .anticon {
-            font-size: 60px;
+            font-size: 30px;
           }
         }
 

--- a/components/activity-indicator/style/index.less
+++ b/components/activity-indicator/style/index.less
@@ -10,8 +10,8 @@
 
   &-spinner {
     display: inline-block;
-    width: 40px;
-    height: 40px;
+    width: 20px;
+    height: 20px;
     .encoded-svg-background('loading');
 
     background-position: 50%;
@@ -46,7 +46,7 @@
     .@{activityIndicatorPrefixCls}-toast {
       display: inline-block;
       position: relative;
-      top: 8px;
+      top: 4px;
     }
   }
 
@@ -61,12 +61,12 @@
     color: @color-text-base-inverse;
     background-color: @toast-fill;
     font-size: @font-size-subhead;
-    line-height: 40px;
+    line-height: 20px;
   }
 
   &-spinner-lg {
-    width: 64px;
-    height: 64px;
+    width: 32px;
+    height: 32px;
   }
 
   @keyframes spinner-anime {

--- a/components/carousel/style/index.less
+++ b/components/carousel/style/index.less
@@ -5,7 +5,7 @@
   position: relative;
 
   &-wrap {
-    font-size: 36px;
+    font-size: 18px;
     color: @color-text-base;
     background: none;
     text-align: center;
@@ -18,9 +18,9 @@
 
       > span {
         display: block;
-        width: 16px;
-        height: 16px;
-        margin: 0 6px;
+        width: 8px;
+        height: 8px;
+        margin: 0 3px;
         border-radius: @radius-circle;
         background: @color-icon-base;
       }

--- a/components/checkbox/style/index.less
+++ b/components/checkbox/style/index.less
@@ -17,7 +17,7 @@
     right: 0;
     width: @icon-size-sm;
     height: @icon-size-sm;
-    border: 3px solid @color-text-caption;
+    border: 1.5px solid @color-text-caption;
     border-radius: @radius-circle;
     transform: rotate(0deg);
     box-sizing: border-box;
@@ -25,13 +25,13 @@
     &:after {
       position: absolute;
       display: none;
-      top: 3px;
-      right: 12px;
+      top: 1.5px;
+      right: 6px;
       z-index: 999;
-      width: 10px;
-      height: 22px;
+      width: 5px;
+      height: 11px;
       border-style: solid;
-      border-width: 0 3px 3px 0;
+      border-width: 0 1.5px 1.5px 0;
       content: '\0020';
       transform: rotate(45deg);
     }
@@ -93,7 +93,7 @@
 
           &-inner {
             left: @h-spacing-lg;
-            top: 24px;
+            top: 12px;
           }
         }
       }
@@ -134,7 +134,7 @@
     color: @color-text-base;
     line-height: @line-height-paragraph;
     margin-left: 2 * @h-spacing-lg;
-    margin-top: 2px;
+    margin-top: 1px;
 
     a {
       color: @brand-primary;

--- a/components/create-tooltip/style/index.less
+++ b/components/create-tooltip/style/index.less
@@ -5,15 +5,15 @@
 // tooltip
 @tooltip-color: @color-text-base-inverse;
 @tooltip-bg: @fill-mask;
-@tooltip-arrow-width: 8px;
+@tooltip-arrow-width: 4px;
 @tooltip-distance: @tooltip-arrow-width + @v-spacing-sm;
 @tooltip-arrow-color: @tooltip-bg;
 
 .@{sliderPrefixCls}-tooltip,
 .rc-slider-tooltip {
   position: absolute;
-  left: -9999px;
-  top: -9999px;
+  left: -4999.5px;
+  top: -4999.5px;
   z-index: 4;
   visibility: visible;
   box-sizing: border-box;
@@ -27,9 +27,9 @@
   }
 
   &-inner {
-    padding: 12px 4px;
-    min-width: 48px;
-    height: 32px;
+    padding: 6px 2px;
+    min-width: 24px;
+    height: 16px;
     font-size: @font-size-subhead;
     line-height: @line-height-base;
     color: @tooltip-color;
@@ -37,7 +37,7 @@
     text-decoration: none;
     background-color: @tooltip-bg;
     border-radius: @radius-xs;
-    // box-shadow: 0 0 4px #d9d9d9;
+    // box-shadow: 0 0 2px #d9d9d9;
   }
 
   &-arrow {

--- a/components/drawer/style/index.less
+++ b/components/drawer/style/index.less
@@ -56,7 +56,7 @@
     }
 
     .@{drawerPrefixCls}-draghandle {
-      width: 20px;
+      width: 10px;
       height: 100%;
     }
   }
@@ -71,7 +71,7 @@
 
     .@{drawerPrefixCls}-draghandle {
       width: 100%;
-      height: 20px;
+      height: 10px;
     }
   }
 
@@ -81,7 +81,7 @@
       transform: translateX(-100%);
 
       .@{drawerPrefixCls}-open& {
-        box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.15);
+        box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.15);
       }
     }
 
@@ -96,7 +96,7 @@
       transform: translateX(100%);
 
       .@{drawerPrefixCls}-open& {
-        box-shadow: -2px 2px 4px rgba(0, 0, 0, 0.15);
+        box-shadow: -1px 1px 2px rgba(0, 0, 0, 0.15);
       }
     }
 
@@ -111,7 +111,7 @@
       transform: translateY(-100%);
 
       .@{drawerPrefixCls}-open& {
-        box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.15);
+        box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.15);
       }
     }
 
@@ -126,7 +126,7 @@
       transform: translateY(100%);
 
       .@{drawerPrefixCls}-open& {
-        box-shadow: 2px -2px 4px rgba(0, 0, 0, 0.15);
+        box-shadow: 1px -1px 2px rgba(0, 0, 0, 0.15);
       }
     }
 

--- a/components/flex/style/index.less
+++ b/components/flex/style/index.less
@@ -105,7 +105,7 @@
     box-sizing: border-box;
     flex: 1;
     margin-left: @h-spacing-md;
-    min-width: 20px;
+    min-width: 10px;
 
     &:first-child {
       margin-left: 0;

--- a/components/grid/style/index.less
+++ b/components/grid/style/index.less
@@ -66,7 +66,7 @@
           &.column-num-2 {
             .@{gridPrefixCls}-text {
               margin-top: @v-spacing-lg;
-              font-size: 36px;
+              font-size: 18px;
             }
           }
         }

--- a/components/image-picker/style/index.less
+++ b/components/image-picker/style/index.less
@@ -39,8 +39,8 @@
         width: @icon-size-xxs;
         height: @icon-size-xxs;
         position: absolute;
-        right: 12px;
-        top: 12px;
+        right: 6px;
+        top: 6px;
         text-align: right;
         vertical-align: top;
         z-index: 2;
@@ -69,7 +69,7 @@
       &:before,
       &:after {
         width: @border-width-md;
-        height: 50px;
+        height: 25px;
         content: " ";
         position: absolute;
         top: 50%;
@@ -79,7 +79,7 @@
       }
 
       &:after {
-        width: 50px;
+        width: 25px;
         height: @border-width-md;
       }
 

--- a/components/input-item/style/custom-keyboard.less
+++ b/components/input-item/style/custom-keyboard.less
@@ -11,8 +11,8 @@
     .ellipsis();
 
     .fake-input-container {
-      height: 60px;
-      line-height: 60px;
+      height: 30px;
+      line-height: 30px;
       position: relative;
 
       .fake-input {
@@ -21,11 +21,11 @@
         left: 0;
         width: 100%;
         height: 100%;
-        margin-right: 10px;
+        margin-right: 5px;
         text-decoration: rtl;
         text-align: right;
         color: #000;
-        font-size: 34px;
+        font-size: 17px;
 
         &.fake-input-disabled {
           color: @color-text-disabled;
@@ -40,7 +40,7 @@
             right: 0;
             top: 10%;
             height: 80%;
-            border-right: 3px solid @keyboard-confirm-color;
+            border-right: 1.5px solid @keyboard-confirm-color;
             animation: keyboard-cursor infinite 1s step-start;
           }
         }
@@ -61,14 +61,14 @@
 
 .@{keyboardPrefixCls}-wrapper {
   &.@{keyboardPrefixCls}-wrapper-hide {
-    bottom: -1000px;
+    bottom: -500px;
   }
   position: fixed;
   bottom: 0;
   left: 0;
   right: 0;
   width: 100%;
-  height: 400px;
+  height: 200px;
   z-index: 10000;
   font-family: 'PingFang SC';
   background-color: #f6f6f7;
@@ -81,7 +81,7 @@
     padding: 0;
     margin: 0;
     border-collapse: collapse;
-    border-top: 1Px solid #ccc;
+    border-top: 1PX solid #ccc;
 
     tr {
       width: 100%;
@@ -92,11 +92,11 @@
         width: 25%;
         padding: 0;
         margin: 0;
-        height: 100px;
+        height: 50px;
         text-align: center;
-        border-left: 1Px solid #ccc;
-        border-bottom: 1Px solid #ccc;
-        font-size: 51px;
+        border-left: 1PX solid #ccc;
+        border-bottom: 1PX solid #ccc;
+        font-size: 25.5px;
         color: #2a2b2c;
         position: relative;
 
@@ -106,7 +106,7 @@
 
         &.keyboard-confirm {
           color: #fff;
-          font-size: 42px;
+          font-size: 21px;
           background-color: @keyboard-confirm-color;
 
           &.@{keyboardPrefixCls}-item-active {
@@ -121,14 +121,14 @@
 
         &.keyboard-delete {
           .encoded-svg-background('input_item_kb_backspace');
-          background-size: 51px 37px;
+          background-size: 25.5px 18.5px;
           background-position: 50% 50%;
           background-repeat: no-repeat;
         }
 
         &.keyboard-hide {
           .encoded-svg-background('input_item_kb_hide');
-          background-size: 65px 47px;
+          background-size: 32.5px 23.5px;
           background-position: 50% 50%;
           background-repeat: no-repeat;
         }

--- a/components/input-item/style/index.less
+++ b/components/input-item/style/index.less
@@ -21,7 +21,7 @@
     text-align: left;
     white-space: nowrap;
     overflow: hidden;
-    padding: 4px 0;
+    padding: 2px 0;
 
     &.@{inputPrefixCls}-label-2 {
       width: 2 * @input-label-width;
@@ -57,7 +57,7 @@
       font-size: @font-size-heading;
       appearance: none;
       width: 100%;
-      padding: 4px 0;
+      padding: 2px 0;
       border: 0;
       background-color: transparent;
       line-height: @line-height-base;
@@ -88,7 +88,7 @@
     .encoded-svg-background('input_item_delete');
 
     background-size: @icon-size-sm auto;
-    background-position: 4px 4px;
+    background-position: 2px 2px;
 
     &:active {
       background-color: @input-color-icon-tap;

--- a/components/list-view/style/index.less
+++ b/components/list-view/style/index.less
@@ -56,17 +56,17 @@
     position: absolute;
     left: 50%;
     top: 50%;
-    margin: -30px auto auto -60px;
-    width: 120px;
-    height: 60px;
+    margin: -15px auto auto -30px;
+    width: 60px;
+    height: 30px;
     background: transparent;
     opacity: 0.7;
     color: #0af;
-    font-size: 40px;
-    border-radius: 60px;
+    font-size: 20px;
+    border-radius: 30px;
     z-index: 1999;
     text-align: center;
-    line-height: 60px;
+    line-height: 30px;
 
     &-hide {
       display: none;
@@ -78,10 +78,10 @@
   &-scrollbar-y {
     position: absolute;
     z-index: 9999;
-    width: 7px;
-    bottom: 2px;
-    top: 2px;
-    right: 1px;
+    width: 3.5px;
+    bottom: 1px;
+    top: 1px;
+    right: 1PX;
     overflow: hidden;
     transform: translateZ(0);
     transition-property: opacity;
@@ -93,7 +93,7 @@
     box-sizing: border-box;
     position: absolute;
     border: @border-width-sm solid rgba(255, 255, 255, 0.901961);
-    border-radius: 3px;
+    border-radius: 1.5px;
     width: 100%;
     display: block;
     background: rgba(0, 0, 0, 0.498039);
@@ -102,10 +102,10 @@
   &-scrollbar-x {
     position: absolute;
     z-index: 9999;
-    height: 7px;
-    left: 2px;
-    right: 2px;
-    bottom: 1px;
+    height: 3.5px;
+    left: 1px;
+    right: 1px;
+    bottom: 1PX;
     overflow: hidden;
     transform: translateZ(0);
     transition-property: opacity;
@@ -117,7 +117,7 @@
     box-sizing: border-box;
     position: absolute;
     border: @border-width-sm solid rgba(255, 255, 255, 0.901961);
-    border-radius: 3px;
+    border-radius: 1.5px;
     height: 100%;
     display: block;
     background: rgba(0, 0, 0, 0.498039);

--- a/components/list/style/index.less
+++ b/components/list/style/index.less
@@ -67,7 +67,7 @@
       align-items: flex-start;
 
       .@{listPrefixCls}-arrow {
-        margin-top: 4px;
+        margin-top: 2px;
       }
     }
   }
@@ -144,8 +144,8 @@
       text-align: left;
       .ellipsis();
 
-      padding-top: 14px;
-      padding-bottom: 14px;
+      padding-top: 7px;
+      padding-bottom: 7px;
     }
 
     /* list右补充内容*/
@@ -157,8 +157,8 @@
       text-align: right;
       .ellipsis();
 
-      padding-top: 14px;
-      padding-bottom: 14px;
+      padding-top: 7px;
+      padding-bottom: 7px;
     }
 
     .@{listPrefixCls}-title {
@@ -203,7 +203,7 @@
     }
 
     &-multiple {
-      padding: 25px @h-spacing-lg 25px 0;
+      padding: 12.5px @h-spacing-lg 12.5px 0;
 
       .@{listPrefixCls}-content {
         padding-top: 0;

--- a/components/modal/style/Dialog.less
+++ b/components/modal/style/Dialog.less
@@ -79,8 +79,8 @@
 
     &-x {
       display: inline-block;
-      width: 30px;
-      height: 30px;
+      width: 15px;
+      height: 15px;
       background-repeat: no-repeat;
       background-size: cover;
       .encoded-svg-background('modal_delete');
@@ -108,7 +108,7 @@
       .@{modalPrefixClass}-button {
         color: @color-text-base;
         text-align: start;
-        padding-left: 30px;
+        padding-left: 15px;
       }
     }
   }

--- a/components/modal/style/index.less
+++ b/components/modal/style/index.less
@@ -49,7 +49,7 @@
   }
 
   &-input {
-    height: 72px;
+    height: 36px;
     line-height: @line-height-base;
     border-left: @border-width-sm solid @border-color-base;
     border-right: @border-width-sm solid @border-color-base;
@@ -88,11 +88,11 @@
       border-radius: 0;
 
       .@{modalPrefixClass}-header {
-        padding: @v-spacing-md 48px 24px;
+        padding: @v-spacing-md 24px 12px;
 
         .@{modalPrefixClass}-title {
           text-align: left;
-          font-size: 42px;
+          font-size: 21px;
           color: @color-text-base;
         }
       }
@@ -100,7 +100,7 @@
       .@{modalPrefixClass}-body {
         color: @color-text-base;
         text-align: left;
-        padding: 0 48px @v-spacing-lg;
+        padding: 0 24px @v-spacing-lg;
 
         .@{modalPrefixClass}-input {
           border-left: 0;
@@ -124,9 +124,9 @@
 
           .@{modalPrefixClass}-button {
             flex: initial;
-            margin-left: 6px;
+            margin-left: 3px;
             padding: 0 @h-spacing-lg;
-            height: 96px;
+            height: 48px;
             box-sizing: border-box;
 
             &:first-child {
@@ -145,8 +145,8 @@
           .@{modalPrefixClass}-button {
             border-top: 0;
             padding: 0 @h-spacing-lg;
-            margin-left: 6px;
-            height: 96px;
+            margin-left: 3px;
+            height: 48px;
             box-sizing: border-box;
           }
         }

--- a/components/nav-bar/style/index.less
+++ b/components/nav-bar/style/index.less
@@ -1,7 +1,7 @@
 @import '../../style/mixins';
 @import '../../style/themes/default';
 
-@navbar-height: 90px;
+@navbar-height: 45px;
 @navbarPrefixCls: am-navbar;
 
 .@{navbarPrefixCls} {
@@ -32,7 +32,7 @@
 
   &-title {
     justify-content: center;
-    font-size: 36px;
+    font-size: 18px;
     white-space: nowrap;
   }
 

--- a/components/pagination/style/index.less
+++ b/components/pagination/style/index.less
@@ -4,7 +4,7 @@
 
 .@{paginationPrefixCls} {
   &-wrap {
-    font-size: 36px;
+    font-size: 18px;
     color: @color-text-base;
     background: none;
     text-align: center;
@@ -31,8 +31,8 @@
 
       > span {
         display: block;
-        width: 16px;
-        height: 16px;
+        width: 8px;
+        height: 8px;
         margin-right: @h-spacing-sm;
         border-radius: @radius-circle;
         background: @color-icon-base;

--- a/components/picker-view/style/index.less
+++ b/components/picker-view/style/index.less
@@ -6,7 +6,7 @@
 
 @import './picker';
 
-@picker-item-height: 68px;
+@picker-item-height: 34px;
 
 .@{pickerPrefixCls} {
   display: flex;

--- a/components/picker/style/index.less
+++ b/components/picker/style/index.less
@@ -41,7 +41,7 @@
     background-image: -webkit-linear-gradient(top, #e7e7e7, #e7e7e7, transparent, transparent);
     background-image: linear-gradient(to bottom, #e7e7e7, #e7e7e7, transparent, transparent);
     background-position: bottom;
-    background-size: 100% 1px;
+    background-size: 100% 1PX;
     background-repeat: no-repeat;
     display: flex;
     align-items: center;

--- a/components/popover/style/base.less
+++ b/components/popover/style/base.less
@@ -1,4 +1,4 @@
-@popover-arrow-width: 14px;
+@popover-arrow-width: 7px;
 
 // Base class
 .@{popoverPrefixCls} {
@@ -30,7 +30,7 @@
   position: absolute;
   width: @popover-arrow-width;
   height: @popover-arrow-width;
-  border-radius: 2px;
+  border-radius: 1px;
   background-color: @fill-base;
   transform: rotate(45deg);
   z-index: 0;

--- a/components/popover/style/index.less
+++ b/components/popover/style/index.less
@@ -10,7 +10,7 @@
   color: @color-text-base;
   background-color: @fill-base;
   border-radius: @radius-sm;
-  box-shadow: 0 0 4px rgba(0, 0, 0, 0.21);
+  box-shadow: 0 0 2px rgba(0, 0, 0, 0.21);
   overflow: hidden; // for popover item active background color not overflow
 }
 
@@ -20,7 +20,7 @@
   &-container {
     display: flex;
     align-items: center;
-    height: 78px;
+    height: 39px;
     box-sizing: border-box;
     border-top: @border-width-sm solid @border-color-base;
     padding: 0 @h-spacing-md;

--- a/components/radio/style/index.less
+++ b/components/radio/style/index.less
@@ -23,13 +23,13 @@
     &:after {
       position: absolute;
       display: none;
-      top: -5px;
-      right: 10px;
+      top: -2.5px;
+      right: 5px;
       z-index: 999;
-      width: 14px;
-      height: 28px;
+      width: 7px;
+      height: 14px;
       border-style: solid;
-      border-width: 0 3px 3px 0;
+      border-width: 0 1.5px 1.5px 0;
       content: '\0020';
       transform: rotate(45deg);
     }

--- a/components/refresh-control/style/index.less
+++ b/components/refresh-control/style/index.less
@@ -13,8 +13,8 @@
   &-ptr {
     color: grey;
     text-align: center;
-    height: 50px;
-    margin-top: -50px;
+    height: 25px;
+    margin-top: -25px;
     overflow: hidden;
 
     &-icon {

--- a/components/result/style/index.less
+++ b/components/result/style/index.less
@@ -7,22 +7,22 @@
   position: relative;
   text-align: center;
   width: 100%;
-  padding-top: 60px;
+  padding-top: 30px;
   padding-bottom: @v-spacing-xl;
   background-color: @fill-base;
   .hairline(@border-color-base, 'bottom');
 
   & &-pic {
-    width: 120px;
-    height: 120px;
+    width: 60px;
+    height: 60px;
     margin: 0 auto;
-    line-height: 120px;
-    background-size: 120px 120px;
+    line-height: 60px;
+    background-size: 60px 60px;
   }
 
   & &-title,
   & &-message {
-    font-size: 42px;
+    font-size: 21px;
     color: @color-text-base;
     padding-left: @h-spacing-lg;
     padding-right: @h-spacing-lg;

--- a/components/search-bar/style/index.less
+++ b/components/search-bar/style/index.less
@@ -45,7 +45,7 @@
         width: @icon-size-xxs;
         height: @icon-size-xxs;
         overflow: hidden;
-        vertical-align: -5px;
+        vertical-align: -2.5px;
         background-repeat: no-repeat;
         background-size: @icon-size-xxs auto;
         .encoded-svg-background('search_bar_search');

--- a/components/slider/style/index.less
+++ b/components/slider/style/index.less
@@ -15,24 +15,24 @@
     position: absolute;
     width: 100%;
     background-color: @border-color-base;
-    height: 4px;
+    height: 2px;
     box-sizing: border-box;
   }
 
   &-track {
     position: absolute;
     left: 0;
-    height: 4px;
+    height: 2px;
     border-radius: @radius-xs;
     background-color: @brand-primary;
   }
 
   &-handle {
     position: absolute;
-    margin-left: -24px;
-    margin-top: -24px;
-    width: 44px;
-    height: 44px;
+    margin-left: -12px;
+    margin-top: -12px;
+    width: 22px;
+    height: 22px;
     cursor: pointer;
     border-radius: @radius-circle;
     border: @border-width-lg solid @brand-primary;
@@ -45,13 +45,13 @@
 
     &:active {
       background-color: tint(@brand-primary, 20%);
-      box-shadow: 0 0 5px tint(@brand-primary, 20%);
+      box-shadow: 0 0 2.5px tint(@brand-primary, 20%);
     }
   }
 
   &-mark {
     position: absolute;
-    top: 40px;
+    top: 20px;
     left: 0;
     width: 100%;
     font-size: @font-size-caption-sm;
@@ -73,16 +73,16 @@
   &-step {
     position: absolute;
     width: 100%;
-    height: 8px;
+    height: 4px;
     background: transparent;
   }
 
   &-dot {
     position: absolute;
-    bottom: -10px;
-    margin-left: -8px;
-    width: 24px;
-    height: 24px;
+    bottom: -5px;
+    margin-left: -4px;
+    width: 12px;
+    height: 12px;
     border: @border-width-lg solid @border-color-base;
     background-color: @fill-base;
     cursor: pointer;
@@ -90,11 +90,11 @@
     vertical-align: middle;
 
     &:first-child {
-      margin-left: -8px;
+      margin-left: -4px;
     }
 
     &:last-child {
-      margin-left: -8px;
+      margin-left: -4px;
     }
 
     &-active {
@@ -106,7 +106,7 @@
     opacity: @opacity-disabled;
 
     .@{sliderPrefixCls}-track {
-      height: 4px;
+      height: 2px;
     }
 
     .@{sliderPrefixCls}-handle,

--- a/components/stepper/style/index.less
+++ b/components/stepper/style/index.less
@@ -20,12 +20,12 @@
 .@{stepperPrefixCls} {
   position: relative;
   margin: 0;
-  padding: 4px 0;
+  padding: 2px 0;
   display: inline-block;
   box-sizing: content-box;
-  width: 126px;
-  height: 70px;
-  line-height: 70px;
+  width: 63px;
+  height: 35px;
+  line-height: 35px;
   font-size: @font-size-base;
   vertical-align: middle;
   overflow: hidden;
@@ -33,15 +33,15 @@
   &-handler-wrap {
     position: absolute;
     width: 100%;
-    font-size: 48px;
+    font-size: 24px;
   }
 
   &-handler,
   &-handler-up-inner,
   &-handler-down-inner {
-    width: 60px;
-    height: 60px;
-    line-height: 60px;
+    width: 30px;
+    height: 30px;
+    line-height: 30px;
   }
 
   &-handler {
@@ -75,23 +75,23 @@
     .iconfont-mixin();
 
     user-select: none;
-    right: 4px;
+    right: 2px;
     color: @color-text-base;
   }
 
   &-input-wrap {
     display: none;
     width: 100%;
-    height: 60px;
-    line-height: 60px;
+    height: 30px;
+    line-height: 30px;
     text-align: center;
     overflow: hidden;
   }
 
   &-input {
     display: none;
-    width: 120px;
-    font-size: 32px;
+    width: 60px;
+    font-size: 16px;
     color: @color-text-base;
     text-align: center;
     border: 0;
@@ -106,7 +106,7 @@
   }
 
   &.showNumber {
-    width: 276px;
+    width: 138px;
 
     .@{stepperPrefixCls}-input-wrap {
       display: inline-block;
@@ -128,7 +128,7 @@
     }
 
     .@{stepperPrefixCls}-handler-down-disabled {
-      right: -2px;
+      right: -1px;
     }
   }
 

--- a/components/steps/style/index.less
+++ b/components/steps/style/index.less
@@ -4,8 +4,8 @@
 @stepsPrefixCls: am-steps;
 @errorTailCls: error-tail;
 @ellipsisItem: ellipsis-item;
-@defaultIconSize: 44px;
-@smallIconSize: 36px;
+@defaultIconSize: 22px;
+@smallIconSize: 18px;
 
 .@{stepsPrefixCls} {
   font-size: 0;
@@ -44,8 +44,8 @@
       .@{stepsPrefixCls}-head-inner {
         border-color: @brand-primary;
         background-color: @brand-primary;
-        width: 44px;
-        height: 44px;
+        width: 22px;
+        height: 22px;
         border-radius: @radius-circle;
         border: 0;
 
@@ -149,15 +149,15 @@
       .@{stepsPrefixCls}-head-inner {
         > .@{stepsPrefixCls}-icon {
           font-size: @font-size-subhead;
-          line-height: 40px;
-          width: 40px;
-          height: 40px;
-          border: 4px solid @color-text-placeholder;
+          line-height: 20px;
+          width: 20px;
+          height: 20px;
+          border: 2px solid @color-text-placeholder;
           border-radius: @radius-circle;
 
           .am-icon {
-            width: 36px;
-            height: 36px;
+            width: 18px;
+            height: 18px;
           }
         }
       }
@@ -178,19 +178,19 @@
   &-head-inner {
     display: block;
     box-sizing: border-box;
-    border: 4px solid @color-text-placeholder;
-    width: 48px;
-    height: 48px;
-    line-height: 48px;
+    border: 2px solid @color-text-placeholder;
+    width: 24px;
+    height: 24px;
+    line-height: 24px;
     text-align: center;
-    border-radius: 48px;
-    font-size: 28px;
-    margin-right: 16px;
+    border-radius: 24px;
+    font-size: 14px;
+    margin-right: 8px;
     transition: background-color 0.3s ease, border-color 0.3s ease;
 
     > .@{stepsPrefixCls}-icon {
       line-height: @line-height-base;
-      top: -1.5px;
+      top: -1.2.5px;
       color: @brand-primary;
       position: relative;
     }
@@ -198,10 +198,10 @@
 
   &-title {
     font-size: @font-size-caption;
-    margin-bottom: 4px;
+    margin-bottom: 2px;
     font-weight: bold;
     display: inline-block;
-    padding-right: 10px;
+    padding-right: 5px;
   }
 
   &-item:last-child {
@@ -222,13 +222,13 @@
     position: absolute;
     left: 0;
     width: 100%;
-    top: 20px;
+    top: 10px;
 
     > i {
       display: inline-block;
       vertical-align: top;
       background: @border-color-base;
-      height: 4px;
+      height: 2px;
       width: 100%;
       position: relative;
 
@@ -260,11 +260,11 @@
     }
 
     .@{stepsPrefixCls}-tail {
-      padding: 0 8px;
+      padding: 0 4px;
 
       > i {
-        height: 1px;
-        border-radius: 1px;
+        height: 1PX;
+        border-radius: 1PX;
         width: 100%;
       }
     }
@@ -289,8 +289,8 @@
       background-color: @fill-base;
 
       .am-icon {
-        width: 36px;
-        height: 36px;
+        width: 18px;
+        height: 18px;
       }
     }
   }
@@ -298,18 +298,18 @@
   &&-small .@{ellipsisItem}&-item&-status-wait&-custom &-head-inner {
     > .@{stepsPrefixCls}-icon {
       .am-icon {
-        width: 24px;
-        height: 24px;
+        width: 12px;
+        height: 12px;
       }
     }
   }
 
   &&-small &-item&-status-wait&-custom &-head-inner {
     > .@{stepsPrefixCls}-icon {
-      font-size: 20px;
-      width: 28px;
-      height: 28px;
-      line-height: 28px;
+      font-size: 10px;
+      width: 14px;
+      height: 14px;
+      line-height: 14px;
     }
   }
 
@@ -329,15 +329,15 @@
 
   .@{stepsPrefixCls}-tail {
     position: absolute;
-    left: 22px;
+    left: 11px;
     height: 100%;
-    width: 4px;
+    width: 2px;
     padding: 0;
     background-color: @border-color-base;
 
     > i {
       height: 100%;
-      width: 4px;
+      width: 2px;
 
       &:after {
         height: 0;
@@ -361,7 +361,7 @@
   }
 
   .@{stepsPrefixCls}-main {
-    min-height: 140px;
+    min-height: 70px;
     overflow: hidden;
     display: block;
 
@@ -371,7 +371,7 @@
   }
 
   .@{stepsPrefixCls}-item.@{stepsPrefixCls}-status-process .@{stepsPrefixCls}-tail > i {
-    width: 4px;
+    width: 2px;
     height: 55%;
   }
 }
@@ -379,9 +379,9 @@
 .@{stepsPrefixCls}-vertical.@{stepsPrefixCls}-small {
   .@{stepsPrefixCls}-tail {
     position: absolute;
-    left: 16px;
+    left: 8px;
     padding: 0;
-    width: 2px;
+    width: 1px;
 
     > i {
       height: 100%;
@@ -390,7 +390,7 @@
 
   .@{stepsPrefixCls}-item.@{stepsPrefixCls}-status-process .@{stepsPrefixCls}-tail > i {
     height: 50%;
-    width: 2px;
+    width: 1px;
   }
 
   .@{stepsPrefixCls}-item .@{stepsPrefixCls}-head-inner {
@@ -404,17 +404,17 @@
   }
 
   .@{stepsPrefixCls}-description {
-    max-width: 150px;
+    max-width: 75px;
   }
 
   &.@{stepsPrefixCls}-small .@{stepsPrefixCls}-tail {
-    top: 16px;
+    top: 8px;
   }
 }
 
 .@{stepsPrefixCls}-label-vertical {
   .@{stepsPrefixCls}-tail {
-    left: 60px;
+    left: 30px;
     right: 0;
     width: auto;
     background-color: @border-color-base;

--- a/components/style/index.less
+++ b/components/style/index.less
@@ -11,12 +11,12 @@
 html {
   // PX does't parse by 'postcss-pxtorem'. But the browser is not case sensitive, so it works fine.
   // Set `50` As the basis for rem initially. So it can work properly in the 1x screen of Android device.
-  font-size: 50PX;
+  font-size: 25px;
 }
 
 body {
   user-select: none;
-  font-size: 32px;
+  font-size: 16px;
   background-color: @fill-body;
 }
 

--- a/components/style/index.less
+++ b/components/style/index.less
@@ -9,8 +9,6 @@
 }
 
 html {
-  // PX does't parse by 'postcss-pxtorem'. But the browser is not case sensitive, so it works fine.
-  // Set `50` As the basis for rem initially. So it can work properly in the 1x screen of Android device.
   font-size: 25px;
 }
 

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -39,40 +39,40 @@
 
 // 字体尺寸
 // ---
-@font-size-icontext: 20px;
-@font-size-caption-sm: 24px;
-@font-size-base: 28px;
-@font-size-subhead: 30px;
-@font-size-caption: 32px;
-@font-size-heading: 34px;
+@font-size-icontext: 10px;
+@font-size-caption-sm: 12px;
+@font-size-base: 14px;
+@font-size-subhead: 15px;
+@font-size-caption: 16px;
+@font-size-heading: 17px;
 
 // 圆角
 // ---
-@radius-xs: 4px;
-@radius-sm: 6px;
-@radius-md: 10px;
-@radius-lg: 14px;
+@radius-xs: 2px;
+@radius-sm: 3px;
+@radius-md: 5px;
+@radius-lg: 7px;
 @radius-circle: 50%;
 
 // 边框尺寸
 // ---
 @border-width-sm: 1PX;
-@border-width-md: 2px;
-@border-width-lg: 4px;
+@border-width-md: 1px;
+@border-width-lg: 2px;
 
 // 间距
 // ---
 // 水平间距
-@h-spacing-sm: 10px;
-@h-spacing-md: 16px;
-@h-spacing-lg: 30px;
+@h-spacing-sm: 5px;
+@h-spacing-md: 8px;
+@h-spacing-lg: 15px;
 
 // 垂直间距
-@v-spacing-xs: 6px;
-@v-spacing-sm: 12px;
-@v-spacing-md: 18px;
-@v-spacing-lg: 30px;
-@v-spacing-xl: 42px;
+@v-spacing-xs: 3px;
+@v-spacing-sm: 6px;
+@v-spacing-md: 9px;
+@v-spacing-lg: 15px;
+@v-spacing-xl: 21px;
 
 // 高度
 // ---
@@ -81,11 +81,11 @@
 
 // 图标尺寸
 // ---
-@icon-size-xxs: 30px;
-@icon-size-xs: 36px;
-@icon-size-sm: 42px;
-@icon-size-md: 44px;       // 导航条上的图标、grid的图标大小
-@icon-size-lg: 72px;
+@icon-size-xxs: 15px;
+@icon-size-xs: 18px;
+@icon-size-sm: 21px;
+@icon-size-md: 22px;       // 导航条上的图标、grid的图标大小
+@icon-size-lg: 36px;
 
 // 动画缓动
 // ---
@@ -94,17 +94,17 @@
 // 组件变量
 // ---
 
-@actionsheet-item-height: 100px;
-@actionsheet-item-font-size: 36px;
+@actionsheet-item-height: 50px;
+@actionsheet-item-font-size: 18px;
 
 // button
-@button-height: 94px;
-@button-font-size: 36px;
+@button-height: 47px;
+@button-font-size: 18px;
 
-@button-height-sm: 60px;
-@button-font-size-sm: 26px;
+@button-height-sm: 30px;
+@button-font-size-sm: 13px;
 
-@across-button-height: 100px;   // 通栏按钮高度
+@across-button-height: 50px;   // 通栏按钮高度
 
 @primary-button-fill: @brand-primary;
 @primary-button-fill-tap: #0e80d2;
@@ -116,52 +116,52 @@
 @warning-button-fill-tap: #d24747;
 
 @link-button-fill-tap: #ddd;
-@link-button-font-size: 32px;
+@link-button-font-size: 16px;
 
 // modal
-@modal-font-size-heading: 36px;
-@modal-button-font-size: 36px; // 按钮字号
-@modal-button-height: 100px; // 按钮高度
+@modal-font-size-heading: 18px;
+@modal-button-font-size: 18px; // 按钮字号
+@modal-button-height: 50px; // 按钮高度
 
 // list
-@list-title-height: 60px;
-@list-item-height-sm: 70px;
-@list-item-height: 88px;
+@list-title-height: 30px;
+@list-item-height-sm: 35px;
+@list-item-height: 44px;
 
 // input
-@input-label-width: 34px;       // InputItem、TextareaItem 文字长度基础值
-@input-font-size: 34px;
+@input-label-width: 17px;       // InputItem、TextareaItem 文字长度基础值
+@input-font-size: 17px;
 @input-color-icon: #ccc; // input clear icon 的背景色
 @input-color-icon-tap: @brand-primary;
 
 // tabs
 @tabs-color: @brand-primary;
-@tabs-height: 87px;
-@tabs-font-size-heading: 30px;
+@tabs-height: 43.5px;
+@tabs-font-size-heading: 15px;
 @tabs-ink-bar-height: @border-width-lg;
 
 // segmented-control
 @segmented-control-color: @brand-primary;  // 同时应用于背景、文字颜色、边框色
-@segmented-control-height: 54px;
+@segmented-control-height: 27px;
 @segmented-control-fill-tap: fade(@brand-primary, 0.1);
 
 // tab-bar
 @tab-bar-fill: #ebeeef;
-@tab-bar-height: 100px;
+@tab-bar-height: 50px;
 
 // toast
 @toast-fill: rgba(58, 58, 58, 0.9); // toast, activity-indicator 的背景颜色
 
 // search-bar
 @search-bar-fill: #efeff4;
-@search-bar-height: 88px;
-@search-bar-input-height: 56px;
-@search-bar-font-size: 30px;
+@search-bar-height: 44px;
+@search-bar-input-height: 28px;
+@search-bar-font-size: 15px;
 @search-color-icon: #bbb; // input search icon 的背景色
 
 // notice-bar
 @notice-bar-fill: #fefcec;
-@notice-bar-height: 72px;
+@notice-bar-height: 36px;
 @notice-bar-color: #f76a24;
 
 // switch
@@ -169,8 +169,8 @@
 @switch-fill-android: @brand-primary;
 
 // tag
-@tag-height: 50px;
-@tag-height-sm: 30px;
+@tag-height: 25px;
+@tag-height-sm: 15px;
 @tag-color: @brand-primary;
 
 // keyboard
@@ -178,7 +178,7 @@
 @keyboard-confirm-tap-color: @brand-primary-tap;
 
 // picker
-@option-height: 84px;           // picker 标题的高度
+@option-height: 42px;           // picker 标题的高度
 
 // z-index
 @progress-zindex: 2000;

--- a/components/switch/style/index.less
+++ b/components/switch/style/index.less
@@ -12,9 +12,9 @@
   align-self: center;
 
   .checkbox {
-    width: 102px;
-    height: 62px;
-    border-radius: 62px;
+    width: 51px;
+    height: 31px;
+    border-radius: 31px;
     box-sizing: border-box;
     background: #e5e5e5;
     z-index: 0;
@@ -29,11 +29,11 @@
     &:before {
       content: ' ';
       position: absolute;
-      left: 3px;
-      top: 3px;
-      width: 96px;
-      height: 56px;
-      border-radius: 56px;
+      left: 1.5px;
+      top: 1.5px;
+      width: 48px;
+      height: 28px;
+      border-radius: 28px;
       box-sizing: border-box;
       background: @fill-base;
       z-index: 1;
@@ -43,17 +43,17 @@
 
     &:after {
       content: ' ';
-      height: 56px;
-      width: 56px;
-      border-radius: 56px;
+      height: 28px;
+      width: 28px;
+      border-radius: 28px;
       background: @fill-base;
       position: absolute;
       z-index: 2;
-      left: 3px;
-      top: 3px;
+      left: 1.5px;
+      top: 1.5px;
       transform: translateX(0);
       transition: all 200ms;
-      box-shadow: 4px 4px 8px rgba(0, 0, 0, 0.21);
+      box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.21);
     }
 
     &.checkbox-disabled {
@@ -81,7 +81,7 @@
         }
 
         &:after {
-          transform: translateX(40px);
+          transform: translateX(20px);
         }
       }
     }
@@ -95,8 +95,8 @@
 
   &&-android {
     .checkbox {
-      width: 144px;
-      height: 46px;
+      width: 72px;
+      height: 23px;
       border-radius: @radius-sm;
       background: #a7aaa6;
 
@@ -105,12 +105,12 @@
       }
 
       &:after {
-        width: 70px;
-        height: 42px;
+        width: 35px;
+        height: 21px;
         border-radius: @radius-xs;
         box-shadow: none;
-        left: 2px;
-        top: 2px;
+        left: 1px;
+        top: 1px;
       }
     }
 
@@ -124,7 +124,7 @@
           }
 
           &:after {
-            transform: translateX(70px);
+            transform: translateX(35px);
           }
         }
       }

--- a/components/tab-bar/style/index.less
+++ b/components/tab-bar/style/index.less
@@ -47,14 +47,14 @@
 
         .tab-badge {
           :last-child {
-            margin-top: 8px;
+            margin-top: 4px;
             left: @icon-size-md;
           }
         }
 
         .tab-dot {
           :last-child {
-            margin-top: 8px;
+            margin-top: 4px;
             left: @icon-size-md;
           }
         }

--- a/components/tabs/style/index.less
+++ b/components/tabs/style/index.less
@@ -11,7 +11,7 @@
   position: absolute;
   top: 0;
   display: block;
-  width: 118px;
+  width: 59px;
   height: 100%;
   content: ' ';
   z-index: @tabs-pagination-zindex;
@@ -78,11 +78,11 @@
 
       .@{badge-prefix-cls} {
         .@{badge-prefix-cls}-text {
-          top: -26px;
-          transform: translateX(-10px);
+          top: -13px;
+          transform: translateX(-5px);
         }
         .@{badge-prefix-cls}-dot {
-          top: -12px;
+          top: -6px;
           transform: translateX(0);
         }
       }

--- a/components/tag/style/index.less
+++ b/components/tag/style/index.less
@@ -41,8 +41,8 @@
 
   &-close {
     position: absolute;
-    top: -18px;
-    left: -20px;
+    top: -9px;
+    left: -10px;
     color: @color-text-placeholder;
 
     &:active {
@@ -51,7 +51,7 @@
 
     .am-icon {
       background-color: @fill-base;
-      border-radius: 18px;
+      border-radius: 9px;
     }
   }
 }

--- a/components/textarea-item/style/index.less
+++ b/components/textarea-item/style/index.less
@@ -82,8 +82,8 @@
 
 .@{textareaPrefixCls}-control {
   flex: 1;
-  padding-top: 23px;
-  padding-bottom: 21px;
+  padding-top: 11.5px;
+  padding-bottom: 10.5px;
 
   textarea {
     color: @color-text-base;
@@ -115,7 +115,7 @@
   display: none;
   width: @icon-size-sm;
   height: @icon-size-sm;
-  margin-top: 24px;
+  margin-top: 12px;
   border-radius: @radius-circle;
   overflow: hidden;
   font-style: normal;
@@ -156,7 +156,7 @@
   }
 
   .@{textareaPrefixCls}-error-extra {
-    margin-top: 24px;
+    margin-top: 12px;
     width: @icon-size-sm;
     height: @icon-size-sm;
     margin-left: @h-spacing-md;

--- a/package.json
+++ b/package.json
@@ -100,7 +100,6 @@
     "lint-staged": "^4.0.2",
     "lodash.debounce": "^4.0.6",
     "mockdate": "^2.0.1",
-    "postcss-pxtorem": "^3.3.1",
     "pre-commit": "1.x",
     "qrcode.react": "^0.7.1",
     "rc-form": "1.x",

--- a/scripts/rewrite-px.js
+++ b/scripts/rewrite-px.js
@@ -1,0 +1,59 @@
+/* eslint-disable */
+const path = require('path');
+const fs = require('fs');
+
+const rootPath = '/Users/jiangkai/github/ant-design-mobile/components';
+
+function rewrite(value) {
+  return value.replace(/(\d+)px/ig, (match, p1) => {
+    const oldValue = parseInt(p1, 10);
+    if (oldValue === 1) {
+      return '1PX';
+    }
+    const newValue = oldValue / 2;
+    return `${newValue}px`;
+  });
+}
+
+function halvePx(filepath) {
+  fs.stat(filepath, (error, stats) => {
+    if (error) {
+      console.error(error);
+      return;
+    }
+    if (stats.isFile()) {
+      if (path.extname(filepath) === '.less') {
+        console.log('start to handle', filepath);
+        const content = fs.readFileSync(filepath, {
+          encoding: 'utf8',
+        });
+        const newContent = rewrite(content);
+        fs.writeFileSync(filepath, newContent, {
+          encoding: 'utf8',
+        });
+      }
+    } else if (stats.isDirectory()) {
+      reWritePxInDir(filepath);
+    }
+  });
+}
+
+function reWritePxInDir(dir) {
+  fs.readdir(dir, (error, files) => {
+    if (error) {
+      console.error(error);
+      return;
+    }
+    const len = files.length;
+    let file = null;
+    for (let i = 0; i < len; i++) {
+      file = files[i];
+      if (!/^(\.|_)/.test(file)) {
+        halvePx(path.join(dir, file));
+      }
+    }
+  });
+}
+
+
+reWritePxInDir(rootPath);

--- a/scripts/rewrite-px.js
+++ b/scripts/rewrite-px.js
@@ -2,7 +2,7 @@
 const path = require('path');
 const fs = require('fs');
 
-const rootPath = '/Users/jiangkai/github/ant-design-mobile/components';
+const rootPath = '/Users/jiangkai/github/ant-design-mobile/site/kitchen';
 
 function rewrite(value) {
   return value.replace(/(\d+)px/ig, (match, p1) => {

--- a/site/bisheng.kitchen.config.js
+++ b/site/bisheng.kitchen.config.js
@@ -1,5 +1,4 @@
 const path = require('path');
-const pxtorem = require('postcss-pxtorem');
 const commonConfig = require('./bisheng.common.config');
 
 module.exports = Object.assign({}, commonConfig, {
@@ -53,13 +52,6 @@ module.exports = Object.assign({}, commonConfig, {
   },
   webpackConfig(config) {
     config = commonConfig.webpackConfig(config);
-
-    config.postcss.push(pxtorem({
-      rootValue: 100,
-      propWhiteList: [],
-      // selectorBlackList: [/^html$/, /^\.ant-/, /^\.github-/, /^\.gh-/], // does't exist these class now.
-    }));
-
     return config;
   },
 });

--- a/site/kitchen/src/static/demo.less
+++ b/site/kitchen/src/static/demo.less
@@ -1,43 +1,43 @@
 .demoName {
-  font-size: 38px;
+  font-size: 19px;
   color: #404040;
-  padding: 42px 0 42px 30px;
+  padding: 21px 0 21px 15px;
   text-align: left;
-  height: 40px;
+  height: 20px;
   .icon {
     display: inline-block;
-    width: 38px;
-    height: 38px;
+    width: 19px;
+    height: 19px;
     background-image: url(https://zos.alipayobjects.com/rmsportal/RfxDFanyfhEhOkynbPXizskAQqkPmPkR.png);
     background-size: cover;
-    vertical-align: -2px;
-    margin-right: 60px;
+    vertical-align: -1px;
+    margin-right: 30px;
     position: relative;
     &:after {
       content: '';
       position: absolute;
-      top: 5px;
-      right: -30px;
-      width: 1px;
-      height: 30px;
+      top: 2.5px;
+      right: -15px;
+      width: 1PX;
+      height: 15px;
       background-color: #ceced1;
     }
   }
   .ch {
-    margin-left: 18px;
-    font-size: 30px;
+    margin-left: 9px;
+    font-size: 15px;
     color: #888;
   }
 }
 .demoTitle {
-  padding: 30px 0 18px 30px;
+  padding: 15px 0 9px 15px;
   color: #000;
-  font-size: 32px;
-  line-height: 32px;
-  height: 32px;
+  font-size: 16px;
+  line-height: 16px;
+  height: 16px;
   font-weight: bolder;
   position: relative;
 }
 .demoContainer {
-  padding: 18px 0;
+  padding: 9px 0;
 }

--- a/site/kitchen/src/static/index.less
+++ b/site/kitchen/src/static/index.less
@@ -1,37 +1,37 @@
 .am-demo-page {
   .am-demo-hd {
-    height: 293px;
+    height: 146.5px;
     position: relative;
     overflow: hidden;
     .am-demo-title,
     .am-demo-subtitle {
       text-align: left;
-      padding-left: 53px;
+      padding-left: 26.5px;
     }
     .am-demo-title {
       color: #3d3d3d;
-      padding-top: 80px;
-      font-size: 60px;
+      padding-top: 40px;
+      font-size: 30px;
       font-weight: normal;
     }
     .am-demo-subtitle {
-      font-size: 26px;
+      font-size: 13px;
       color: #3d3d3d;
       font-weight: normal;
     }
   }
   .am-demo-bd {
     .am-list {
-      margin: 0 32px 24px;
+      margin: 0 16px 12px;
       background-color: white;
-      border-radius: 4px;
+      border-radius: 2px;
       .am-list-header {
         padding: 0;
-        padding-left: 48px;
-        height: 140px;
-        line-height: 140px;
+        padding-left: 24px;
+        height: 70px;
+        line-height: 70px;
         color: #404040;
-        font-size: 32px;
+        font-size: 16px;
       }
       .am-list-body {
         border-top: none;
@@ -40,10 +40,10 @@
         }
       }
       .am-list-item {
-        padding-left: 48px;
+        padding-left: 24px;
         .am-list-content {
           color: #666;
-          font-size: 28px;
+          font-size: 14px;
         }
       }
       &.category-closed {
@@ -62,12 +62,12 @@
       flex: 1;
     }
     &-arrow {
-      width: 100px;
+      width: 50px;
       text-align: center;
       transform: rotate(0deg);
       transition: transform 0.3s;
       span {
-        margin-top: 10px;
+        margin-top: 5px;
         display: inline-block;
         color: #c7c7cc;
       }

--- a/site/kitchen/src/static/template.html
+++ b/site/kitchen/src/static/template.html
@@ -2,58 +2,11 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,user-scalable=no,initial-scale=0.5,maximum-scale=0.5,minimum-scale=0.5">
     <title>支付宝移动组件库</title>
     <script>
       if (!window.Intl) {
         document.writeln('<script src="https://as.alipayobjects.com/g/component/intl/1.0.1/??Intl.js,locale-data/jsonp/en.js,locale-data/jsonp/zh.js">' + '<' + '/script>');
-      }
-      if(/noScale=true/.test(window.location.search)) {
-        window.__noAntdMobileScale = true;
-      }
-    </script>
-    <script>
-      (function (baseFontSize, fontscale) {
-        var _baseFontSize = baseFontSize || 100;
-        var _fontscale = fontscale || 1;
-        var win = window;
-        var doc = win.document;
-        var ua = navigator.userAgent;
-        var matches = ua.match(/Android[\S\s]+AppleWebkit\/(\d{3})/i);
-        var UCversion = ua.match(/U3\/((\d+|\.){5,})/i);
-        var isUCHd = UCversion && parseInt(UCversion[1].split('.').join(''), 10) >= 80;
-        var isIos = navigator.appVersion.match(/(iphone|ipad|ipod)/gi);
-        var dpr = win.devicePixelRatio || 1;
-        if (window.__noAntdMobileScale || (!isIos && !(matches && matches[1] > 534) && !isUCHd)) {
-          // 如果非iOS, 非Android4.3以上, 非UC内核, 就不执行高清, dpr设为1;
-          dpr = 1;
-        }
-        var scale = 1 / dpr;
-        if (scale < 1) {
-          doc.documentElement.setAttribute('data-scale', scale);
-        }
-
-        var metaEl = doc.querySelector('meta[name="viewport"]');
-        if (!metaEl) {
-          metaEl = doc.createElement('meta');
-          metaEl.setAttribute('name', 'viewport');
-          doc.head.appendChild(metaEl);
-        }
-        metaEl.setAttribute('content', 'width=device-width,user-scalable=no,initial-scale=' + scale + ',maximum-scale=' + scale + ',minimum-scale=' + scale);
-        doc.documentElement.style.fontSize = _baseFontSize / 2 * dpr * _fontscale + 'px';
-      })();
-      if(!window.Promise) {
-        document.writeln('<script src="https://as.alipayobjects.com/g/component/es6-promise/3.2.2/es6-promise.min.js"'+'>'+'<'+'/'+'script>');
-      }
-      // Enable Google Analytics
-      if (!location.port) {
-        /* eslint-disable */
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-        ga('create', 'UA-72788897-2', 'auto');
-        ga('send', 'pageview');
-        /* eslint-enable */
       }
     </script>
     <link rel="icon" href="https://zos.alipayobjects.com/rmsportal/wIjMDnsrDoPPcIV.png" type="image/x-icon">

--- a/site/kitchen/src/static/template.html
+++ b/site/kitchen/src/static/template.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width,user-scalable=no,initial-scale=0.5,maximum-scale=0.5,minimum-scale=0.5">
+    <meta name="viewport" content="width=device-width,user-scalable=no,initial-scale=1,maximum-scale=1,minimum-scale=1">
     <title>支付宝移动组件库</title>
     <script>
       if (!window.Intl) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,4 @@
 const getWebpackConfig = require('antd-tools/lib/getWebpackConfig');
-const pxtorem = require('postcss-pxtorem');
 const Visualizer = require('webpack-visualizer-plugin');
 const configSvg = require('./svg.config');
 const pkg = require('./package.json');
@@ -13,10 +12,6 @@ module.exports = function (webpackConfig) {
     webpackConfig = [webpackConfig, webpackConfig];
   }
   webpackConfig.forEach((config, index) => {
-    config.postcss.push(pxtorem({
-      rootValue: 100,
-      propWhiteList: [],
-    }));
     configSvg(config);
     if (index === 0) {
       config.plugins.push(new Visualizer({


### PR DESCRIPTION
https://github.com/ant-design/ant-design-mobile/pull/1682

- 所有 px 减半，以后按 375px  宽度的 1 倍样式写
- 去除 rem 编译，viewport 缩放脚本相关
- 边框都用 style 里面的 common mixin
- 单位：只有用到 border: 1px 地方的单位仍然用大写，其他用小写，为了方便用户可能使用 post-css-px-to-rem 的情况。


## antd-mobile@2.0 适配方案
1.  @ustccjw 改造了1px 线的实现，默认不依赖 viewport 缩放，html 上加上 data-scale 属性的时候，回退到 normal 的border，即依赖 viewport 缩放实现 1px 线
2. 在 1 的前提下, antd-mobile 默认就不再依赖 viewport 缩放，则对外提供的都是 1 倍（375）的 px 样式。
3. 如果用户自己要使用 viewport 缩放，确保在 html 上加上 data-scale 属性，并用 post-css 处理样式 （会体现在文档）

## 影响
- 1.x dpr 大的屏幕显示元素大。
- 2.x 屏幕大的手机显示内容多，大小不变大。

## 收益
- 用户使用简单了很多，没那些高清方案带来的各种门槛和问题
- 对那些有 canvas 或者地图这种不能缩 viewport 的场景友好一些。



First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [ ] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [ ] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [ ] Rebase before creating a PR to keep commit history clear.
* [ ] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/1713)
<!-- Reviewable:end -->
