### PR TITLE
refactor: use touchFeedback to replace :active pseudo-class, ref #1717

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -42,6 +42,7 @@ timeline: true
   - **[React Native]** Button 组件 style 里`disabledRaw`/`disabledRawText`修改为`defaultDisabledRaw`/`defaultDisabledRawText`
   - Result: `buttonClick` 更改为 `onButtonClick`
   - 去除`Table`组件
+  - remove `onLongPress` property of `List`
 
 - **Theme**
   - 删除 `@fill-overlay-inverse`, `@color-shadow`, `@brand-hot`, `@font-size-display-sm`, `@font-size-display-md`, `@font-size-display-xl`, `@font-size-display-lg`,`@font-family-code`, `@font-family-base`；

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -41,6 +41,7 @@ timeline: true
   - **[React Native]** Button 组件 style 里`disabledRaw`/`disabledRawText`修改为`defaultDisabledRaw`/`defaultDisabledRawText`
   - Result: `buttonClick` 更改为 `onButtonClick`
   - 去除`Table`组件
+  - 移除 List 组件的 `onLongPress` 属性
 
 - **Theme**
   - 删除 `@fill-overlay-inverse`, `@color-shadow`, `@brand-hot`, `@font-size-display-sm`, `@font-size-display-md`, `@font-size-display-xl`, `@font-size-display-lg`,`@font-family-code`, `@font-family-base`；

--- a/components/_util/touchFeedback.tsx
+++ b/components/_util/touchFeedback.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+
+const touchSupported = typeof window !== 'undefined' && 'ontouchstart' in window;
+
+export interface TouchProps {
+  disabled?: boolean;
+  activeClassName?: string;
+  activeStyle?: any;
+  onTouchStart?: Function;
+  onTouchEnd?: Function;
+  onTouchCancel?: Function;
+  onMouseDown?: Function;
+  onMouseUp?: Function;
+}
+
+export interface TouchState {
+  active: boolean;
+}
+
+export default class TouchFeedback extends React.Component<TouchProps, TouchState> {
+  static defaultProps = {
+    disabled: false,
+  };
+
+  state = {
+    active: false,
+  };
+
+  componentDidUpdate() {
+    if (this.props.disabled && this.state.active) {
+      this.setState({
+        active: false,
+      });
+    }
+  }
+
+  setTouchFeedbackState(active) {
+    this.setState({
+      active,
+    });
+  }
+
+  onTouchStart = (e) => {
+    if (this.props.onTouchStart) {
+      this.props.onTouchStart(e);
+    }
+    this.setTouchFeedbackState(true);
+  }
+
+  onTouchEnd = (e) => {
+    if (this.props.onTouchEnd) {
+      this.props.onTouchEnd(e);
+    }
+    this.setTouchFeedbackState(false);
+  }
+
+  onTouchCancel = (e) => {
+    if (this.props.onTouchCancel) {
+      this.props.onTouchCancel(e);
+    }
+    this.setTouchFeedbackState(false);
+  }
+
+  onMouseDown = (e) => {
+    if (this.props.onTouchStart) {
+      this.props.onTouchStart(e);
+    }
+    this.setTouchFeedbackState(true);
+  }
+
+  onMouseUp = (e) => {
+    if (this.props.onTouchEnd) {
+      this.props.onTouchEnd(e);
+    }
+    this.setTouchFeedbackState(false);
+  }
+
+  render() {
+    const { children, disabled, activeClassName, activeStyle } = this.props;
+
+    const events = disabled ? undefined : (
+      touchSupported ? {
+        onTouchStart: this.onTouchStart,
+        onTouchEnd: this.onTouchEnd,
+        onTouchCancel: this.onTouchCancel,
+      } : {
+        onMouseDown: this.onMouseDown,
+        onMouseUp: this.onMouseUp,
+      }
+    );
+
+    const child = React.Children.only(children);
+
+    if (!disabled && this.state.active) {
+      let { style, className } = child.props;
+
+      if (activeStyle) {
+        style = {
+          ...style,
+          ...activeStyle,
+        };
+      }
+
+      if (activeClassName) {
+        if (className) {
+          className += ` ${activeClassName}`;
+        } else {
+          className = activeClassName;
+        }
+      }
+      return React.cloneElement(child, {
+        className,
+        style,
+        ...events,
+      });
+    }
+
+    return React.cloneElement(child, events);
+  }
+}

--- a/components/_util/touchFeedback.tsx
+++ b/components/_util/touchFeedback.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import classNames from 'classnames';
 
 const touchSupported = typeof window !== 'undefined' && 'ontouchstart' in window;
 
@@ -34,45 +35,34 @@ export default class TouchFeedback extends React.Component<TouchProps, TouchStat
     }
   }
 
-  setTouchFeedbackState(active) {
+  triggerEvent(type, isActive, ev) {
+    const eventType = `on${type}`;
+    if (this.props[eventType]) {
+      this.props[eventType](ev);
+    }
     this.setState({
-      active,
+      active: isActive,
     });
   }
 
   onTouchStart = (e) => {
-    if (this.props.onTouchStart) {
-      this.props.onTouchStart(e);
-    }
-    this.setTouchFeedbackState(true);
+    this.triggerEvent('TouchStart', true, e);
   }
 
   onTouchEnd = (e) => {
-    if (this.props.onTouchEnd) {
-      this.props.onTouchEnd(e);
-    }
-    this.setTouchFeedbackState(false);
+    this.triggerEvent('TouchEnd', false, e);
   }
 
   onTouchCancel = (e) => {
-    if (this.props.onTouchCancel) {
-      this.props.onTouchCancel(e);
-    }
-    this.setTouchFeedbackState(false);
+    this.triggerEvent('TouchCancel', false, e);
   }
 
   onMouseDown = (e) => {
-    if (this.props.onTouchStart) {
-      this.props.onTouchStart(e);
-    }
-    this.setTouchFeedbackState(true);
+    this.triggerEvent('TouchStart', true, e);
   }
 
   onMouseUp = (e) => {
-    if (this.props.onTouchEnd) {
-      this.props.onTouchEnd(e);
-    }
-    this.setTouchFeedbackState(false);
+    this.triggerEvent('TouchEnd', false, e);
   }
 
   render() {
@@ -101,15 +91,13 @@ export default class TouchFeedback extends React.Component<TouchProps, TouchStat
         };
       }
 
-      if (activeClassName) {
-        if (className) {
-          className += ` ${activeClassName}`;
-        } else {
-          className = activeClassName;
-        }
-      }
+      const cls = classNames({
+        [className as string]: !!className,
+        [activeClassName as string]: !!activeClassName,
+      });
+
       return React.cloneElement(child, {
-        className,
+        className: cls,
         style,
         ...events,
       });

--- a/components/action-sheet/index.tsx
+++ b/components/action-sheet/index.tsx
@@ -5,7 +5,7 @@ import Dialog from 'rc-dialog';
 import classNames from 'classnames';
 import Icon from '../icon';
 import getDataAttr from '../_util/getDataAttr';
-import Touchable from 'rc-touchable';
+import TouchFeedback from '../_util/touchFeedback';
 
 const NORMAL = 'NORMAL';
 const SHARE = 'SHARE';
@@ -73,19 +73,19 @@ function createActionSheet(flag, config, callback) {
               role: 'button',
             };
             let bItem = (
-              <Touchable key={index} activeClassName={`${prefixCls}-button-list-item-active`}>
+              <TouchFeedback key={index} activeClassName={`${prefixCls}-button-list-item-active`}>
                 <div {...itemProps}>{item}</div>
-              </Touchable>
+              </TouchFeedback>
             );
             if (cancelButtonIndex === index || destructiveButtonIndex === index) {
               bItem = (
-                <Touchable key={index} activeClassName={`${prefixCls}-button-list-item-active`}>
+                <TouchFeedback key={index} activeClassName={`${prefixCls}-button-list-item-active`}>
                   <div {...itemProps}>
                     {item}
                     {cancelButtonIndex === index ?
                     <span className={`${prefixCls}-cancel-button-mask`} /> : null}
                   </div>
-                </Touchable>
+                </TouchFeedback>
               );
             }
             return bItem;
@@ -116,11 +116,11 @@ function createActionSheet(flag, config, callback) {
                 {options.map((item, index) => createList(item, index))}
             </div>
           )}
-          <Touchable activeClassName={`${prefixCls}-share-cancel-button-active`}>
+          <TouchFeedback activeClassName={`${prefixCls}-share-cancel-button-active`}>
             <div className={`${prefixCls}-share-cancel-button`} role="button" onClick={() => cb(-1)}>
               {cancelButtonText}
             </div>
-          </Touchable>
+          </TouchFeedback>
         </div>
       </div>);
       break;

--- a/components/button/index.tsx
+++ b/components/button/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 import Icon from '../icon';
 import { ButtonProps } from './PropsType';
-import Touchable from 'rc-touchable';
+import TouchFeedback from '../_util/touchFeedback';
 
 const rxTwoCNChar = /^[\u4e00-\u9fa5]{2}$/;
 const isTwoCNChar = rxTwoCNChar.test.bind(rxTwoCNChar);
@@ -61,13 +61,6 @@ class Button extends React.Component<ButtonProps, any> {
       wrapCls[`${prefixCls}-icon`] = true;
     }
 
-    const delayProps: any = {};
-    if (delayPressIn) {
-      delayProps.delayPressIn = delayPressIn;
-    }
-    if (delayPressOut) {
-      delayProps.delayPressOut = delayPressOut;
-    }
     let iconEl;
     if (typeof iconType === 'string') {
       iconEl =
@@ -88,11 +81,10 @@ class Button extends React.Component<ButtonProps, any> {
     }
     // use div, button native is buggy @yiminghe
     return (
-      <Touchable
+      <TouchFeedback
         activeClassName={activeClassName || (activeStyle ? `${prefixCls}-active` : undefined)}
         disabled={disabled}
         activeStyle={activeStyle}
-        {...delayProps}
       >
         <a
           role="button"
@@ -104,7 +96,7 @@ class Button extends React.Component<ButtonProps, any> {
           {iconEl}
           {kids}
         </a>
-      </Touchable>
+      </TouchFeedback>
     );
   }
 }

--- a/components/checkbox/demo/basic.md
+++ b/components/checkbox/demo/basic.md
@@ -47,14 +47,3 @@ class Test extends React.Component {
 
 ReactDOM.render(<Test />, mountNode);
 ````
-
-````css
-.am-checkbox-agree .am-checkbox-agree-label a {
-  color: #108ee9;
-  transition: color .3s ease;
-}
-.am-checkbox-agree .am-checkbox-agree-label a:active,
-.am-checkbox-agree .am-checkbox-agree-label a:hover {
-    color: #1284d6;
-}
-````

--- a/components/grid/index.tsx
+++ b/components/grid/index.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import Flex from '../flex';
 import Carousel from '../carousel';
 import { DataItem, GridProps } from './PropsType';
+import TouchFeedback from '../_util/touchFeedback';
 
 export default class Grid extends React.Component<GridProps, any> {
   static defaultProps = {
@@ -88,14 +89,15 @@ export default class Grid extends React.Component<GridProps, any> {
         if (dataIndex < dataLength) {
           const el = data && data[dataIndex];
           itemEl = (
-            <Flex.Item
-              key={`griditem-${dataIndex}`}
-              className={`${prefixCls}-item`}
-              onClick={() => onClick && onClick(el, dataIndex)}
-              style={colStyle}
-            >
-              {this.renderItem(el, dataIndex, columnNum, renderItem)}
-            </Flex.Item>
+            <TouchFeedback key={`griditem-${dataIndex}`} activeClassName={`${prefixCls}-item-active`}>
+              <Flex.Item
+                className={`${prefixCls}-item`}
+                onClick={() => onClick && onClick(el, dataIndex)}
+                style={colStyle}
+              >
+                {this.renderItem(el, dataIndex, columnNum, renderItem)}
+              </Flex.Item>
+            </TouchFeedback>
           );
         } else {
           itemEl = (

--- a/components/grid/style/index.less
+++ b/components/grid/style/index.less
@@ -14,12 +14,11 @@
 
       &.@{gridPrefixCls}-item {
         position: relative;
+      }
 
-        &:active {
+      &.@{gridPrefixCls}-item-active {
+        .@{gridPrefixCls}-item-content {
           background-color: @fill-tap;
-        }
-        &.@{gridPrefixCls}-null-item:active {
-         background-color: @fill-base;
         }
       }
 

--- a/components/image-picker/index.tsx
+++ b/components/image-picker/index.tsx
@@ -5,7 +5,7 @@ import WingBlank from '../wing-blank';
 import Flex from '../flex';
 import Toast from '../toast';
 import { ImagePickerPropTypes } from './PropsType';
-import Touchable from 'rc-touchable';
+import TouchFeedback from '../_util/touchFeedback';
 
 const Item = Flex.Item;
 function noop() { }
@@ -172,8 +172,8 @@ export default class ImagePicker extends React.Component<ImagePickerPropTypes, a
     });
 
     const selectEl = (
-      <Touchable activeClassName={`${prefixCls}-upload-btn-active`} key="select">
-        <Item>
+      <Item>
+        <TouchFeedback activeClassName={`${prefixCls}-upload-btn-active`} key="select">
           <div
             className={`${prefixCls}-item ${prefixCls}-upload-btn`}
             onClick={onAddImageClick}
@@ -187,8 +187,8 @@ export default class ImagePicker extends React.Component<ImagePickerPropTypes, a
               onChange={() => { this.onFileChange(); }}
             />
           </div>
-        </Item>
-      </Touchable>
+        </TouchFeedback>
+      </Item>
     );
 
     let allEl = selectable ? imgItemList.concat([selectEl]) : imgItemList;

--- a/components/input-item/CustomKeyboard.tsx
+++ b/components/input-item/CustomKeyboard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
-import Touchable from 'rc-touchable';
+import TouchFeedback from '../_util/touchFeedback';
 
 export class KeyboardItem extends React.Component<any, any> {
   static defaultProps = {
@@ -24,7 +24,7 @@ export class KeyboardItem extends React.Component<any, any> {
       [className as string]: className,
       [`${prefixCls}-item`]: true,
     };
-    return (<Touchable activeClassName={`${prefixCls}-item-active`}>
+    return (<TouchFeedback activeClassName={`${prefixCls}-item-active`}>
       <td
         ref={tdRef}
         onClick={(e) => { onClick(e, value); }}
@@ -33,7 +33,7 @@ export class KeyboardItem extends React.Component<any, any> {
       >
         {children}
       </td>
-    </Touchable>);
+    </TouchFeedback>);
   }
 }
 

--- a/components/input-item/index.tsx
+++ b/components/input-item/index.tsx
@@ -7,6 +7,7 @@ import InputItemProps from './PropsType';
 import Input from './Input';
 import CustomInput from './CustomInput';
 import { getComponentLocale } from '../_util/getLocale';
+import TouchFeedback from '../_util/touchFeedback';
 
 function noop() { }
 
@@ -274,10 +275,9 @@ class InputItem extends React.Component<InputItemProps, any> {
           )}
         </div>
         {clear && editable && !disabled && (value && value.length > 0) ?
-          <div
-            className={`${prefixCls}-clear`}
-            onClick={this.clearInput}
-          />
+          <TouchFeedback activeClassName={`${prefixCls}-clear-active`}>
+            <div className={`${prefixCls}-clear`} onClick={this.clearInput} />
+          </TouchFeedback>
           : null}
         {error ? (<div className={`${prefixCls}-error-extra`} onClick={this.onErrorClick} />) : null}
         {extra !== '' ? <div className={`${prefixCls}-extra`} onClick={this.onExtraClick}>{extra}</div> : null}

--- a/components/input-item/style/index.less
+++ b/components/input-item/style/index.less
@@ -90,7 +90,7 @@
     background-size: @icon-size-sm auto;
     background-position: 2px 2px;
 
-    &:active {
+    &-active {
       background-color: @input-color-icon-tap;
     }
   }
@@ -136,4 +136,3 @@
     }
   }
 }
-

--- a/components/list/ListItem.tsx
+++ b/components/list/ListItem.tsx
@@ -1,9 +1,9 @@
 /* tslint:disable:jsx-no-multiline-js */
 import React from 'react';
 import classNames from 'classnames';
-import Touchable from 'rc-touchable';
 import { ListItemProps, BriefProps } from './PropsType';
 import omit from 'omit.js';
+import TouchFeedback from '../_util/touchFeedback';
 
 export class Brief extends React.Component<BriefProps, any> {
   render() {
@@ -82,7 +82,7 @@ class ListItem extends React.Component<ListItemProps, any> {
 
     const {
       prefixCls, className, activeStyle, error, align, wrap, disabled,
-      children, multipleLine, thumb, extra, arrow, onClick, onLongPress, ...restProps} = this.props;
+      children, multipleLine, thumb, extra, arrow, onClick, ...restProps} = this.props;
 
     const { coverRippleStyle, RippleClicked } = this.state;
     const wrapCls = {
@@ -131,14 +131,13 @@ class ListItem extends React.Component<ListItemProps, any> {
     </div>;
 
     return (
-      <Touchable
-        disabled={disabled || (!onClick && !onLongPress)}
+      <TouchFeedback
+        disabled={disabled || !onClick}
         activeStyle={activeStyle}
         activeClassName={`${prefixCls}-item-active`}
-        onLongPress={onLongPress}
       >
         {content}
-      </Touchable>
+      </TouchFeedback>
     );
   }
 }

--- a/components/list/demo/basic.md
+++ b/components/list/demo/basic.md
@@ -16,13 +16,11 @@ class ListExample extends React.Component {
   state = {
     disabled: false,
   }
-  handleLongPress = (e) => {
-    console.log('longpress toggled', e);
-  }
+
   render() {
     return (<div>
       <List renderHeader={() => 'Basic Style'} className="my-list">
-        <Item extra={'extra content'} onLongPress={this.handleLongPress}>Title</Item>
+        <Item extra={'extra content'}>Title</Item>
       </List>
       <List renderHeader={() => 'Subtitle'} className="my-list">
         <Item arrow="horizontal" multipleLine>

--- a/components/list/index.en-US.md
+++ b/components/list/index.en-US.md
@@ -31,7 +31,6 @@ Properties | Descrition | Type | Default
 | arrow      | arrow direction, options: `horizontal`,`up`,`down`, `empty`; `empty` option may hide the dom  | String |     |
 | align    |    vertical alignment of `Flex` child elements，options: `top`,`middle`,`bottom`  | String   | `middle` |
 | onClick    | callback is called when  list is clicked | (): void |    |
-| onLongPress  | callback is called when  list is long pressed | (): void |    |
 | error(`web only`)    | Whether to display error style(the color of text on the right side may change to orange) | Boolean  | `false`  |
 | multipleLine    | multiple line | Boolean  | `false`  |
 | wrap    | Whether to wrap long texts, otherwise it will be hidden by default. | Boolean  | `false`  |

--- a/components/list/index.zh-CN.md
+++ b/components/list/index.zh-CN.md
@@ -33,7 +33,6 @@ subtitle: 列表
 | arrow      | 箭头方向(右,上,下), 可选`horizontal`,`up`,`down`,`empty`，如果是`empty`则存在对应的dom,但是不显示   | String |   无  |
 | align    |    Flex 子元素垂直对齐，可选`top`,`middle`,`bottom`  | String   | `middle` |
 | onClick    | 点击事件的回调函数 | (): void |  无  |
-| onLongPress  | 长按事件的回调函数 | (): void |  无  |
 | error(`web only`)    | 报错样式,右侧文字颜色变成橙色 | Boolean  | `false`  |
 | multipleLine    | 多行 | Boolean  | `false`  |
 | wrap    | 是否换行，默认情况下，文字超长会被隐藏， | Boolean  | `false`  |

--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import Dialog from 'rc-dialog';
 import classNames from 'classnames';
-import Touchable from 'rc-touchable';
 import { ModalProps, ModalComponent } from './PropsType';
 import omit from 'omit.js';
+import TouchFeedback from '../_util/touchFeedback';
 
 function checkIfAndroid(platform) {
   return platform === 'android' ||
@@ -73,11 +73,11 @@ export default class Modal extends ModalComponent<ModalProps, any> {
     };
 
     return (
-      <Touchable activeClassName={`${prefixCls}-button-active`} key={i}>
+      <TouchFeedback activeClassName={`${prefixCls}-button-active`} key={i}>
         <a className={`${prefixCls}-button`} role="button" style={buttonStyle} href="#" onClick={onClickFn}>
           {button.text || `Button`}
         </a>
-      </Touchable>
+      </TouchFeedback>
     );
   }
   componentDidMount() {

--- a/components/popover/Item.tsx
+++ b/components/popover/Item.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
-import Touchable from 'rc-touchable';
+import TouchFeedback from '../_util/touchFeedback';
 
 export default class Item extends React.Component<any, any> {
   static defaultProps = {
@@ -12,11 +12,11 @@ export default class Item extends React.Component<any, any> {
   render() {
 
     const { children, className, prefixCls, icon, disabled, firstItem, activeStyle, ...restProps } = this.props;
-    const cls = {
+    const cls = classNames({
       [className as string]: !!className,
       [`${prefixCls}-item`]: true,
       [`${prefixCls}-item-disabled`]: disabled,
-    };
+    });
 
     let activeClass = `${prefixCls}-item-active `;
     if (firstItem) {
@@ -24,14 +24,14 @@ export default class Item extends React.Component<any, any> {
     }
 
     return (
-      <Touchable disabled={disabled} activeClassName={activeClass} activeStyle={activeStyle} >
-        <div className={classNames(cls)} {...restProps}>
+      <TouchFeedback disabled={disabled} activeClassName={activeClass} activeStyle={activeStyle} >
+        <div className={cls} {...restProps}>
           <div className={`${prefixCls}-item-container`}>
             {icon ? <span className={`${prefixCls}-item-icon`} aria-hidden="true">{icon}</span> : null}
             <span className={`${prefixCls}-item-content`}>{children}</span>
           </div>
         </div>
-      </Touchable>
+      </TouchFeedback>
     );
   }
 }

--- a/components/search-bar/index.tsx
+++ b/components/search-bar/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 import { SearchBarProps, SearchBarState, defaultProps } from './PropsType';
 import getDataAttr from '../_util/getDataAttr';
+import TouchFeedback from '../_util/touchFeedback';
 
 export default class SearchBar extends React.Component<SearchBarProps, SearchBarState> {
   static defaultProps = defaultProps;
@@ -228,7 +229,9 @@ export default class SearchBar extends React.Component<SearchBarProps, SearchBar
             maxLength={maxLength}
             {...getDataAttr(this.props)}
           />
-          <a onClick={this.onClear} className={clearCls} />
+          <TouchFeedback activeClassName={`${prefixCls}-clear-active`}>
+            <a onClick={this.onClear} className={clearCls} />
+          </TouchFeedback>
         </div>
         <div className={cancelCls} onClick={this.onCancel} ref="rightBtn">
           {cancelText}

--- a/components/search-bar/style/index.less
+++ b/components/search-bar/style/index.less
@@ -99,7 +99,7 @@
       transition: all .3s;
       .encoded-svg-background('search_bar_clear');
 
-      &:active {
+      &-active {
         .encoded-svg-background('search_bar_clear_active');
       }
 

--- a/components/segmented-control/index.tsx
+++ b/components/segmented-control/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
-import Touchable from 'rc-touchable';
 import SegmentedControlProps from './PropsType';
+import TouchFeedback from '../_util/touchFeedback';
 
 export default class SegmentedControl extends React.Component<SegmentedControlProps, any> {
   static defaultProps = {
@@ -64,7 +64,7 @@ export default class SegmentedControl extends React.Component<SegmentedControlPr
     };
 
     return (
-      <Touchable
+      <TouchFeedback
         key={idx}
         disabled={disabled}
         activeClassName={`${prefixCls}-item-active`}
@@ -80,7 +80,7 @@ export default class SegmentedControl extends React.Component<SegmentedControlPr
           <div className={`${prefixCls}-item-inner`} />
           {value}
         </div>
-      </Touchable>
+      </TouchFeedback>
     );
   }
 

--- a/components/slider/style/index.less
+++ b/components/slider/style/index.less
@@ -42,11 +42,6 @@
     &:focus {
       background-color: tint(@brand-primary, 20%);
     }
-
-    &:active {
-      background-color: tint(@brand-primary, 20%);
-      box-shadow: 0 0 2.5px tint(@brand-primary, 20%);
-    }
   }
 
   &-mark {

--- a/components/tag/index.tsx
+++ b/components/tag/index.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import TagProps from './PropsType';
 import Icon from '../icon';
 import getDataAttr from '../_util/getDataAttr';
+import TouchFeedback from '../_util/touchFeedback';
 
 export default class Tag extends React.Component<TagProps, any> {
   static defaultProps = {
@@ -69,9 +70,11 @@ export default class Tag extends React.Component<TagProps, any> {
     });
 
     const closableDom = closable && !disabled && !small ? (
-      <div className={`${prefixCls}-close`} role="button" onClick={this.onTagClose} aria-label="remove tag">
-        <Icon type="cross-circle" size="xs" aria-hidden="true" />
-      </div>
+      <TouchFeedback activeClassName={`${prefixCls}-close-active`}>
+        <div className={`${prefixCls}-close`} role="button" onClick={this.onTagClose} aria-label="remove tag">
+          <Icon type="cross-circle" size="xs" aria-hidden="true" />
+        </div>
+      </TouchFeedback>
     ) : null;
 
     return !this.state.closed ? (

--- a/components/tag/style/index.less
+++ b/components/tag/style/index.less
@@ -44,7 +44,7 @@
     left: -10px;
     color: @color-text-placeholder;
 
-    &:active {
+    &-active {
       color: @color-text-caption;
     }
 

--- a/components/textarea-item/index.tsx
+++ b/components/textarea-item/index.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import classNames from 'classnames';
 import TextareaItemProps from './PropsType';
 import omit from 'omit.js';
+import TouchFeedback from '../_util/touchFeedback';
 
 function noop() {}
 
@@ -224,7 +225,9 @@ export default class TextareaItem extends React.Component<TextareaItemProps, Tex
           />
         </div>
         {clear && editable && value && characterLength > 0 &&
-          <div className={`${prefixCls}-clear`} onClick={this.clearInput} onTouchStart={this.clearInput} />
+          <TouchFeedback activeClassName={`${prefixCls}-clear-active`}>
+            <div className={`${prefixCls}-clear`} onClick={this.clearInput} onTouchStart={this.clearInput} />
+          </TouchFeedback>
         }
         {error && <div className={`${prefixCls}-error-extra`} onClick={this.onErrorClick} />}
         {count > 0 && rows > 1 &&

--- a/components/textarea-item/style/index.less
+++ b/components/textarea-item/style/index.less
@@ -125,7 +125,7 @@
   background-size: @icon-size-sm auto;
   .encoded-svg-background('textarea_item_delete');
 
-  &:active {
+  &-active {
     background-color: @input-color-icon-tap;
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "rc-swipeout": "~1.4.2",
     "rc-tabs": "~9.1.0",
     "rc-tooltip": "~3.4.3",
-    "rc-touchable": "~1.2.2",
     "react-native-camera-roll-picker": "~1.2.0",
     "react-native-collapsible": "^0.8.0",
     "react-native-drawer-layout": "~1.3.0",


### PR DESCRIPTION
考虑到有些组件（:active）替换成  rc-touchable 会增加单个组件的体积，现方案为下：

移除 rc-touchable，增加 TouchFeedback util 组件，废弃 list 用到的 onlongpress

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/1772)
<!-- Reviewable:end -->
