### PR TITLE
Upgrade to antd-tools@4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@types/react-native": "^0.47.2",
     "antd": "2.x",
     "antd-mobile-demo-data": "^0.1.1",
-    "antd-tools": "^2.0.0",
+    "antd-tools": "^4.0.1",
     "babel-eslint": "^7.2.3",
     "babel-plugin-import": "1.6.1",
     "babel-plugin-transform-runtime": "^6.23.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,21 +2,14 @@ const getWebpackConfig = require('antd-tools/lib/getWebpackConfig');
 const Visualizer = require('webpack-visualizer-plugin');
 const pkg = require('./package.json');
 
-module.exports = function (webpackConfig) {
-  // fix `npm run dist` sourceMap error, do not know the reason
-  delete webpackConfig.ts.compilerOptions.sourceMap;
+const webpackConfig = getWebpackConfig(false);
 
-  webpackConfig = getWebpackConfig(webpackConfig, true);
-  if (!Array.isArray(webpackConfig)) {
-    webpackConfig = [webpackConfig, webpackConfig];
+webpackConfig.forEach((config, index) => {
+  if (index === 0) {
+    config.plugins.push(new Visualizer({
+      filename: `../ant-design-analysis/${pkg.name}@${pkg.version}-stats.html`,
+    }));
   }
-  webpackConfig.forEach((config, index) => {
-    if (index === 0) {
-      config.plugins.push(new Visualizer({
-        filename: `../ant-design-analysis/${pkg.name}@${pkg.version}-stats.html`,
-      }));
-    }
-  });
+});
 
-  return webpackConfig;
-};
+module.exports = webpackConfig;


### PR DESCRIPTION
更新内容见： https://github.com/ant-design/antd-tools/pull/60

更新后构建大小比较：

<img width="1193" alt="dingtalk20171019164344" src="https://user-images.githubusercontent.com/465125/31762149-ed93fa20-b47f-11e7-86e2-3837f6d57734.png">

启用 Tree shaking 后 antd-mobile.min.js 的构建结果小了 55k，css 大了一点是因为 autoprefix 更新后，`box-sizing` 也会被 prefix。

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/1960)
<!-- Reviewable:end -->
