### PR TITLE
Update Collapsible. Fixes crash with React 0.49

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "rc-slider": "~8.2.0",
     "rc-swipeout": "~2.0.0",
     "react-native-camera-roll-picker": "^1.2.1",
-    "react-native-collapsible": "^0.8.0",
+    "react-native-collapsible": "^0.9.0",
     "react-native-drawer-layout": "~1.3.0",
     "react-native-menu": "^0.23.0",
     "rmc-calendar": "^1.0.0",


### PR DESCRIPTION
Update in react-native-collapsible handles issue with crash due to `View.propTypes` as of 0.9.0. See [fix](https://github.com/oblador/react-native-collapsible/commit/960fd76ab8317b78ce72fe4767273738fec38f5f).



Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/1969)
<!-- Reviewable:end -->
