### PR TITLE
set 'keyboardType' of stepper to be a numeric type

### DIFF
--- a/components/stepper/__tests__/__snapshots__/demo.test.native.js.snap
+++ b/components/stepper/__tests__/__snapshots__/demo.test.native.js.snap
@@ -176,7 +176,7 @@ exports[`renders ./components/stepper/demo/basic.native.tsx correctly 1`] = `
               <TextInput
                 autoFocus={undefined}
                 editable={true}
-                keyboardType={undefined}
+                keyboardType="numbers-and-punctuation"
                 onChange={[Function]}
                 onEndEditing={[Function]}
                 onFocus={[Function]}
@@ -411,7 +411,7 @@ exports[`renders ./components/stepper/demo/basic.native.tsx correctly 1`] = `
               <TextInput
                 autoFocus={undefined}
                 editable={true}
-                keyboardType={undefined}
+                keyboardType="numbers-and-punctuation"
                 onChange={[Function]}
                 onEndEditing={[Function]}
                 onFocus={[Function]}
@@ -646,7 +646,7 @@ exports[`renders ./components/stepper/demo/basic.native.tsx correctly 1`] = `
               <TextInput
                 autoFocus={undefined}
                 editable={false}
-                keyboardType={undefined}
+                keyboardType="numbers-and-punctuation"
                 onChange={[Function]}
                 onEndEditing={[Function]}
                 onFocus={[Function]}

--- a/components/stepper/index.native.tsx
+++ b/components/stepper/index.native.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import RMCInputNumber from 'rmc-input-number/lib/index.ios';
 import BasePropsType from './PropsType';
-import styles from 'rmc-input-number/lib/styles';
 import { Platform } from 'react-native';
+import RMCInputNumber from 'rmc-input-number/lib/index.ios';
+import React from 'react';
+import styles from 'rmc-input-number/lib/styles';
 
 export interface StepProps extends BasePropsType {
   styles?: typeof styles;
@@ -13,7 +13,6 @@ export default class Stepper extends React.Component<StepProps, any> {
     step: 1,
     readOnly: false,
     disabled: false,
-    keyboardType: 'numeric',
     styles,
     inputStyle: {},
   } as StepProps;
@@ -30,7 +29,7 @@ export default class Stepper extends React.Component<StepProps, any> {
       ...inputStyle,
     };
     return (
-      <RMCInputNumber {...restProps} inputStyle={_inputStyle} />
+      <RMCInputNumber {...restProps} keyboardType="numeric" inputStyle={_inputStyle} />
     );
   }
 }

--- a/components/stepper/index.native.tsx
+++ b/components/stepper/index.native.tsx
@@ -13,6 +13,7 @@ export default class Stepper extends React.Component<StepProps, any> {
     step: 1,
     readOnly: false,
     disabled: false,
+    keyboardType: 'numeric',
     styles,
     inputStyle: {},
   } as StepProps;

--- a/components/stepper/index.native.tsx
+++ b/components/stepper/index.native.tsx
@@ -24,12 +24,13 @@ export default class Stepper extends React.Component<StepProps, any> {
       height: 26,
     } : {};
     const { inputStyle, ...restProps } = this.props;
+    const keyboardType = Platform.OS === 'android' ? 'numeric' : 'numbers-and-punctuation';
     const _inputStyle = {
       ...inputAndroidStyle,
       ...inputStyle,
     };
     return (
-      <RMCInputNumber {...restProps} keyboardType="numeric" inputStyle={_inputStyle} />
+      <RMCInputNumber {...restProps} keyboardType={keyboardType} inputStyle={_inputStyle} />
     );
   }
 }


### PR DESCRIPTION
Hi,
A keyboardType of stepper on Native environment should be numeric only. It can prevent the unexpected problem that happens because the value is not numeric.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/2020)
<!-- Reviewable:end -->
