### PR TITLE
[RN] Remove TouchableWithoutFeedback wrapper in `flexItem` and `flex` component

### DIFF
--- a/components/flex/Flex.native.tsx
+++ b/components/flex/Flex.native.tsx
@@ -52,11 +52,9 @@ export default class Flex extends React.Component<FlexProps, any> {
     };
 
     return (
-      <TouchableWithoutFeedback {...restProps}>
-        <View style={[flexStyle, style]}>
-          {children}
-        </View>
-      </TouchableWithoutFeedback>
+      <View style={[flexStyle, style]} {...restProps}>
+        {children}
+      </View>
     );
   }
 }

--- a/components/flex/FlexItem.native.tsx
+++ b/components/flex/FlexItem.native.tsx
@@ -22,11 +22,9 @@ export default class FlexItem extends React.Component<FlexItemProps, any> {
     // support other touchablewithoutfeedback props
     // TODO  support TouchableHighlight
     return (
-      <TouchableWithoutFeedback {...restProps}>
-        <View style={[flexItemStyle, style]}>
-          {children}
-        </View>
-      </TouchableWithoutFeedback>
+      <View style={[flexItemStyle, style]} {...restProps }>
+        {children}
+      </View>
     );
   }
 }


### PR DESCRIPTION
relate issues: #1108, #769

@silentcloud has been promised fix this issue in milestones `2.0.1`, but in `2.0.3` it still happen. so i remove `TouchableWithoutFeedback` and make a PR to ant team.

`Flex` and `FlexItem` component should not 'help' developer to handle press event, it will be prevent developer's own event handler.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/2093)
<!-- Reviewable:end -->
