### PR TITLE
[RN] Optional use TouchableWithoutFeedback component in Flex/FlexItem component

### DIFF
--- a/components/activity-indicator/__tests__/__snapshots__/demo.test.native.js.snap
+++ b/components/activity-indicator/__tests__/__snapshots__/demo.test.native.js.snap
@@ -22,19 +22,6 @@ exports[`renders ./components/activity-indicator/demo/basic.native.tsx correctly
     }
   >
     <View
-      accessibilityComponentType={undefined}
-      accessibilityLabel={undefined}
-      accessibilityTraits={undefined}
-      accessible={true}
-      hitSlop={undefined}
-      nativeID={undefined}
-      onLayout={undefined}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       style={
         Array [
           Object {
@@ -46,22 +33,8 @@ exports[`renders ./components/activity-indicator/demo/basic.native.tsx correctly
           undefined,
         ]
       }
-      testID={undefined}
     >
       <View
-        accessibilityComponentType={undefined}
-        accessibilityLabel={undefined}
-        accessibilityTraits={undefined}
-        accessible={true}
-        hitSlop={undefined}
-        nativeID={undefined}
-        onLayout={undefined}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
@@ -70,7 +43,6 @@ exports[`renders ./components/activity-indicator/demo/basic.native.tsx correctly
             undefined,
           ]
         }
-        testID={undefined}
       >
         <Text
           accessible={true}
@@ -82,19 +54,6 @@ exports[`renders ./components/activity-indicator/demo/basic.native.tsx correctly
         </Text>
       </View>
       <View
-        accessibilityComponentType={undefined}
-        accessibilityLabel={undefined}
-        accessibilityTraits={undefined}
-        accessible={true}
-        hitSlop={undefined}
-        nativeID={undefined}
-        onLayout={undefined}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
@@ -103,7 +62,6 @@ exports[`renders ./components/activity-indicator/demo/basic.native.tsx correctly
             undefined,
           ]
         }
-        testID={undefined}
       >
         <View
           style={
@@ -148,19 +106,6 @@ exports[`renders ./components/activity-indicator/demo/basic.native.tsx correctly
     }
   >
     <View
-      accessibilityComponentType={undefined}
-      accessibilityLabel={undefined}
-      accessibilityTraits={undefined}
-      accessible={true}
-      hitSlop={undefined}
-      nativeID={undefined}
-      onLayout={undefined}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       style={
         Array [
           Object {
@@ -172,22 +117,8 @@ exports[`renders ./components/activity-indicator/demo/basic.native.tsx correctly
           undefined,
         ]
       }
-      testID={undefined}
     >
       <View
-        accessibilityComponentType={undefined}
-        accessibilityLabel={undefined}
-        accessibilityTraits={undefined}
-        accessible={true}
-        hitSlop={undefined}
-        nativeID={undefined}
-        onLayout={undefined}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
@@ -196,7 +127,6 @@ exports[`renders ./components/activity-indicator/demo/basic.native.tsx correctly
             undefined,
           ]
         }
-        testID={undefined}
       >
         <Text
           accessible={true}
@@ -208,19 +138,6 @@ exports[`renders ./components/activity-indicator/demo/basic.native.tsx correctly
         </Text>
       </View>
       <View
-        accessibilityComponentType={undefined}
-        accessibilityLabel={undefined}
-        accessibilityTraits={undefined}
-        accessible={true}
-        hitSlop={undefined}
-        nativeID={undefined}
-        onLayout={undefined}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
@@ -229,7 +146,6 @@ exports[`renders ./components/activity-indicator/demo/basic.native.tsx correctly
             undefined,
           ]
         }
-        testID={undefined}
       >
         <View
           style={
@@ -291,19 +207,6 @@ exports[`renders ./components/activity-indicator/demo/basic.native.tsx correctly
     }
   >
     <View
-      accessibilityComponentType={undefined}
-      accessibilityLabel={undefined}
-      accessibilityTraits={undefined}
-      accessible={true}
-      hitSlop={undefined}
-      nativeID={undefined}
-      onLayout={undefined}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       style={
         Array [
           Object {
@@ -315,22 +218,8 @@ exports[`renders ./components/activity-indicator/demo/basic.native.tsx correctly
           undefined,
         ]
       }
-      testID={undefined}
     >
       <View
-        accessibilityComponentType={undefined}
-        accessibilityLabel={undefined}
-        accessibilityTraits={undefined}
-        accessible={true}
-        hitSlop={undefined}
-        nativeID={undefined}
-        onLayout={undefined}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
@@ -339,7 +228,6 @@ exports[`renders ./components/activity-indicator/demo/basic.native.tsx correctly
             undefined,
           ]
         }
-        testID={undefined}
       >
         <Text
           accessible={true}
@@ -351,19 +239,6 @@ exports[`renders ./components/activity-indicator/demo/basic.native.tsx correctly
         </Text>
       </View>
       <View
-        accessibilityComponentType={undefined}
-        accessibilityLabel={undefined}
-        accessibilityTraits={undefined}
-        accessible={true}
-        hitSlop={undefined}
-        nativeID={undefined}
-        onLayout={undefined}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
@@ -372,7 +247,6 @@ exports[`renders ./components/activity-indicator/demo/basic.native.tsx correctly
             undefined,
           ]
         }
-        testID={undefined}
       >
         <View
           style={
@@ -431,19 +305,6 @@ exports[`renders ./components/activity-indicator/demo/basic.native.tsx correctly
     }
   >
     <View
-      accessibilityComponentType={undefined}
-      accessibilityLabel={undefined}
-      accessibilityTraits={undefined}
-      accessible={true}
-      hitSlop={undefined}
-      nativeID={undefined}
-      onLayout={undefined}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       style={
         Array [
           Object {
@@ -455,22 +316,8 @@ exports[`renders ./components/activity-indicator/demo/basic.native.tsx correctly
           undefined,
         ]
       }
-      testID={undefined}
     >
       <View
-        accessibilityComponentType={undefined}
-        accessibilityLabel={undefined}
-        accessibilityTraits={undefined}
-        accessible={true}
-        hitSlop={undefined}
-        nativeID={undefined}
-        onLayout={undefined}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
@@ -479,7 +326,6 @@ exports[`renders ./components/activity-indicator/demo/basic.native.tsx correctly
             undefined,
           ]
         }
-        testID={undefined}
       >
         <Text
           accessible={true}
@@ -491,19 +337,6 @@ exports[`renders ./components/activity-indicator/demo/basic.native.tsx correctly
         </Text>
       </View>
       <View
-        accessibilityComponentType={undefined}
-        accessibilityLabel={undefined}
-        accessibilityTraits={undefined}
-        accessible={true}
-        hitSlop={undefined}
-        nativeID={undefined}
-        onLayout={undefined}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
@@ -512,7 +345,6 @@ exports[`renders ./components/activity-indicator/demo/basic.native.tsx correctly
             undefined,
           ]
         }
-        testID={undefined}
       >
         <View
           style={

--- a/components/flex/Flex.native.tsx
+++ b/components/flex/Flex.native.tsx
@@ -52,11 +52,9 @@ export default class Flex extends React.Component<FlexProps, any> {
     };
 
     return (
-      <TouchableWithoutFeedback {...restProps}>
-        <View style={[flexStyle, style]}>
-          {children}
-        </View>
-      </TouchableWithoutFeedback>
+      <View style={[flexStyle, style]} {...restProps}>
+        {children}
+      </View>
     );
   }
 }

--- a/components/flex/Flex.native.tsx
+++ b/components/flex/Flex.native.tsx
@@ -20,9 +20,17 @@ export default class Flex extends React.Component<FlexProps, any> {
   };
 
   render() {
-    let { style, direction, wrap, justify, align, children, ...restProps } = this.props;
+    let {
+      style,
+      direction,
+      wrap,
+      justify,
+      align,
+      children,
+      ...restProps,
+    } = this.props;
     let transferConst = [justify, align];
-    transferConst = transferConst.map((el) => {
+    transferConst = transferConst.map(el => {
       let tempTxt;
       switch (el) {
         case 'start':
@@ -51,10 +59,26 @@ export default class Flex extends React.Component<FlexProps, any> {
       alignItems: transferConst[1],
     };
 
-    return (
+    const inner = (
       <View style={[flexStyle, style]} {...restProps}>
         {children}
       </View>
     );
+
+    const shouldWrapInTouchableComponent =
+      restProps.onPress ||
+      restProps.onLongPress ||
+      restProps.onPressIn ||
+      restProps.onPressOut;
+
+    if (!!shouldWrapInTouchableComponent) {
+      return (
+        <TouchableWithoutFeedback {...restProps}>
+          {inner}
+        </TouchableWithoutFeedback>
+      );
+    } else {
+      return inner;
+    }
   }
 }

--- a/components/flex/FlexItem.native.tsx
+++ b/components/flex/FlexItem.native.tsx
@@ -10,17 +10,12 @@ export interface FlexItemProps extends BasePropsType {
   onPressOut?: any;
 }
 
-export default class FlexItem extends React.Component < FlexItemProps, any > {
+export default class FlexItem extends React.Component <FlexItemProps, any> {
   static defaultProps = {
     flex: 1,
   };
   render() {
-    let {
-      style,
-      children,
-      flex,
-      ...restProps,
-    } = this.props;
+    let { style, children, flex, ...restProps } = this.props;
     const flexItemStyle = {
       flex: flex || 1,
     };

--- a/components/flex/FlexItem.native.tsx
+++ b/components/flex/FlexItem.native.tsx
@@ -10,21 +10,42 @@ export interface FlexItemProps extends BasePropsType {
   onPressOut?: any;
 }
 
-export default class FlexItem extends React.Component<FlexItemProps, any> {
+export default class FlexItem extends React.Component < FlexItemProps, any > {
   static defaultProps = {
     flex: 1,
   };
   render() {
-    let { style, children, flex, ...restProps } = this.props;
+    let {
+      style,
+      children,
+      flex,
+      ...restProps,
+    } = this.props;
     const flexItemStyle = {
       flex: flex || 1,
     };
     // support other touchablewithoutfeedback props
     // TODO  support TouchableHighlight
-    return (
-      <View style={[flexItemStyle, style]} {...restProps }>
+    const inner = (
+      <View style={[flexItemStyle, style]} {...restProps}>
         {children}
       </View>
     );
+
+    const shouldWrapInTouchableComponent =
+      restProps.onPress
+      || restProps.onLongPress
+      || restProps.onPressIn
+      || restProps.onPressOut;
+
+    if (!!shouldWrapInTouchableComponent) {
+      return (
+        <TouchableWithoutFeedback {...restProps}>
+          {inner}
+        </TouchableWithoutFeedback>
+      );
+    } else {
+      return inner;
+    }
   }
 }

--- a/components/flex/FlexItem.native.tsx
+++ b/components/flex/FlexItem.native.tsx
@@ -22,11 +22,9 @@ export default class FlexItem extends React.Component<FlexItemProps, any> {
     // support other touchablewithoutfeedback props
     // TODO  support TouchableHighlight
     return (
-      <TouchableWithoutFeedback {...restProps}>
-        <View style={[flexItemStyle, style]}>
-          {children}
-        </View>
-      </TouchableWithoutFeedback>
+      <View style={[flexItemStyle, style]} {...restProps }>
+        {children}
+      </View>
     );
   }
 }

--- a/components/flex/__tests__/__snapshots__/demo.test.native.js.snap
+++ b/components/flex/__tests__/__snapshots__/demo.test.native.js.snap
@@ -62,19 +62,6 @@ exports[`renders ./components/flex/demo/basic.native.tsx correctly 1`] = `
       }
     >
       <View
-        accessibilityComponentType={undefined}
-        accessibilityLabel={undefined}
-        accessibilityTraits={undefined}
-        accessible={true}
-        hitSlop={undefined}
-        nativeID={undefined}
-        onLayout={undefined}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
@@ -86,22 +73,8 @@ exports[`renders ./components/flex/demo/basic.native.tsx correctly 1`] = `
             undefined,
           ]
         }
-        testID={undefined}
       >
         <View
-          accessibilityComponentType={undefined}
-          accessibilityLabel={undefined}
-          accessibilityTraits={undefined}
-          accessible={true}
-          hitSlop={undefined}
-          nativeID={undefined}
-          onLayout={undefined}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             Array [
               Object {
@@ -113,7 +86,6 @@ exports[`renders ./components/flex/demo/basic.native.tsx correctly 1`] = `
               },
             ]
           }
-          testID={undefined}
         >
           <View
             accessibilityComponentType={undefined}
@@ -193,19 +165,6 @@ exports[`renders ./components/flex/demo/basic.native.tsx correctly 1`] = `
           </View>
         </View>
         <View
-          accessibilityComponentType={undefined}
-          accessibilityLabel={undefined}
-          accessibilityTraits={undefined}
-          accessible={true}
-          hitSlop={undefined}
-          nativeID={undefined}
-          onLayout={undefined}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             Array [
               Object {
@@ -217,7 +176,6 @@ exports[`renders ./components/flex/demo/basic.native.tsx correctly 1`] = `
               },
             ]
           }
-          testID={undefined}
         >
           <View
             accessibilityComponentType={undefined}
@@ -297,19 +255,6 @@ exports[`renders ./components/flex/demo/basic.native.tsx correctly 1`] = `
           </View>
         </View>
         <View
-          accessibilityComponentType={undefined}
-          accessibilityLabel={undefined}
-          accessibilityTraits={undefined}
-          accessible={true}
-          hitSlop={undefined}
-          nativeID={undefined}
-          onLayout={undefined}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             Array [
               Object {
@@ -321,7 +266,6 @@ exports[`renders ./components/flex/demo/basic.native.tsx correctly 1`] = `
               },
             ]
           }
-          testID={undefined}
         >
           <View
             accessibilityComponentType={undefined}
@@ -439,19 +383,6 @@ exports[`renders ./components/flex/demo/basic.native.tsx correctly 1`] = `
       }
     >
       <View
-        accessibilityComponentType={undefined}
-        accessibilityLabel={undefined}
-        accessibilityTraits={undefined}
-        accessible={true}
-        hitSlop={undefined}
-        nativeID={undefined}
-        onLayout={undefined}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
@@ -463,22 +394,8 @@ exports[`renders ./components/flex/demo/basic.native.tsx correctly 1`] = `
             undefined,
           ]
         }
-        testID={undefined}
       >
         <View
-          accessibilityComponentType={undefined}
-          accessibilityLabel={undefined}
-          accessibilityTraits={undefined}
-          accessible={true}
-          hitSlop={undefined}
-          nativeID={undefined}
-          onLayout={undefined}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             Array [
               Object {
@@ -489,7 +406,6 @@ exports[`renders ./components/flex/demo/basic.native.tsx correctly 1`] = `
               },
             ]
           }
-          testID={undefined}
         >
           <View
             accessibilityComponentType={undefined}
@@ -569,19 +485,6 @@ exports[`renders ./components/flex/demo/basic.native.tsx correctly 1`] = `
           </View>
         </View>
         <View
-          accessibilityComponentType={undefined}
-          accessibilityLabel={undefined}
-          accessibilityTraits={undefined}
-          accessible={true}
-          hitSlop={undefined}
-          nativeID={undefined}
-          onLayout={undefined}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             Array [
               Object {
@@ -592,7 +495,6 @@ exports[`renders ./components/flex/demo/basic.native.tsx correctly 1`] = `
               },
             ]
           }
-          testID={undefined}
         >
           <View
             accessibilityComponentType={undefined}
@@ -672,19 +574,6 @@ exports[`renders ./components/flex/demo/basic.native.tsx correctly 1`] = `
           </View>
         </View>
         <View
-          accessibilityComponentType={undefined}
-          accessibilityLabel={undefined}
-          accessibilityTraits={undefined}
-          accessible={true}
-          hitSlop={undefined}
-          nativeID={undefined}
-          onLayout={undefined}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             Array [
               Object {
@@ -695,7 +584,6 @@ exports[`renders ./components/flex/demo/basic.native.tsx correctly 1`] = `
               },
             ]
           }
-          testID={undefined}
         >
           <View
             accessibilityComponentType={undefined}
@@ -827,19 +715,6 @@ exports[`renders ./components/flex/demo/basic.native.tsx correctly 1`] = `
       }
     >
       <View
-        accessibilityComponentType={undefined}
-        accessibilityLabel={undefined}
-        accessibilityTraits={undefined}
-        accessible={true}
-        hitSlop={undefined}
-        nativeID={undefined}
-        onLayout={undefined}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
@@ -851,7 +726,6 @@ exports[`renders ./components/flex/demo/basic.native.tsx correctly 1`] = `
             undefined,
           ]
         }
-        testID={undefined}
       >
         <View
           style={
@@ -947,19 +821,6 @@ exports[`renders ./components/flex/demo/basic.native.tsx correctly 1`] = `
       }
     >
       <View
-        accessibilityComponentType={undefined}
-        accessibilityLabel={undefined}
-        accessibilityTraits={undefined}
-        accessible={true}
-        hitSlop={undefined}
-        nativeID={undefined}
-        onLayout={undefined}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
@@ -971,7 +832,6 @@ exports[`renders ./components/flex/demo/basic.native.tsx correctly 1`] = `
             undefined,
           ]
         }
-        testID={undefined}
       >
         <View
           style={
@@ -1067,19 +927,6 @@ exports[`renders ./components/flex/demo/basic.native.tsx correctly 1`] = `
       }
     >
       <View
-        accessibilityComponentType={undefined}
-        accessibilityLabel={undefined}
-        accessibilityTraits={undefined}
-        accessible={true}
-        hitSlop={undefined}
-        nativeID={undefined}
-        onLayout={undefined}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
@@ -1091,7 +938,6 @@ exports[`renders ./components/flex/demo/basic.native.tsx correctly 1`] = `
             undefined,
           ]
         }
-        testID={undefined}
       >
         <View
           style={
@@ -1187,19 +1033,6 @@ exports[`renders ./components/flex/demo/basic.native.tsx correctly 1`] = `
       }
     >
       <View
-        accessibilityComponentType={undefined}
-        accessibilityLabel={undefined}
-        accessibilityTraits={undefined}
-        accessible={true}
-        hitSlop={undefined}
-        nativeID={undefined}
-        onLayout={undefined}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
@@ -1211,7 +1044,6 @@ exports[`renders ./components/flex/demo/basic.native.tsx correctly 1`] = `
             undefined,
           ]
         }
-        testID={undefined}
       >
         <View
           style={
@@ -1307,19 +1139,6 @@ exports[`renders ./components/flex/demo/basic.native.tsx correctly 1`] = `
       }
     >
       <View
-        accessibilityComponentType={undefined}
-        accessibilityLabel={undefined}
-        accessibilityTraits={undefined}
-        accessible={true}
-        hitSlop={undefined}
-        nativeID={undefined}
-        onLayout={undefined}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
@@ -1331,7 +1150,6 @@ exports[`renders ./components/flex/demo/basic.native.tsx correctly 1`] = `
             undefined,
           ]
         }
-        testID={undefined}
       >
         <View
           style={
@@ -1441,19 +1259,6 @@ exports[`renders ./components/flex/demo/basic.native.tsx correctly 1`] = `
       }
     >
       <View
-        accessibilityComponentType={undefined}
-        accessibilityLabel={undefined}
-        accessibilityTraits={undefined}
-        accessible={true}
-        hitSlop={undefined}
-        nativeID={undefined}
-        onLayout={undefined}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
@@ -1467,7 +1272,6 @@ exports[`renders ./components/flex/demo/basic.native.tsx correctly 1`] = `
             },
           ]
         }
-        testID={undefined}
       >
         <Text
           accessible={true}
@@ -1572,19 +1376,6 @@ exports[`renders ./components/flex/demo/basic.native.tsx correctly 1`] = `
       }
     >
       <View
-        accessibilityComponentType={undefined}
-        accessibilityLabel={undefined}
-        accessibilityTraits={undefined}
-        accessible={true}
-        hitSlop={undefined}
-        nativeID={undefined}
-        onLayout={undefined}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
@@ -1598,7 +1389,6 @@ exports[`renders ./components/flex/demo/basic.native.tsx correctly 1`] = `
             },
           ]
         }
-        testID={undefined}
       >
         <Text
           accessible={true}
@@ -1703,19 +1493,6 @@ exports[`renders ./components/flex/demo/basic.native.tsx correctly 1`] = `
       }
     >
       <View
-        accessibilityComponentType={undefined}
-        accessibilityLabel={undefined}
-        accessibilityTraits={undefined}
-        accessible={true}
-        hitSlop={undefined}
-        nativeID={undefined}
-        onLayout={undefined}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
@@ -1729,7 +1506,6 @@ exports[`renders ./components/flex/demo/basic.native.tsx correctly 1`] = `
             },
           ]
         }
-        testID={undefined}
       >
         <Text
           accessible={true}
@@ -1845,19 +1621,6 @@ exports[`renders ./components/flex/demo/basic.native.tsx correctly 1`] = `
         }
       >
         <View
-          accessibilityComponentType={undefined}
-          accessibilityLabel={undefined}
-          accessibilityTraits={undefined}
-          accessible={true}
-          hitSlop={undefined}
-          nativeID={undefined}
-          onLayout={undefined}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             Array [
               Object {
@@ -1871,7 +1634,6 @@ exports[`renders ./components/flex/demo/basic.native.tsx correctly 1`] = `
               },
             ]
           }
-          testID={undefined}
         >
           <Text
             accessible={true}
@@ -2381,6 +2143,7 @@ exports[`renders ./components/flex/demo/basic.native.tsx correctly 1`] = `
         hitSlop={undefined}
         nativeID={undefined}
         onLayout={undefined}
+        onPress={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -2721,6 +2484,26 @@ exports[`renders ./components/flex/demo/basic.native.tsx correctly 1`] = `
         />
       </View>
     </View>
+    <View
+      style={
+        Array [
+          Object {
+            "height": 9,
+          },
+          undefined,
+        ]
+      }
+    />
+    <View
+      style={
+        Array [
+          Object {
+            "height": 9,
+          },
+          undefined,
+        ]
+      }
+    />
     <View
       style={
         Array [

--- a/components/flex/demo/basic.native.tsx
+++ b/components/flex/demo/basic.native.tsx
@@ -1,6 +1,6 @@
-import { Button, Flex, WingBlank, WhiteSpace } from 'antd-mobile';
+import { Button, WingBlank, WhiteSpace, Flex } from 'antd-mobile';
 import React from 'react';
-import { View, Text, ScrollView } from 'react-native';
+import { View, Text, ScrollView, TouchableWithoutFeedback } from 'react-native';
 
 const Circle = (props) => {
   const size = props.size || 20;
@@ -154,7 +154,7 @@ export default class FlexExample extends React.Component<any, any> {
         </WingBlank>
         <WingBlank style={{ marginBottom: 5 }}>
           <WingBlank>
-            <Flex align="stretch" style={{ height: 70 }}>
+            <Flex align="stretch" style={{ height: 70 }} >
               <Text style={{ fontSize: 20, borderWidth: 1, borderStyle: 'solid', borderColor: '#527fe4' }}>兜兜</Text>
               <Text style={{ fontSize: 18, borderWidth: 1, borderStyle: 'solid', borderColor: '#527fe4' }}>兜兜</Text>
               <Text style={{ fontSize: 16, borderWidth: 1, borderStyle: 'solid', borderColor: '#527fe4' }}>兜兜</Text>
@@ -167,18 +167,22 @@ export default class FlexExample extends React.Component<any, any> {
           <Text>wrap="wrap":换行</Text>
         </WingBlank>
         <WingBlank style={{ marginBottom: 5 }}>
+         <TouchableWithoutFeedback onPress={() => ({})} >
           <Flex wrap="wrap">
             {'ooooooooooooooooooooooooooooo'.split('').map((char, i) => <Circle key={`${i}-${char}`} />)}
           </Flex>
+          </TouchableWithoutFeedback>
         </WingBlank>
         <WingBlank style={{ marginTop: 5, marginBottom: 5 }}>
           <Text>wrap="nowrap":不换行</Text>
         </WingBlank>
         <WingBlank style={{ marginBottom: 5 }}>
-          <Flex wrap="nowrap">
-            {'ooooooooooooooooooooooooooooo'.split('').map((char, i) => <Circle key={`${i}-${char}`} />)}
-          </Flex>
+            <Flex wrap="nowrap" onPress={() => ({})}>
+              {'ooooooooooooooooooooooooooooo'.split('').map((char, i) => <Circle key={`${i}-${char}`} />)}
+            </Flex>
         </WingBlank>
+        <WhiteSpace />
+        <WhiteSpace />
         <WhiteSpace />
       </ScrollView>
     );

--- a/components/grid/__tests__/__snapshots__/demo.test.native.js.snap
+++ b/components/grid/__tests__/__snapshots__/demo.test.native.js.snap
@@ -31,19 +31,6 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
       }
     >
       <View
-        accessibilityComponentType={undefined}
-        accessibilityLabel={undefined}
-        accessibilityTraits={undefined}
-        accessible={true}
-        hitSlop={undefined}
-        nativeID={undefined}
-        onLayout={undefined}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
@@ -55,22 +42,8 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
             undefined,
           ]
         }
-        testID={undefined}
       >
         <View
-          accessibilityComponentType={undefined}
-          accessibilityLabel={undefined}
-          accessibilityTraits={undefined}
-          accessible={true}
-          hitSlop={undefined}
-          nativeID={undefined}
-          onLayout={undefined}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             Array [
               Object {
@@ -90,7 +63,6 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
               ],
             ]
           }
-          testID={undefined}
         >
           <View
             accessibilityComponentType={undefined}
@@ -100,6 +72,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
             hitSlop={undefined}
             nativeID={undefined}
             onLayout={undefined}
+            onPress={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
             onResponderRelease={[Function]}
@@ -136,6 +109,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
               hitSlop={undefined}
               nativeID={undefined}
               onLayout={undefined}
+              onPress={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
               onResponderRelease={[Function]}
@@ -195,6 +169,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
             hitSlop={undefined}
             nativeID={undefined}
             onLayout={undefined}
+            onPress={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
             onResponderRelease={[Function]}
@@ -231,6 +206,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
               hitSlop={undefined}
               nativeID={undefined}
               onLayout={undefined}
+              onPress={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
               onResponderRelease={[Function]}
@@ -290,6 +266,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
             hitSlop={undefined}
             nativeID={undefined}
             onLayout={undefined}
+            onPress={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
             onResponderRelease={[Function]}
@@ -326,6 +303,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
               hitSlop={undefined}
               nativeID={undefined}
               onLayout={undefined}
+              onPress={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
               onResponderRelease={[Function]}
@@ -385,6 +363,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
             hitSlop={undefined}
             nativeID={undefined}
             onLayout={undefined}
+            onPress={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
             onResponderRelease={[Function]}
@@ -421,6 +400,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
               hitSlop={undefined}
               nativeID={undefined}
               onLayout={undefined}
+              onPress={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
               onResponderRelease={[Function]}
@@ -474,19 +454,6 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
           </View>
         </View>
         <View
-          accessibilityComponentType={undefined}
-          accessibilityLabel={undefined}
-          accessibilityTraits={undefined}
-          accessible={true}
-          hitSlop={undefined}
-          nativeID={undefined}
-          onLayout={undefined}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             Array [
               Object {
@@ -506,7 +473,6 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
               ],
             ]
           }
-          testID={undefined}
         >
           <View
             accessibilityComponentType={undefined}
@@ -516,6 +482,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
             hitSlop={undefined}
             nativeID={undefined}
             onLayout={undefined}
+            onPress={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
             onResponderRelease={[Function]}
@@ -552,6 +519,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
               hitSlop={undefined}
               nativeID={undefined}
               onLayout={undefined}
+              onPress={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
               onResponderRelease={[Function]}
@@ -611,6 +579,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
             hitSlop={undefined}
             nativeID={undefined}
             onLayout={undefined}
+            onPress={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
             onResponderRelease={[Function]}
@@ -647,6 +616,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
               hitSlop={undefined}
               nativeID={undefined}
               onLayout={undefined}
+              onPress={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
               onResponderRelease={[Function]}
@@ -706,6 +676,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
             hitSlop={undefined}
             nativeID={undefined}
             onLayout={undefined}
+            onPress={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
             onResponderRelease={[Function]}
@@ -742,6 +713,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
               hitSlop={undefined}
               nativeID={undefined}
               onLayout={undefined}
+              onPress={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
               onResponderRelease={[Function]}
@@ -801,6 +773,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
             hitSlop={undefined}
             nativeID={undefined}
             onLayout={undefined}
+            onPress={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
             onResponderRelease={[Function]}
@@ -837,6 +810,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
               hitSlop={undefined}
               nativeID={undefined}
               onLayout={undefined}
+              onPress={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
               onResponderRelease={[Function]}
@@ -890,19 +864,6 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
           </View>
         </View>
         <View
-          accessibilityComponentType={undefined}
-          accessibilityLabel={undefined}
-          accessibilityTraits={undefined}
-          accessible={true}
-          hitSlop={undefined}
-          nativeID={undefined}
-          onLayout={undefined}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             Array [
               Object {
@@ -922,7 +883,6 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
               ],
             ]
           }
-          testID={undefined}
         >
           <View
             accessibilityComponentType={undefined}
@@ -932,6 +892,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
             hitSlop={undefined}
             nativeID={undefined}
             onLayout={undefined}
+            onPress={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
             onResponderRelease={[Function]}
@@ -968,6 +929,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
               hitSlop={undefined}
               nativeID={undefined}
               onLayout={undefined}
+              onPress={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
               onResponderRelease={[Function]}
@@ -1020,19 +982,6 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
             </View>
           </View>
           <View
-            accessibilityComponentType={undefined}
-            accessibilityLabel={undefined}
-            accessibilityTraits={undefined}
-            accessible={true}
-            hitSlop={undefined}
-            nativeID={undefined}
-            onLayout={undefined}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             style={
               Array [
                 Object {
@@ -1049,22 +998,8 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
                 ],
               ]
             }
-            testID={undefined}
           />
           <View
-            accessibilityComponentType={undefined}
-            accessibilityLabel={undefined}
-            accessibilityTraits={undefined}
-            accessible={true}
-            hitSlop={undefined}
-            nativeID={undefined}
-            onLayout={undefined}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             style={
               Array [
                 Object {
@@ -1081,22 +1016,8 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
                 ],
               ]
             }
-            testID={undefined}
           />
           <View
-            accessibilityComponentType={undefined}
-            accessibilityLabel={undefined}
-            accessibilityTraits={undefined}
-            accessible={true}
-            hitSlop={undefined}
-            nativeID={undefined}
-            onLayout={undefined}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             style={
               Array [
                 Object {
@@ -1113,7 +1034,6 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
                 ],
               ]
             }
-            testID={undefined}
           />
         </View>
       </View>
@@ -1221,19 +1141,6 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
               }
             >
               <View
-                accessibilityComponentType={undefined}
-                accessibilityLabel={undefined}
-                accessibilityTraits={undefined}
-                accessible={true}
-                hitSlop={undefined}
-                nativeID={undefined}
-                onLayout={undefined}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
                   Array [
                     Object {
@@ -1253,7 +1160,6 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
                     ],
                   ]
                 }
-                testID={undefined}
               >
                 <View
                   accessibilityComponentType={undefined}
@@ -1263,6 +1169,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
                   hitSlop={undefined}
                   nativeID={undefined}
                   onLayout={undefined}
+                  onPress={[Function]}
                   onResponderGrant={[Function]}
                   onResponderMove={[Function]}
                   onResponderRelease={[Function]}
@@ -1299,6 +1206,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
                     hitSlop={undefined}
                     nativeID={undefined}
                     onLayout={undefined}
+                    onPress={[Function]}
                     onResponderGrant={[Function]}
                     onResponderMove={[Function]}
                     onResponderRelease={[Function]}
@@ -1358,6 +1266,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
                   hitSlop={undefined}
                   nativeID={undefined}
                   onLayout={undefined}
+                  onPress={[Function]}
                   onResponderGrant={[Function]}
                   onResponderMove={[Function]}
                   onResponderRelease={[Function]}
@@ -1394,6 +1303,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
                     hitSlop={undefined}
                     nativeID={undefined}
                     onLayout={undefined}
+                    onPress={[Function]}
                     onResponderGrant={[Function]}
                     onResponderMove={[Function]}
                     onResponderRelease={[Function]}
@@ -1453,6 +1363,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
                   hitSlop={undefined}
                   nativeID={undefined}
                   onLayout={undefined}
+                  onPress={[Function]}
                   onResponderGrant={[Function]}
                   onResponderMove={[Function]}
                   onResponderRelease={[Function]}
@@ -1489,6 +1400,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
                     hitSlop={undefined}
                     nativeID={undefined}
                     onLayout={undefined}
+                    onPress={[Function]}
                     onResponderGrant={[Function]}
                     onResponderMove={[Function]}
                     onResponderRelease={[Function]}
@@ -1542,19 +1454,6 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
                 </View>
               </View>
               <View
-                accessibilityComponentType={undefined}
-                accessibilityLabel={undefined}
-                accessibilityTraits={undefined}
-                accessible={true}
-                hitSlop={undefined}
-                nativeID={undefined}
-                onLayout={undefined}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
                   Array [
                     Object {
@@ -1574,7 +1473,6 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
                     ],
                   ]
                 }
-                testID={undefined}
               >
                 <View
                   accessibilityComponentType={undefined}
@@ -1584,6 +1482,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
                   hitSlop={undefined}
                   nativeID={undefined}
                   onLayout={undefined}
+                  onPress={[Function]}
                   onResponderGrant={[Function]}
                   onResponderMove={[Function]}
                   onResponderRelease={[Function]}
@@ -1620,6 +1519,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
                     hitSlop={undefined}
                     nativeID={undefined}
                     onLayout={undefined}
+                    onPress={[Function]}
                     onResponderGrant={[Function]}
                     onResponderMove={[Function]}
                     onResponderRelease={[Function]}
@@ -1679,6 +1579,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
                   hitSlop={undefined}
                   nativeID={undefined}
                   onLayout={undefined}
+                  onPress={[Function]}
                   onResponderGrant={[Function]}
                   onResponderMove={[Function]}
                   onResponderRelease={[Function]}
@@ -1715,6 +1616,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
                     hitSlop={undefined}
                     nativeID={undefined}
                     onLayout={undefined}
+                    onPress={[Function]}
                     onResponderGrant={[Function]}
                     onResponderMove={[Function]}
                     onResponderRelease={[Function]}
@@ -1774,6 +1676,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
                   hitSlop={undefined}
                   nativeID={undefined}
                   onLayout={undefined}
+                  onPress={[Function]}
                   onResponderGrant={[Function]}
                   onResponderMove={[Function]}
                   onResponderRelease={[Function]}
@@ -1810,6 +1713,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
                     hitSlop={undefined}
                     nativeID={undefined}
                     onLayout={undefined}
+                    onPress={[Function]}
                     onResponderGrant={[Function]}
                     onResponderMove={[Function]}
                     onResponderRelease={[Function]}
@@ -1884,19 +1788,6 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
               }
             >
               <View
-                accessibilityComponentType={undefined}
-                accessibilityLabel={undefined}
-                accessibilityTraits={undefined}
-                accessible={true}
-                hitSlop={undefined}
-                nativeID={undefined}
-                onLayout={undefined}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
                   Array [
                     Object {
@@ -1916,7 +1807,6 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
                     ],
                   ]
                 }
-                testID={undefined}
               >
                 <View
                   accessibilityComponentType={undefined}
@@ -1926,6 +1816,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
                   hitSlop={undefined}
                   nativeID={undefined}
                   onLayout={undefined}
+                  onPress={[Function]}
                   onResponderGrant={[Function]}
                   onResponderMove={[Function]}
                   onResponderRelease={[Function]}
@@ -1962,6 +1853,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
                     hitSlop={undefined}
                     nativeID={undefined}
                     onLayout={undefined}
+                    onPress={[Function]}
                     onResponderGrant={[Function]}
                     onResponderMove={[Function]}
                     onResponderRelease={[Function]}
@@ -2021,6 +1913,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
                   hitSlop={undefined}
                   nativeID={undefined}
                   onLayout={undefined}
+                  onPress={[Function]}
                   onResponderGrant={[Function]}
                   onResponderMove={[Function]}
                   onResponderRelease={[Function]}
@@ -2057,6 +1950,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
                     hitSlop={undefined}
                     nativeID={undefined}
                     onLayout={undefined}
+                    onPress={[Function]}
                     onResponderGrant={[Function]}
                     onResponderMove={[Function]}
                     onResponderRelease={[Function]}
@@ -2116,6 +2010,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
                   hitSlop={undefined}
                   nativeID={undefined}
                   onLayout={undefined}
+                  onPress={[Function]}
                   onResponderGrant={[Function]}
                   onResponderMove={[Function]}
                   onResponderRelease={[Function]}
@@ -2152,6 +2047,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
                     hitSlop={undefined}
                     nativeID={undefined}
                     onLayout={undefined}
+                    onPress={[Function]}
                     onResponderGrant={[Function]}
                     onResponderMove={[Function]}
                     onResponderRelease={[Function]}
@@ -2205,19 +2101,6 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
                 </View>
               </View>
               <View
-                accessibilityComponentType={undefined}
-                accessibilityLabel={undefined}
-                accessibilityTraits={undefined}
-                accessible={true}
-                hitSlop={undefined}
-                nativeID={undefined}
-                onLayout={undefined}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
                   Array [
                     Object {
@@ -2236,22 +2119,8 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
                     ],
                   ]
                 }
-                testID={undefined}
               >
                 <View
-                  accessibilityComponentType={undefined}
-                  accessibilityLabel={undefined}
-                  accessibilityTraits={undefined}
-                  accessible={true}
-                  hitSlop={undefined}
-                  nativeID={undefined}
-                  onLayout={undefined}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
                   style={
                     Array [
                       Object {
@@ -2268,22 +2137,8 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
                       ],
                     ]
                   }
-                  testID={undefined}
                 />
                 <View
-                  accessibilityComponentType={undefined}
-                  accessibilityLabel={undefined}
-                  accessibilityTraits={undefined}
-                  accessible={true}
-                  hitSlop={undefined}
-                  nativeID={undefined}
-                  onLayout={undefined}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
                   style={
                     Array [
                       Object {
@@ -2300,22 +2155,8 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
                       ],
                     ]
                   }
-                  testID={undefined}
                 />
                 <View
-                  accessibilityComponentType={undefined}
-                  accessibilityLabel={undefined}
-                  accessibilityTraits={undefined}
-                  accessible={true}
-                  hitSlop={undefined}
-                  nativeID={undefined}
-                  onLayout={undefined}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
                   style={
                     Array [
                       Object {
@@ -2332,7 +2173,6 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
                       ],
                     ]
                   }
-                  testID={undefined}
                 />
               </View>
             </View>
@@ -2423,19 +2263,6 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
       </Text>
     </View>
     <View
-      accessibilityComponentType={undefined}
-      accessibilityLabel={undefined}
-      accessibilityTraits={undefined}
-      accessible={true}
-      hitSlop={undefined}
-      nativeID={undefined}
-      onLayout={undefined}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       style={
         Array [
           Object {
@@ -2447,22 +2274,8 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
           undefined,
         ]
       }
-      testID={undefined}
     >
       <View
-        accessibilityComponentType={undefined}
-        accessibilityLabel={undefined}
-        accessibilityTraits={undefined}
-        accessible={true}
-        hitSlop={undefined}
-        nativeID={undefined}
-        onLayout={undefined}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
@@ -2482,7 +2295,6 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
             ],
           ]
         }
-        testID={undefined}
       >
         <View
           accessibilityComponentType={undefined}
@@ -2492,6 +2304,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
           hitSlop={undefined}
           nativeID={undefined}
           onLayout={undefined}
+          onPress={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
           onResponderRelease={[Function]}
@@ -2531,6 +2344,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
             hitSlop={undefined}
             nativeID={undefined}
             onLayout={undefined}
+            onPress={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
             onResponderRelease={[Function]}
@@ -2590,6 +2404,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
           hitSlop={undefined}
           nativeID={undefined}
           onLayout={undefined}
+          onPress={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
           onResponderRelease={[Function]}
@@ -2629,6 +2444,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
             hitSlop={undefined}
             nativeID={undefined}
             onLayout={undefined}
+            onPress={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
             onResponderRelease={[Function]}
@@ -2688,6 +2504,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
           hitSlop={undefined}
           nativeID={undefined}
           onLayout={undefined}
+          onPress={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
           onResponderRelease={[Function]}
@@ -2727,6 +2544,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
             hitSlop={undefined}
             nativeID={undefined}
             onLayout={undefined}
+            onPress={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
             onResponderRelease={[Function]}
@@ -2780,19 +2598,6 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
         </View>
       </View>
       <View
-        accessibilityComponentType={undefined}
-        accessibilityLabel={undefined}
-        accessibilityTraits={undefined}
-        accessible={true}
-        hitSlop={undefined}
-        nativeID={undefined}
-        onLayout={undefined}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
@@ -2812,7 +2617,6 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
             ],
           ]
         }
-        testID={undefined}
       >
         <View
           accessibilityComponentType={undefined}
@@ -2822,6 +2626,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
           hitSlop={undefined}
           nativeID={undefined}
           onLayout={undefined}
+          onPress={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
           onResponderRelease={[Function]}
@@ -2861,6 +2666,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
             hitSlop={undefined}
             nativeID={undefined}
             onLayout={undefined}
+            onPress={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
             onResponderRelease={[Function]}
@@ -2920,6 +2726,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
           hitSlop={undefined}
           nativeID={undefined}
           onLayout={undefined}
+          onPress={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
           onResponderRelease={[Function]}
@@ -2959,6 +2766,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
             hitSlop={undefined}
             nativeID={undefined}
             onLayout={undefined}
+            onPress={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
             onResponderRelease={[Function]}
@@ -3018,6 +2826,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
           hitSlop={undefined}
           nativeID={undefined}
           onLayout={undefined}
+          onPress={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
           onResponderRelease={[Function]}
@@ -3057,6 +2866,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
             hitSlop={undefined}
             nativeID={undefined}
             onLayout={undefined}
+            onPress={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
             onResponderRelease={[Function]}
@@ -3110,19 +2920,6 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
         </View>
       </View>
       <View
-        accessibilityComponentType={undefined}
-        accessibilityLabel={undefined}
-        accessibilityTraits={undefined}
-        accessible={true}
-        hitSlop={undefined}
-        nativeID={undefined}
-        onLayout={undefined}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
@@ -3142,7 +2939,6 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
             ],
           ]
         }
-        testID={undefined}
       >
         <View
           accessibilityComponentType={undefined}
@@ -3152,6 +2948,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
           hitSlop={undefined}
           nativeID={undefined}
           onLayout={undefined}
+          onPress={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
           onResponderRelease={[Function]}
@@ -3191,6 +2988,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
             hitSlop={undefined}
             nativeID={undefined}
             onLayout={undefined}
+            onPress={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
             onResponderRelease={[Function]}
@@ -3250,6 +3048,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
           hitSlop={undefined}
           nativeID={undefined}
           onLayout={undefined}
+          onPress={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
           onResponderRelease={[Function]}
@@ -3289,6 +3088,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
             hitSlop={undefined}
             nativeID={undefined}
             onLayout={undefined}
+            onPress={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
             onResponderRelease={[Function]}
@@ -3348,6 +3148,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
           hitSlop={undefined}
           nativeID={undefined}
           onLayout={undefined}
+          onPress={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
           onResponderRelease={[Function]}
@@ -3387,6 +3188,7 @@ exports[`renders ./components/grid/demo/basic.native.tsx correctly 1`] = `
             hitSlop={undefined}
             nativeID={undefined}
             onLayout={undefined}
+            onPress={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
             onResponderRelease={[Function]}

--- a/components/icon/__tests__/__snapshots__/demo.test.native.js.snap
+++ b/components/icon/__tests__/__snapshots__/demo.test.native.js.snap
@@ -2,19 +2,6 @@
 
 exports[`renders ./components/icon/demo/basic.native.tsx correctly 1`] = `
 <View
-  accessibilityComponentType={undefined}
-  accessibilityLabel={undefined}
-  accessibilityTraits={undefined}
-  accessible={true}
-  hitSlop={undefined}
-  nativeID={undefined}
-  onLayout={undefined}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
   style={
     Array [
       Object {
@@ -26,22 +13,8 @@ exports[`renders ./components/icon/demo/basic.native.tsx correctly 1`] = `
       undefined,
     ]
   }
-  testID={undefined}
 >
   <View
-    accessibilityComponentType={undefined}
-    accessibilityLabel={undefined}
-    accessibilityTraits={undefined}
-    accessible={true}
-    hitSlop={undefined}
-    nativeID={undefined}
-    onLayout={undefined}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
     style={
       Array [
         Object {
@@ -61,7 +34,6 @@ exports[`renders ./components/icon/demo/basic.native.tsx correctly 1`] = `
         ],
       ]
     }
-    testID={undefined}
   >
     <View
       accessibilityComponentType={undefined}
@@ -71,6 +43,7 @@ exports[`renders ./components/icon/demo/basic.native.tsx correctly 1`] = `
       hitSlop={undefined}
       nativeID={undefined}
       onLayout={undefined}
+      onPress={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
       onResponderRelease={[Function]}
@@ -107,6 +80,7 @@ exports[`renders ./components/icon/demo/basic.native.tsx correctly 1`] = `
         hitSlop={undefined}
         nativeID={undefined}
         onLayout={undefined}
+        onPress={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -169,6 +143,7 @@ exports[`renders ./components/icon/demo/basic.native.tsx correctly 1`] = `
       hitSlop={undefined}
       nativeID={undefined}
       onLayout={undefined}
+      onPress={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
       onResponderRelease={[Function]}
@@ -205,6 +180,7 @@ exports[`renders ./components/icon/demo/basic.native.tsx correctly 1`] = `
         hitSlop={undefined}
         nativeID={undefined}
         onLayout={undefined}
+        onPress={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -267,6 +243,7 @@ exports[`renders ./components/icon/demo/basic.native.tsx correctly 1`] = `
       hitSlop={undefined}
       nativeID={undefined}
       onLayout={undefined}
+      onPress={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
       onResponderRelease={[Function]}
@@ -303,6 +280,7 @@ exports[`renders ./components/icon/demo/basic.native.tsx correctly 1`] = `
         hitSlop={undefined}
         nativeID={undefined}
         onLayout={undefined}
+        onPress={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -359,19 +337,6 @@ exports[`renders ./components/icon/demo/basic.native.tsx correctly 1`] = `
     </View>
   </View>
   <View
-    accessibilityComponentType={undefined}
-    accessibilityLabel={undefined}
-    accessibilityTraits={undefined}
-    accessible={true}
-    hitSlop={undefined}
-    nativeID={undefined}
-    onLayout={undefined}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
     style={
       Array [
         Object {
@@ -391,7 +356,6 @@ exports[`renders ./components/icon/demo/basic.native.tsx correctly 1`] = `
         ],
       ]
     }
-    testID={undefined}
   >
     <View
       accessibilityComponentType={undefined}
@@ -401,6 +365,7 @@ exports[`renders ./components/icon/demo/basic.native.tsx correctly 1`] = `
       hitSlop={undefined}
       nativeID={undefined}
       onLayout={undefined}
+      onPress={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
       onResponderRelease={[Function]}
@@ -437,6 +402,7 @@ exports[`renders ./components/icon/demo/basic.native.tsx correctly 1`] = `
         hitSlop={undefined}
         nativeID={undefined}
         onLayout={undefined}
+        onPress={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -499,6 +465,7 @@ exports[`renders ./components/icon/demo/basic.native.tsx correctly 1`] = `
       hitSlop={undefined}
       nativeID={undefined}
       onLayout={undefined}
+      onPress={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
       onResponderRelease={[Function]}
@@ -535,6 +502,7 @@ exports[`renders ./components/icon/demo/basic.native.tsx correctly 1`] = `
         hitSlop={undefined}
         nativeID={undefined}
         onLayout={undefined}
+        onPress={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -597,6 +565,7 @@ exports[`renders ./components/icon/demo/basic.native.tsx correctly 1`] = `
       hitSlop={undefined}
       nativeID={undefined}
       onLayout={undefined}
+      onPress={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
       onResponderRelease={[Function]}
@@ -633,6 +602,7 @@ exports[`renders ./components/icon/demo/basic.native.tsx correctly 1`] = `
         hitSlop={undefined}
         nativeID={undefined}
         onLayout={undefined}
+        onPress={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -689,19 +659,6 @@ exports[`renders ./components/icon/demo/basic.native.tsx correctly 1`] = `
     </View>
   </View>
   <View
-    accessibilityComponentType={undefined}
-    accessibilityLabel={undefined}
-    accessibilityTraits={undefined}
-    accessible={true}
-    hitSlop={undefined}
-    nativeID={undefined}
-    onLayout={undefined}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
     style={
       Array [
         Object {
@@ -721,7 +678,6 @@ exports[`renders ./components/icon/demo/basic.native.tsx correctly 1`] = `
         ],
       ]
     }
-    testID={undefined}
   >
     <View
       accessibilityComponentType={undefined}
@@ -731,6 +687,7 @@ exports[`renders ./components/icon/demo/basic.native.tsx correctly 1`] = `
       hitSlop={undefined}
       nativeID={undefined}
       onLayout={undefined}
+      onPress={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
       onResponderRelease={[Function]}
@@ -767,6 +724,7 @@ exports[`renders ./components/icon/demo/basic.native.tsx correctly 1`] = `
         hitSlop={undefined}
         nativeID={undefined}
         onLayout={undefined}
+        onPress={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -829,6 +787,7 @@ exports[`renders ./components/icon/demo/basic.native.tsx correctly 1`] = `
       hitSlop={undefined}
       nativeID={undefined}
       onLayout={undefined}
+      onPress={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
       onResponderRelease={[Function]}
@@ -865,6 +824,7 @@ exports[`renders ./components/icon/demo/basic.native.tsx correctly 1`] = `
         hitSlop={undefined}
         nativeID={undefined}
         onLayout={undefined}
+        onPress={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -927,6 +887,7 @@ exports[`renders ./components/icon/demo/basic.native.tsx correctly 1`] = `
       hitSlop={undefined}
       nativeID={undefined}
       onLayout={undefined}
+      onPress={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
       onResponderRelease={[Function]}
@@ -963,6 +924,7 @@ exports[`renders ./components/icon/demo/basic.native.tsx correctly 1`] = `
         hitSlop={undefined}
         nativeID={undefined}
         onLayout={undefined}
+        onPress={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -1019,19 +981,6 @@ exports[`renders ./components/icon/demo/basic.native.tsx correctly 1`] = `
     </View>
   </View>
   <View
-    accessibilityComponentType={undefined}
-    accessibilityLabel={undefined}
-    accessibilityTraits={undefined}
-    accessible={true}
-    hitSlop={undefined}
-    nativeID={undefined}
-    onLayout={undefined}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
     style={
       Array [
         Object {
@@ -1051,7 +1000,6 @@ exports[`renders ./components/icon/demo/basic.native.tsx correctly 1`] = `
         ],
       ]
     }
-    testID={undefined}
   >
     <View
       accessibilityComponentType={undefined}
@@ -1061,6 +1009,7 @@ exports[`renders ./components/icon/demo/basic.native.tsx correctly 1`] = `
       hitSlop={undefined}
       nativeID={undefined}
       onLayout={undefined}
+      onPress={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
       onResponderRelease={[Function]}
@@ -1097,6 +1046,7 @@ exports[`renders ./components/icon/demo/basic.native.tsx correctly 1`] = `
         hitSlop={undefined}
         nativeID={undefined}
         onLayout={undefined}
+        onPress={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -1159,6 +1109,7 @@ exports[`renders ./components/icon/demo/basic.native.tsx correctly 1`] = `
       hitSlop={undefined}
       nativeID={undefined}
       onLayout={undefined}
+      onPress={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
       onResponderRelease={[Function]}
@@ -1195,6 +1146,7 @@ exports[`renders ./components/icon/demo/basic.native.tsx correctly 1`] = `
         hitSlop={undefined}
         nativeID={undefined}
         onLayout={undefined}
+        onPress={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
@@ -1257,6 +1209,7 @@ exports[`renders ./components/icon/demo/basic.native.tsx correctly 1`] = `
       hitSlop={undefined}
       nativeID={undefined}
       onLayout={undefined}
+      onPress={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
       onResponderRelease={[Function]}
@@ -1293,6 +1246,7 @@ exports[`renders ./components/icon/demo/basic.native.tsx correctly 1`] = `
         hitSlop={undefined}
         nativeID={undefined}
         onLayout={undefined}
+        onPress={[Function]}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}

--- a/components/locale-provider/__tests__/__snapshots__/demo.test.native.js.snap
+++ b/components/locale-provider/__tests__/__snapshots__/demo.test.native.js.snap
@@ -107,19 +107,6 @@ exports[`renders ./components/locale-provider/demo/basic.native.tsx correctly 1`
       }
     >
       <View
-        accessibilityComponentType={undefined}
-        accessibilityLabel={undefined}
-        accessibilityTraits={undefined}
-        accessible={true}
-        hitSlop={undefined}
-        nativeID={undefined}
-        onLayout={undefined}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
@@ -131,22 +118,8 @@ exports[`renders ./components/locale-provider/demo/basic.native.tsx correctly 1`
             undefined,
           ]
         }
-        testID={undefined}
       >
         <View
-          accessibilityComponentType={undefined}
-          accessibilityLabel={undefined}
-          accessibilityTraits={undefined}
-          accessible={true}
-          hitSlop={undefined}
-          nativeID={undefined}
-          onLayout={undefined}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             Array [
               Object {
@@ -155,7 +128,6 @@ exports[`renders ./components/locale-provider/demo/basic.native.tsx correctly 1`
               undefined,
             ]
           }
-          testID={undefined}
         >
           <View
             accessibilityComponentType={undefined}
@@ -240,19 +212,6 @@ exports[`renders ./components/locale-provider/demo/basic.native.tsx correctly 1`
           </View>
         </View>
         <View
-          accessibilityComponentType={undefined}
-          accessibilityLabel={undefined}
-          accessibilityTraits={undefined}
-          accessible={true}
-          hitSlop={undefined}
-          nativeID={undefined}
-          onLayout={undefined}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             Array [
               Object {
@@ -261,7 +220,6 @@ exports[`renders ./components/locale-provider/demo/basic.native.tsx correctly 1`
               undefined,
             ]
           }
-          testID={undefined}
         >
           <View
             style={
@@ -309,19 +267,6 @@ exports[`renders ./components/locale-provider/demo/basic.native.tsx correctly 1`
           </View>
         </View>
         <View
-          accessibilityComponentType={undefined}
-          accessibilityLabel={undefined}
-          accessibilityTraits={undefined}
-          accessible={true}
-          hitSlop={undefined}
-          nativeID={undefined}
-          onLayout={undefined}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             Array [
               Object {
@@ -330,7 +275,6 @@ exports[`renders ./components/locale-provider/demo/basic.native.tsx correctly 1`
               undefined,
             ]
           }
-          testID={undefined}
         >
           <View
             accessibilityComponentType={undefined}

--- a/components/pagination/__tests__/__snapshots__/demo.test.native.js.snap
+++ b/components/pagination/__tests__/__snapshots__/demo.test.native.js.snap
@@ -34,19 +34,6 @@ exports[`renders ./components/pagination/demo/basic.native.tsx correctly 1`] = `
     }
   >
     <View
-      accessibilityComponentType={undefined}
-      accessibilityLabel={undefined}
-      accessibilityTraits={undefined}
-      accessible={true}
-      hitSlop={undefined}
-      nativeID={undefined}
-      onLayout={undefined}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       style={
         Array [
           Object {
@@ -58,22 +45,8 @@ exports[`renders ./components/pagination/demo/basic.native.tsx correctly 1`] = `
           undefined,
         ]
       }
-      testID={undefined}
     >
       <View
-        accessibilityComponentType={undefined}
-        accessibilityLabel={undefined}
-        accessibilityTraits={undefined}
-        accessible={true}
-        hitSlop={undefined}
-        nativeID={undefined}
-        onLayout={undefined}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
@@ -82,7 +55,6 @@ exports[`renders ./components/pagination/demo/basic.native.tsx correctly 1`] = `
             undefined,
           ]
         }
-        testID={undefined}
       >
         <View
           accessibilityComponentType={undefined}
@@ -167,19 +139,6 @@ exports[`renders ./components/pagination/demo/basic.native.tsx correctly 1`] = `
         </View>
       </View>
       <View
-        accessibilityComponentType={undefined}
-        accessibilityLabel={undefined}
-        accessibilityTraits={undefined}
-        accessible={true}
-        hitSlop={undefined}
-        nativeID={undefined}
-        onLayout={undefined}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
@@ -188,7 +147,6 @@ exports[`renders ./components/pagination/demo/basic.native.tsx correctly 1`] = `
             undefined,
           ]
         }
-        testID={undefined}
       >
         <View
           style={
@@ -236,19 +194,6 @@ exports[`renders ./components/pagination/demo/basic.native.tsx correctly 1`] = `
         </View>
       </View>
       <View
-        accessibilityComponentType={undefined}
-        accessibilityLabel={undefined}
-        accessibilityTraits={undefined}
-        accessible={true}
-        hitSlop={undefined}
-        nativeID={undefined}
-        onLayout={undefined}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
@@ -257,7 +202,6 @@ exports[`renders ./components/pagination/demo/basic.native.tsx correctly 1`] = `
             undefined,
           ]
         }
-        testID={undefined}
       >
         <View
           accessibilityComponentType={undefined}
@@ -360,19 +304,6 @@ exports[`renders ./components/pagination/demo/basic.native.tsx correctly 1`] = `
     }
   >
     <View
-      accessibilityComponentType={undefined}
-      accessibilityLabel={undefined}
-      accessibilityTraits={undefined}
-      accessible={true}
-      hitSlop={undefined}
-      nativeID={undefined}
-      onLayout={undefined}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       style={
         Array [
           Object {
@@ -384,22 +315,8 @@ exports[`renders ./components/pagination/demo/basic.native.tsx correctly 1`] = `
           undefined,
         ]
       }
-      testID={undefined}
     >
       <View
-        accessibilityComponentType={undefined}
-        accessibilityLabel={undefined}
-        accessibilityTraits={undefined}
-        accessible={true}
-        hitSlop={undefined}
-        nativeID={undefined}
-        onLayout={undefined}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
@@ -408,7 +325,6 @@ exports[`renders ./components/pagination/demo/basic.native.tsx correctly 1`] = `
             undefined,
           ]
         }
-        testID={undefined}
       >
         <View
           accessibilityComponentType={undefined}
@@ -493,19 +409,6 @@ exports[`renders ./components/pagination/demo/basic.native.tsx correctly 1`] = `
         </View>
       </View>
       <View
-        accessibilityComponentType={undefined}
-        accessibilityLabel={undefined}
-        accessibilityTraits={undefined}
-        accessible={true}
-        hitSlop={undefined}
-        nativeID={undefined}
-        onLayout={undefined}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
@@ -514,22 +417,8 @@ exports[`renders ./components/pagination/demo/basic.native.tsx correctly 1`] = `
             undefined,
           ]
         }
-        testID={undefined}
       />
       <View
-        accessibilityComponentType={undefined}
-        accessibilityLabel={undefined}
-        accessibilityTraits={undefined}
-        accessible={true}
-        hitSlop={undefined}
-        nativeID={undefined}
-        onLayout={undefined}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Array [
             Object {
@@ -538,7 +427,6 @@ exports[`renders ./components/pagination/demo/basic.native.tsx correctly 1`] = `
             undefined,
           ]
         }
-        testID={undefined}
       >
         <View
           accessibilityComponentType={undefined}

--- a/components/pagination/__tests__/__snapshots__/index.test.native.js.snap
+++ b/components/pagination/__tests__/__snapshots__/index.test.native.js.snap
@@ -13,19 +13,6 @@ exports[`Pagination renders correctly 1`] = `
   }
 >
   <View
-    accessibilityComponentType={undefined}
-    accessibilityLabel={undefined}
-    accessibilityTraits={undefined}
-    accessible={true}
-    hitSlop={undefined}
-    nativeID={undefined}
-    onLayout={undefined}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
     style={
       Array [
         Object {
@@ -37,22 +24,8 @@ exports[`Pagination renders correctly 1`] = `
         undefined,
       ]
     }
-    testID={undefined}
   >
     <View
-      accessibilityComponentType={undefined}
-      accessibilityLabel={undefined}
-      accessibilityTraits={undefined}
-      accessible={true}
-      hitSlop={undefined}
-      nativeID={undefined}
-      onLayout={undefined}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       style={
         Array [
           Object {
@@ -61,7 +34,6 @@ exports[`Pagination renders correctly 1`] = `
           undefined,
         ]
       }
-      testID={undefined}
     >
       <View
         accessibilityComponentType={undefined}
@@ -141,19 +113,6 @@ exports[`Pagination renders correctly 1`] = `
       </View>
     </View>
     <View
-      accessibilityComponentType={undefined}
-      accessibilityLabel={undefined}
-      accessibilityTraits={undefined}
-      accessible={true}
-      hitSlop={undefined}
-      nativeID={undefined}
-      onLayout={undefined}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       style={
         Array [
           Object {
@@ -162,7 +121,6 @@ exports[`Pagination renders correctly 1`] = `
           undefined,
         ]
       }
-      testID={undefined}
     >
       <View
         style={
@@ -210,19 +168,6 @@ exports[`Pagination renders correctly 1`] = `
       </View>
     </View>
     <View
-      accessibilityComponentType={undefined}
-      accessibilityLabel={undefined}
-      accessibilityTraits={undefined}
-      accessible={true}
-      hitSlop={undefined}
-      nativeID={undefined}
-      onLayout={undefined}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       style={
         Array [
           Object {
@@ -231,7 +176,6 @@ exports[`Pagination renders correctly 1`] = `
           undefined,
         ]
       }
-      testID={undefined}
     >
       <View
         accessibilityComponentType={undefined}


### PR DESCRIPTION
relate issues: #1108, #769

`Flex` and `FlexItem` now have capability to switch that `TouchableWithoutFeedback` wrap or not.

When developer pass one of `onPress` `onLongPress` `onPressIn` `onPressOut` parameter, the `Flex` component will be wrapped by `TouchableWithoutFeedback`.

This solution avoid make a break change to developer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/2095)
<!-- Reviewable:end -->
