### PR TITLE
add swedish locale 🇸🇪

### DIFF
--- a/components/date-picker-view/locale/sv_SE.tsx
+++ b/components/date-picker-view/locale/sv_SE.tsx
@@ -1,0 +1,3 @@
+import DatePickerLocale from 'rmc-date-picker/lib/locale/en_US';
+
+export default DatePickerLocale;

--- a/components/date-picker/locale/sv_SE.tsx
+++ b/components/date-picker/locale/sv_SE.tsx
@@ -1,0 +1,8 @@
+import DatePickerLocale from 'rmc-date-picker/lib/locale/en_US';
+
+export default {
+  okText: 'Ok',
+  dismissText: 'Avbryt',
+  extra: 'vänligen välj',
+  DatePickerLocale,
+};

--- a/components/input-item/locale/sv_SE.tsx
+++ b/components/input-item/locale/sv_SE.tsx
@@ -1,0 +1,3 @@
+export default {
+  confirmLabel: 'Ok',
+};

--- a/components/locale-provider/sv_SE.tsx
+++ b/components/locale-provider/sv_SE.tsx
@@ -1,0 +1,16 @@
+import Pagination from '../pagination/locale/sv_Se';
+import DatePicker from '../date-picker/locale/sv_Se';
+import DatePickerView from '../date-picker-view/locale/sv_Se';
+import InputItem from '../input-item/locale/sv_Se';
+import Picker from '../picker/locale/sv_Se';
+import SearchBar from '../search-bar/locale/sv_Se';
+
+export default {
+  locale: 'sv',
+  Pagination,
+  DatePicker,
+  DatePickerView,
+  InputItem,
+  Picker,
+  SearchBar,
+};

--- a/components/pagination/locale/sv_SE.tsx
+++ b/components/pagination/locale/sv_SE.tsx
@@ -1,0 +1,4 @@
+export default {
+  prevText: 'Föreg',
+  nextText: 'Nästa',
+};

--- a/components/picker/locale/sv_SE.tsx
+++ b/components/picker/locale/sv_SE.tsx
@@ -1,0 +1,5 @@
+export default {
+  okText: 'Ok',
+  dismissText: 'Avbryt',
+  extra: 'vänligen välj',
+};

--- a/components/search-bar/locale/sv_SE.tsx
+++ b/components/search-bar/locale/sv_SE.tsx
@@ -1,0 +1,3 @@
+export default {
+  cancelText: 'Avbryt',
+};


### PR DESCRIPTION
i can add sv_SE to rmc-date-picker later but basically it will be plain copy of en US because its empty.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/2132)
<!-- Reviewable:end -->
