### PR TITLE
issues#2214：Modal.prompt中onPress返回promise仍会导致modal关闭

### DIFF
--- a/components/modal/OperationContainer.native.tsx
+++ b/components/modal/OperationContainer.native.tsx
@@ -21,7 +21,7 @@ export default class OperationContainer extends React.Component<OperationContain
     };
   }
 
-  onClose= () => {
+  onClose = () => {
     this.setState({
       visible: false,
     });

--- a/components/modal/PromptContainer.native.tsx
+++ b/components/modal/PromptContainer.native.tsx
@@ -117,7 +117,6 @@ export default class PropmptContainer extends React.Component<PropmptContainerPr
         transparent
         title={title}
         visible={this.state.visible}
-        onClose={this.onClose}
         footer={footer}
         onAnimationEnd={onAnimationEnd}
       >


### PR DESCRIPTION
Fix https://github.com/ant-design/ant-design-mobile/issues/2214

Modal.prompt的onClose重复调用引发的bug，在prompt中不能通过点击mask触发onClose，建议移除

First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/2243)
<!-- Reviewable:end -->
