### PR TITLE
Update documentation links to ant mobile

### DIFF
--- a/docs/react/customize-theme.en-US.md
+++ b/docs/react/customize-theme.en-US.md
@@ -13,7 +13,7 @@ Ant Design Mobile allows to customize some basic design aspects in order to meet
 
 We are using [Less](http://lesscss.org/) as the development language of style. A set of less variables are defined for each design aspect that can be customized to your needs.
 
-- [the default style variable](https://github.com/ant-design/ant-design/blob/master/components/style/themes/default.less)
+- [the default style variable](https://github.com/ant-design/ant-design-mobile/blob/master/components/style/themes/default.less)
 
 Please report an issue if the existing list of variables is not enough for you.
 
@@ -42,7 +42,7 @@ we can use the way of [modifyVars](http://lesscss.org/usage/#using-less-in-the-b
 }
 ```
 
-- Then，add the 'theme' in `package.json` file, [the default style variable](https://github.com/ant-design/ant-design/blob/master/components/style/themes/default.less)
+- Then，add the 'theme' in `package.json` file, [the default style variable](https://github.com/ant-design/ant-design-mobile/blob/master/components/style/themes/default.less)
 
 ```js
 {


### PR DESCRIPTION
Right now the documentation is redirecting to less variables of *ant design* project no *ant mobile design* project

First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [ ] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [ ] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [ ] Rebase before creating a PR to keep commit history clear.
* [ ] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/2290)
<!-- Reviewable:end -->
