### PR TITLE
bugfix: fixed bug in image-picker, Uncaught TypeError: Cannot set pro…

### DIFF
--- a/components/image-picker/index.tsx
+++ b/components/image-picker/index.tsx
@@ -191,7 +191,7 @@ export default class ImagePicker extends React.Component<ImagePickerPropTypes, a
             aria-label="Choose and add image"
           >
             <input
-              ref={(input) => { this.fileSelectorInput = input; }}
+              ref={(input) => { if (input) { this.fileSelectorInput = input; } }}
               type="file"
               accept={accept}
               onChange={() => { this.onFileChange(); }}


### PR DESCRIPTION
Fixed a bug in image-picker, Uncaught TypeError: Cannot set property 'value' of null.

When the selector at the header of a new row, then delete a pic, and readd a new pic, the bug appear. So, do not delete the fileselectorInput, if the input is null.

First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [ ] Rebase before creating a PR to keep commit history clear.
* [ ] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [x] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/2302)
<!-- Reviewable:end -->
