### PR TITLE
Full locale components in russian language

### DIFF
--- a/components/date-picker/locale/ru_RU.tsx
+++ b/components/date-picker/locale/ru_RU.tsx
@@ -3,6 +3,6 @@ import DatePickerLocale from 'rmc-date-picker/lib/locale/en_US';
 export default {
   okText: 'Ок',
   dismissText: 'Отмена',
-  extra: 'Пожалуйста, выберите',
+  extra: '',
   DatePickerLocale,
 };

--- a/components/input-item/locale/ru_RU.tsx
+++ b/components/input-item/locale/ru_RU.tsx
@@ -1,3 +1,3 @@
 export default {
-  confirmLabel: 'сделанный',
+  confirmLabel: 'Ок',
 };

--- a/components/locale-provider/ru_RU.tsx
+++ b/components/locale-provider/ru_RU.tsx
@@ -1,10 +1,16 @@
+import DatePickerView from '../date-picker-view/locale/ru_RU';
 import DatePicker from '../date-picker/locale/ru_RU';
 import InputItem from '../input-item/locale/ru_RU';
 import Pagination from '../pagination/locale/ru_RU';
+import Picker from '../picker/locale/ru_RU';
+import SearchBar from '../search-bar/locale/ru_RU';
 
 export default {
   locale: 'ru',
   Pagination,
   DatePicker,
+  DatePickerView,
   InputItem,
+  Picker,
+  SearchBar,
 };

--- a/components/picker/locale/ru_RU.tsx
+++ b/components/picker/locale/ru_RU.tsx
@@ -1,0 +1,5 @@
+export default {
+  okText: 'Ок',
+  dismissText: 'Отмена',
+  extra: '',
+};

--- a/components/search-bar/locale/ru_RU.tsx
+++ b/components/search-bar/locale/ru_RU.tsx
@@ -1,0 +1,3 @@
+export default {
+  cancelText: 'Отмена',
+};


### PR DESCRIPTION
Added by Russian locale for all components

And i remove 'Пожалуйста, выберите' because, the inscription was cut off and it was visible only  'Пожалуйста ...' It is read as if the component asks for help :). in English 'Please ...'
![image](https://user-images.githubusercontent.com/5278430/37565543-bf5baa0c-2add-11e8-8cb7-4a7332c6ab7f.png)

If leave "выберите" in English "select", it will look like an order and still does not convey thoughts. I did a small test, and people said that it's better not to write anything at all

* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [x] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/2400)
<!-- Reviewable:end -->
