### PR TITLE
fix(input-item): value.substring is not a function

### DIFF
--- a/components/input-item/CustomInput.tsx
+++ b/components/input-item/CustomInput.tsx
@@ -205,7 +205,8 @@ class NumberInput extends React.Component<NumberInputProps, any> {
     let valueAfterChange;
     // 删除键
     if (KeyboardItemValue === 'delete') {
-      valueAfterChange = value.substring(0, value.length - 1);
+      const _value = (typeof value === 'number' ? value.toString() : value);
+      valueAfterChange = _value.substring(0, _value.length - 1);
       onChange({ target: { value: valueAfterChange } });
       // 确认键
     } else if (KeyboardItemValue === 'confirm') {

--- a/components/input-item/CustomInput.tsx
+++ b/components/input-item/CustomInput.tsx
@@ -14,7 +14,6 @@ export interface NumberInputProps {
   editable?: boolean;
   moneyKeyboardAlign?: 'left' | 'right' | string;
   value?: string;
-  defaultValue?: string;
   prefixCls?: string;
   keyboardPrefixCls?: string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
@@ -205,8 +204,7 @@ class NumberInput extends React.Component<NumberInputProps, any> {
     let valueAfterChange;
     // 删除键
     if (KeyboardItemValue === 'delete') {
-      const _value = (typeof value === 'number' ? value.toString() : value);
-      valueAfterChange = _value.substring(0, _value.length - 1);
+      valueAfterChange = value.substring(0, value.length - 1);
       onChange({ target: { value: valueAfterChange } });
       // 确认键
     } else if (KeyboardItemValue === 'confirm') {

--- a/components/input-item/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/input-item/__tests__/__snapshots__/demo.test.js.snap
@@ -131,7 +131,7 @@ exports[`renders ./components/input-item/demo/basic.md correctly 1`] = `
               data-seed="logId"
               placeholder="please input content"
               type="text"
-              value=""
+              value="Title"
             />
           </div>
         </div>
@@ -610,15 +610,15 @@ exports[`renders ./components/input-item/demo/money.md correctly 1`] = `
               class="fake-input-container fake-input-container-left"
             >
               <div
-                class="fake-input-placeholder"
-              >
-                start from left
-              </div>
-              <div
                 class="fake-input"
-              />
+              >
+                100
+              </div>
             </div>
           </div>
+          <div
+            class="am-input-clear"
+          />
         </div>
       </div>
       <div

--- a/components/input-item/demo/basic.md
+++ b/components/input-item/demo/basic.md
@@ -57,6 +57,7 @@ class BasicInputExample extends React.Component {
             placeholder="controled input"
           >受控组件</InputItem>
           <InputItem
+            defaultValue="Title"
             placeholder="please input content"
             data-seed="logId"
           >非受控组件</InputItem>

--- a/components/input-item/demo/money.md
+++ b/components/input-item/demo/money.md
@@ -30,6 +30,7 @@ class H5NumberInputExample extends React.Component {
           <InputItem
             {...getFieldProps('money3')}
             type={type}
+            defaultValue={100}
             placeholder="start from left"
             clear
             moneyKeyboardAlign="left"

--- a/components/input-item/index.tsx
+++ b/components/input-item/index.tsx
@@ -305,6 +305,7 @@ class InputItem extends React.Component<InputItemProps, any> {
                 {...restProps}
                 {...classNameProps}
                 value={normalizeValue(value)}
+                defaultValue={undefined}
                 ref={(el: any) => (this.inputRef = el)}
                 style={style}
                 type={inputType}

--- a/components/input-item/index.tsx
+++ b/components/input-item/index.tsx
@@ -24,11 +24,11 @@ export interface InputItemProps extends InputItemPropsType, HTMLInputProps {
 
 function noop() {}
 
-function fixControlledValue(value?: string) {
+function normalizeValue(value?: string) {
   if (typeof value === 'undefined' || value === null) {
     return '';
   }
-  return value;
+  return value + '';
 }
 
 class InputItem extends React.Component<InputItemProps, any> {
@@ -63,7 +63,7 @@ class InputItem extends React.Component<InputItemProps, any> {
     super(props);
     this.state = {
       placeholder: props.placeholder,
-      value: props.value || props.defaultValue || '',
+      value: normalizeValue(props.value || props.defaultValue),
     };
   }
 
@@ -213,7 +213,7 @@ class InputItem extends React.Component<InputItemProps, any> {
       moneyKeyboardAlign,
       ...restProps,
     } = this.props;
-    const { defaultValue, name, disabled, maxLength } = restProps;
+    const { name, disabled, maxLength } = restProps;
     const { value } = this.state;
 
     // tslint:disable-next-line:variable-name
@@ -284,8 +284,7 @@ class InputItem extends React.Component<InputItemProps, any> {
           <div className={controlCls}>
             {type === 'money' ? (
               <CustomInput
-                value={fixControlledValue(value)}
-                defaultValue={defaultValue}
+                value={normalizeValue(value)}
                 type={type}
                 ref={el => (this.inputRef = el)}
                 maxLength={maxLength}
@@ -305,8 +304,7 @@ class InputItem extends React.Component<InputItemProps, any> {
                 {...patternProps}
                 {...restProps}
                 {...classNameProps}
-                value={fixControlledValue(value)}
-                defaultValue={defaultValue}
+                value={normalizeValue(value)}
                 ref={(el: any) => (this.inputRef = el)}
                 style={style}
                 type={inputType}


### PR DESCRIPTION
This commit applies a fault tolerance when user performs "delete" on a
number "value" passed to \<InputItem/>, error occurred because Number
doesn't have .substring().

Refs: #2493 

* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [x] Make sure that you add at least one unit test for the bug which you had fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/2508)
<!-- Reviewable:end -->
