### PR TITLE
fix: style of <SearchBar/>

### DIFF
--- a/components/search-bar/style/index.less
+++ b/components/search-bar/style/index.less
@@ -31,6 +31,7 @@
     }
 
     .@{searchPrefixCls}-synthetic-ph {
+      box-sizing: content-box;
       z-index: 1;
       height: @search-bar-input-height;
       line-height: @search-bar-input-height;
@@ -83,6 +84,7 @@
     }
 
     .@{searchPrefixCls}-clear {
+      box-sizing: content-box;
       position: absolute;
       display: none;
       z-index: 3;


### PR DESCRIPTION
This commit force ".am-search-synthetic-ph" and ".am-search-clear"
to use "content-box" to prevent external style such as ".am-tabs" breaking
its box-sizing.

Refs: #2447 

* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

* [x] Make sure that you add at least one unit test for the bug which you had fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/2510)
<!-- Reviewable:end -->
