### PR TITLE
rename wrapOnTouchStart to onWrapTouchStart

### DIFF
--- a/components/modal/demo/basic.md
+++ b/components/modal/demo/basic.md
@@ -47,7 +47,7 @@ class App extends React.Component {
     });
   }
 
-  onWrapTouchStart = (e) => {
+  wrapOnTouchStart = (e) => {
     // fix touch to scroll background page on iOS
     if (!/iPhone|iPod|iPad/i.test(navigator.userAgent)) {
       return;
@@ -70,7 +70,7 @@ class App extends React.Component {
           onClose={this.onClose('modal1')}
           title="Title"
           footer={[{ text: 'Ok', onPress: () => { console.log('ok'); this.onClose('modal1')(); } }]}
-          wrapProps={{ onTouchStart: this.onWrapTouchStart }}
+          wrapProps={{ onTouchStart: this.wrapOnTouchStart }}
         >
           <div style={{ height: 100, overflow: 'scroll' }}>
             scoll content...<br />


### PR DESCRIPTION
Makes much more sense grammar-wise

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/2535)
<!-- Reviewable:end -->
