### PR TITLE
fix(input-item): user experience regression on non-mutate control

### DIFF
--- a/components/input-item/index.tsx
+++ b/components/input-item/index.tsx
@@ -88,37 +88,37 @@ class InputItem extends React.Component<InputItemProps, any> {
   }
 
   onInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    let value = e.target.value;
+    const { value } = e.target;
     const { type } = this.props;
 
+    let newValue = value;
     switch (type) {
-      case 'text':
-        break;
       case 'bankCard':
-        value = value.replace(/\D/g, '').replace(/(....)(?=.)/g, '$1 ');
+        newValue = value.replace(/\D/g, '').replace(/(....)(?=.)/g, '$1 ');
         break;
       case 'phone':
-        value = value.replace(/\D/g, '').substring(0, 11);
-        const valueLen = value.length;
+        newValue = value.replace(/\D/g, '').substring(0, 11);
+        const valueLen = newValue.length;
         if (valueLen > 3 && valueLen < 8) {
-          value = `${value.substr(0, 3)} ${value.substr(3)}`;
+          newValue = `${newValue.substr(0, 3)} ${newValue.substr(3)}`;
         } else if (valueLen >= 8) {
-          value = `${value.substr(0, 3)} ${value.substr(3, 4)} ${value.substr(
+          newValue = `${newValue.substr(0, 3)} ${newValue.substr(3, 4)} ${newValue.substr(
             7,
           )}`;
         }
         break;
       case 'number':
-        value = value.replace(/\D/g, '');
+        newValue = value.replace(/\D/g, '');
         break;
+      case 'text':
       case 'password':
-        break;
       default:
         break;
     }
-    this.handleOnChange(value);
+    this.handleOnChange(newValue, newValue !== value);
   }
-  handleOnChange = (value: string) => {
+
+  handleOnChange = (value: string, isMutated: boolean = false) => {
     const { onChange } = this.props;
 
     if (!('value' in this.props)) {
@@ -127,7 +127,7 @@ class InputItem extends React.Component<InputItemProps, any> {
       this.setState({ value: this.props.value });
     }
     if (onChange) {
-      setTimeout(() => onChange(value));
+      isMutated ? setTimeout(() => onChange(value)) : onChange(value);
     }
   }
   onInputFocus = (value: string) => {


### PR DESCRIPTION
PR #2532 会引起一个问题：在输入的内容中间插入或删除字符的时候，光标会被重置到末尾，体验很差。

该PR将区分对待 onChange 过程中**可能会**改变原始值的场景（bankCard、phone、number），对其他类型不做延迟 `onChange`。

* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/2537)
<!-- Reviewable:end -->
