### PR TITLE
feat(input-item): add "moneyKeyboardWrapProps"

### DIFF
--- a/components/input-item/CustomInput.tsx
+++ b/components/input-item/CustomInput.tsx
@@ -15,6 +15,7 @@ export interface NumberInputProps {
   disabled?: boolean;
   editable?: boolean;
   moneyKeyboardAlign?: 'left' | 'right' | string;
+  moneyKeyboardWrapProps?: object;
   value?: string;
   prefixCls?: string;
   keyboardPrefixCls?: string;
@@ -98,6 +99,7 @@ class NumberInput extends React.Component<NumberInputProps, any> {
       backspaceLabel,
       cancelKeyboardLabel,
       keyboardPrefixCls,
+      moneyKeyboardWrapProps,
     } = this.props;
 
     return (
@@ -108,6 +110,7 @@ class NumberInput extends React.Component<NumberInputProps, any> {
         confirmLabel={confirmLabel}
         backspaceLabel={backspaceLabel}
         cancelKeyboardLabel={cancelKeyboardLabel}
+        wrapProps={moneyKeyboardWrapProps}
       />
     );
   }

--- a/components/input-item/CustomKeyboard.tsx
+++ b/components/input-item/CustomKeyboard.tsx
@@ -95,12 +95,14 @@ class CustomKeyboard extends React.Component<any, any> {
       </KeyboardItem>
     );
   }
+
   render() {
     const {
       prefixCls,
       confirmLabel,
       backspaceLabel,
       cancelKeyboardLabel,
+      wrapProps,
     } = this.props;
 
     const wrapperCls = classnames(
@@ -109,7 +111,7 @@ class CustomKeyboard extends React.Component<any, any> {
     );
 
     return (
-      <div className={wrapperCls} ref={el => (this.antmKeyboard = el)}>
+      <div className={wrapperCls} ref={el => (this.antmKeyboard = el)} {...wrapProps}>
         <table>
           <tbody>
             <tr>

--- a/components/input-item/PropsType.tsx
+++ b/components/input-item/PropsType.tsx
@@ -4,6 +4,7 @@ export type InputEventHandler = (value?: string) => void;
 export interface InputItemPropsType {
   /** web only */
   moneyKeyboardAlign?: string;
+  moneyKeyboardWrapProps?: object;
   type?:
     | 'text'
     | 'bankCard'

--- a/components/input-item/demo/money.md
+++ b/components/input-item/demo/money.md
@@ -17,6 +17,17 @@ Recommended use of [rc-form ](https://github.com/react-component/form) for contr
 import { List, InputItem } from 'antd-mobile';
 import { createForm } from 'rc-form';
 
+// 通过自定义 moneyKeyboardWrapProps 修复虚拟键盘滚动穿透问题
+// https://github.com/ant-design/ant-design-mobile/issues/307
+// https://github.com/ant-design/ant-design-mobile/issues/163
+const isIPhone = new RegExp('\\biPhone\\b|\\biPod\\b', 'i').test(window.navigator.userAgent);
+let moneyKeyboardWrapProps;
+if (isIPhone) {
+  moneyKeyboardWrapProps = {
+    onTouchStart: e => e.preventDefault(),
+  };
+}
+
 class H5NumberInputExample extends React.Component {
   state = {
     type: 'money',
@@ -34,6 +45,7 @@ class H5NumberInputExample extends React.Component {
             placeholder="start from left"
             clear
             moneyKeyboardAlign="left"
+            moneyKeyboardWrapProps={moneyKeyboardWrapProps}
           >光标在左</InputItem>
           <InputItem
             type={type}
@@ -41,6 +53,7 @@ class H5NumberInputExample extends React.Component {
             clear
             onChange={(v) => { console.log('onChange', v); }}
             onBlur={(v) => { console.log('onBlur', v); }}
+            moneyKeyboardWrapProps={moneyKeyboardWrapProps}
           >光标在右</InputItem>
           <InputItem
             {...getFieldProps('money2', {
@@ -58,6 +71,7 @@ class H5NumberInputExample extends React.Component {
             placeholder="money format"
             ref={el => this.customFocusInst = el}
             clear
+            moneyKeyboardWrapProps={moneyKeyboardWrapProps}
           >数字键盘</InputItem>
           <List.Item>
             <div

--- a/components/input-item/index.en-US.md
+++ b/components/input-item/index.en-US.md
@@ -18,7 +18,7 @@ Support WEB, React-Native.
 
 **`InputItem` must wrapped by a [List](https://mobile.ant.design/components/list)**
 
-Properties | Descrition | Type | Default
+Properties | Description | Type | Default
 -----------|------------|------|--------
 | type    | can be `bankCard`; `phone`(which the maxLength is 11 and setting will be ignored); `password`; `number`(in order to evoke the 'numeric keyboard with decimal', this type is not a native number, but `<input type="text" pattern="[0-9]*"/>`); `digit`(represent the native type number); `money`(analog numeric keyboard with decimal,`Web Only`); As well as other standard html input type values. | String |  `text`  |
 | value | the value of input (see [react doc](https://facebook.github.io/react/docs/forms.html) for more information about controled component)  | String | |
@@ -40,6 +40,7 @@ Properties | Descrition | Type | Default
 | prefixListCls (`web only`)    |   the class name prefix of list      | String |  `am-list`  |
 | name (`web only`)   | the name of input       | String |   |
 | moneyKeyboardAlign (`web only`)   | text align direction, only `type='money'` support this api， could be `'left'`, `'right'`       | String |  'right'  |
+| moneyKeyboardWrapProps (`web only`)   | custom money virtual keyboard props  | Object | {} |
 | locale   | 国际化，可覆盖全局`[LocaleProvider](https://mobile.ant.design/components/locale-provider)`的配置,  when`type`is`money`，can cunstom the keyboard confirm item's label | Object: { confirmLabel } |  无 |
 
 > More available react-native `InputItem` API can be found at [react-native TextInput](http://facebook.github.io/react-native/docs/textinput.html)

--- a/components/input-item/index.tsx
+++ b/components/input-item/index.tsx
@@ -50,6 +50,7 @@ class InputItem extends React.Component<InputItemProps, any> {
     labelNumber: 5,
     updatePlaceholder: false,
     moneyKeyboardAlign: 'right',
+    moneyKeyboardWrapProps: {},
   };
 
   static contextTypes = {
@@ -130,6 +131,7 @@ class InputItem extends React.Component<InputItemProps, any> {
       isMutated ? setTimeout(() => onChange(value)) : onChange(value);
     }
   }
+
   onInputFocus = (value: string) => {
     if (this.debounceTimeout) {
       clearTimeout(this.debounceTimeout);
@@ -193,6 +195,7 @@ class InputItem extends React.Component<InputItemProps, any> {
       this.inputRef.focus();
     }
   }
+
   render() {
     const {
       prefixCls,
@@ -205,12 +208,9 @@ class InputItem extends React.Component<InputItemProps, any> {
       className,
       extra,
       labelNumber,
-      onExtraClick,
-      onErrorClick,
-      updatePlaceholder,
       type,
-      locale,
       moneyKeyboardAlign,
+      moneyKeyboardWrapProps,
       ...restProps,
     } = this.props;
     const { name, disabled, maxLength } = restProps;
@@ -307,6 +307,7 @@ class InputItem extends React.Component<InputItemProps, any> {
                 backspaceLabel={backspaceLabel}
                 cancelKeyboardLabel={cancelKeyboardLabel}
                 moneyKeyboardAlign={moneyKeyboardAlign}
+                moneyKeyboardWrapProps={moneyKeyboardWrapProps}
               />
             ) : (
               <Input

--- a/components/input-item/index.zh-CN.md
+++ b/components/input-item/index.zh-CN.md
@@ -43,6 +43,7 @@ subtitle: 文本输入
 | prefixListCls (`web only`)    |   列表 className 前缀      | String |  `am-list`  |
 | name (`web only`)   | input 的 name        | String |  无  |
 | moneyKeyboardAlign (`web only`)   | 文字排版起始方向, 只有 `type='money'` 支持， 可选为 `'left'`, `'right'`       | String |  'right'  |
+| moneyKeyboardWrapProps (`web only`)   | 自定义金额虚拟键盘属性  | Object | {} |
 | locale   | 国际化，可覆盖全局`[LocaleProvider](https://mobile.ant.design/components/locale-provider)`的配置, 当`type`为`money`，可以自定义确认按钮的文案。 | Object: { confirmLabel } |  无 |
 
 > 更多 react-native `InputItem` 属性请参考 react-native TextInput (http://facebook.github.io/react-native/docs/textinput.html)


### PR DESCRIPTION
This commit add a new property to InputItem. Allow user to add
customized props to virtual money keyboard.

Fixed: #2247 

* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

*isNewFeature* **:**

  * [x] Update API docs for the component.
  * [x] Update/Add demo to demonstrate new feature.
  * [x] Update TypeScript definition for the component.
  * [x] Add unit tests for the feature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/2550)
<!-- Reviewable:end -->
