### PR TITLE
References window only on client for CustomKeyboard

### DIFF
--- a/components/calendar/__tests__/__snapshots__/index.test.js.snap
+++ b/components/calendar/__tests__/__snapshots__/index.test.js.snap
@@ -2320,6 +2320,28 @@ exports[`Calendar renders correctly 1`] = `
                         <div
                           class="date"
                         >
+                          29
+                        </div>
+                        <span
+                          class="right"
+                        />
+                      </div>
+                      <div
+                        class="info"
+                      />
+                    </div>
+                    <div
+                      class="cell "
+                    >
+                      <div
+                        class="date-wrapper"
+                      >
+                        <span
+                          class="left"
+                        />
+                        <div
+                          class="date"
+                        >
                           30
                         </div>
                         <span

--- a/components/input-item/CustomKeyboard.tsx
+++ b/components/input-item/CustomKeyboard.tsx
@@ -3,8 +3,6 @@ import React from 'react';
 import TouchFeedback from 'rmc-feedback';
 import { Omit } from '../_util/types';
 
-const IS_IOS = /iphone|ipad|ipod/i.test(window.navigator.userAgent);
-
 export type HTMLTableDataProps = Omit<
   React.HTMLProps<HTMLTableDataCellElement>,
   'onClick'
@@ -76,6 +74,18 @@ class CustomKeyboard extends React.Component<any, any> {
   antmKeyboard: HTMLDivElement | null;
   confirmDisabled: boolean;
   confirmKeyboardItem: HTMLTableDataCellElement | null;
+
+  constructor(props: any) {
+    super(props);
+
+    this.state = { isIOS: false };
+  }
+
+  componentDidMount() {
+    this.setState({
+      isIOS: /iphone|ipad|ipod/i.test(window.navigator.userAgent),
+    });
+  }
 
   onKeyboardClick = (
     e: React.MouseEvent<HTMLTableDataCellElement>,
@@ -169,8 +179,8 @@ class CustomKeyboard extends React.Component<any, any> {
     );
   }
 
-  getAriaAttr(label: string) {
-    if (IS_IOS) {
+  getAriaAttr = (label: string) => {
+    if (this.state.isIOS) {
       return { label, iconOnly: true };
     } else {
       return { role: 'button', 'aria-label': label };


### PR DESCRIPTION
The `<CustomKeyboard />` throws when rendered on server side because it tries to access the window object that it doesn't exist.

It is a bug fix, so I'll add a unit test as soon as possible.
Let me know what do you think about the proposed solution.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/2622)
<!-- Reviewable:end -->
