### PR TITLE
fix: tabs underline render error on some webview

### DIFF
--- a/components/tabs/style/index.less
+++ b/components/tabs/style/index.less
@@ -143,6 +143,8 @@
     &-underline {
       position: absolute;
       border: 1px @tabs-color solid;
+      // force GPU acceleration
+      transform: translate3d(0, 0, 0);
     }
 
     &-animated &-content {


### PR DESCRIPTION
fix https://github.com/ant-design/ant-design-mobile/issues/2672

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/2674)
<!-- Reviewable:end -->
