### PR TITLE
Explicitly set InputItem.defaultProps type to avoid type collision

### DIFF
--- a/components/activity-indicator/index.tsx
+++ b/components/activity-indicator/index.tsx
@@ -12,11 +12,10 @@ export default class ActivityIndicator extends React.Component<
   ActivityIndicatorProps,
   any
 > {
-  static defaultProps = {
+  static defaultProps: Partial<ActivityIndicatorProps> = {
     prefixCls: 'am-activity-indicator',
     animating: true,
     size: 'small',
-    panelColor: 'rgba(34,34,34,0.6)',
     toast: false,
   };
 

--- a/components/badge/index.tsx
+++ b/components/badge/index.tsx
@@ -10,7 +10,7 @@ export interface BadgeProps extends BadgePropsTypes {
 }
 
 export default class Badge extends React.Component<BadgeProps, any> {
-  static defaultProps = {
+  static defaultProps: Partial<BadgeProps> = {
     prefixCls: 'am-badge',
     size: 'small',
     overflowCount: 99,

--- a/components/button/index.tsx
+++ b/components/button/index.tsx
@@ -41,7 +41,7 @@ function insertSpace(child: any) {
 }
 
 class Button extends React.Component<ButtonProps, any> {
-  static defaultProps = {
+  static defaultProps: Partial<ButtonProps> = {
     prefixCls: 'am-button',
     size: 'large',
     inline: false,

--- a/components/carousel/index.tsx
+++ b/components/carousel/index.tsx
@@ -22,13 +22,11 @@ export default class Carousel extends React.Component<
   CarouselProps,
   CarouselState
 > {
-  static defaultProps = {
+  static defaultProps: Partial<CarouselProps> = {
     prefixCls: 'am-carousel',
     dots: true,
-    arrows: false,
     autoplay: false,
     infinite: false,
-    cellAlign: 'center',
     selectedIndex: 0,
     dotStyle: {},
     dotActiveStyle: {},

--- a/components/date-picker-view/date-picker-view.tsx
+++ b/components/date-picker-view/date-picker-view.tsx
@@ -8,13 +8,12 @@ export default class DatePickerView extends React.Component<
   DatePickerProps,
   any
 > {
-  static defaultProps = {
+  static defaultProps: Partial<DatePickerProps> = {
     mode: 'datetime',
     extra: '请选择',
     prefixCls: 'am-picker',
     pickerPrefixCls: 'am-picker-col',
     minuteStep: 1,
-    use12Hours: false,
   };
 
   static contextTypes = {

--- a/components/date-picker/index.tsx
+++ b/components/date-picker/index.tsx
@@ -17,7 +17,7 @@ export interface PropsType extends DatePickerPropsType {
   onVisibleChange?: (visible: boolean) => void;
 }
 export default class DatePicker extends React.Component<PropsType, any> {
-  static defaultProps = {
+  static defaultProps: Partial<PropsType> = {
     mode: 'datetime',
     prefixCls: 'am-picker',
     pickerPrefixCls: 'am-picker-col',

--- a/components/flex/Flex.tsx
+++ b/components/flex/Flex.tsx
@@ -14,7 +14,7 @@ export interface FlexProps extends BasePropsType {
 export default class Flex extends React.Component<FlexProps, any> {
   static Item: any;
 
-  static defaultProps = {
+  static defaultProps: Partial<FlexProps> = {
     prefixCls: 'am-flexbox',
     align: 'center',
   };

--- a/components/icon/index.tsx
+++ b/components/icon/index.tsx
@@ -14,7 +14,7 @@ export interface IconProps extends IconPropsType, SvgProps {
 }
 
 export default class Icon extends React.Component<IconProps, any> {
-  static defaultProps = {
+  static defaultProps: Partial<IconProps> = {
     size: 'md',
   };
   componentDidMount() {

--- a/components/input-item/index.tsx
+++ b/components/input-item/index.tsx
@@ -32,7 +32,7 @@ function normalizeValue(value?: string) {
 }
 
 class InputItem extends React.Component<InputItemProps, any> {
-  static defaultProps = {
+  static defaultProps: Partial<InputItemProps> = {
     prefixCls: 'am-input',
     prefixListCls: 'am-list',
     type: 'text',

--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -40,14 +40,13 @@ export interface ModalProps extends ModalPropsType<React.CSSProperties> {
 }
 
 export default class Modal extends ModalComponent<ModalProps, any> {
-  static defaultProps = {
+  static defaultProps: Partial<ModalProps> = {
     prefixCls: 'am-modal',
     transparent: false,
     popup: false,
     animationType: 'slide-down',
     animated: true,
     style: {},
-    onShow() {},
     footer: [],
     closable: false,
     operation: false,

--- a/components/nav-bar/index.tsx
+++ b/components/nav-bar/index.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { NavBarProps } from './PropsType';
 
 export default class NavBar extends React.Component<NavBarProps, any> {
-  static defaultProps = {
+  static defaultProps: Partial<NavBarProps> = {
     prefixCls: 'am-navbar',
     mode: 'dark',
     onLeftClick: () => {},

--- a/components/notice-bar/index.tsx
+++ b/components/notice-bar/index.tsx
@@ -12,9 +12,8 @@ export interface NoticeWebProps extends NoticeBarPropsType {
 }
 
 export default class NoticeBar extends React.Component<NoticeWebProps, any> {
-  static defaultProps = {
+  static defaultProps: Partial<NoticeWebProps> = {
     prefixCls: 'am-notice-bar',
-    mode: '',
     icon: <Icon type="voice" size="xxs" />,
     onClick() {},
   };

--- a/components/pagination/index.tsx
+++ b/components/pagination/index.tsx
@@ -15,7 +15,7 @@ export default class Pagination extends React.Component<
   PaginationProps,
   PaginationState
 > {
-  static defaultProps = {
+  static defaultProps: Partial<PaginationProps> = {
     prefixCls: 'am-pagination',
     mode: 'button',
     current: 1,

--- a/components/picker-view/PickerView.tsx
+++ b/components/picker-view/PickerView.tsx
@@ -30,7 +30,7 @@ export interface IPickerView {
 }
 
 export default class PickerView extends React.Component<IPickerView, any> {
-  static defaultProps = getDefaultProps();
+  static defaultProps: Partial<IPickerView> = getDefaultProps();
 
   getCol = () => {
     const { data, pickerPrefixCls, indicatorStyle, itemStyle } = this.props;

--- a/components/popover/index.tsx
+++ b/components/popover/index.tsx
@@ -43,11 +43,9 @@ function recursiveCloneChildren(
 }
 
 export default class Popover extends React.Component<PopOverPropsType, any> {
-  static defaultProps = {
+  static defaultProps: Partial<PopOverPropsType> = {
     prefixCls: 'am-popover',
     placement: 'bottomRight',
-    align: { overflow: { adjustY: 0, adjustX: 0 } },
-    trigger: ['click'],
   };
   static Item = Item;
 

--- a/components/progress/index.tsx
+++ b/components/progress/index.tsx
@@ -10,7 +10,7 @@ export interface ProgressProps extends ProgressPropsType {
 }
 
 export default class Progress extends React.Component<ProgressProps, any> {
-  static defaultProps = {
+  static defaultProps: Partial<ProgressProps> = {
     prefixCls: 'am-progress',
     percent: 0,
     position: 'fixed',

--- a/components/result/index.tsx
+++ b/components/result/index.tsx
@@ -11,9 +11,8 @@ export interface ResultProps extends ResultPropsType {
 }
 
 export default class Result extends React.Component<ResultProps, any> {
-  static defaultProps = {
+  static defaultProps: Partial<ResultProps> = {
     prefixCls: 'am-result',
-    buttonType: '',
     onButtonClick: () => {},
   };
 

--- a/components/search-bar/index.tsx
+++ b/components/search-bar/index.tsx
@@ -30,7 +30,7 @@ export default class SearchBar extends React.Component<
   SearchBarProps,
   SearchBarState
 > {
-  static defaultProps = defaultProps;
+  static defaultProps: Partial<SearchBarProps> = defaultProps;
 
   static contextTypes = {
     antLocale: PropTypes.object,

--- a/components/steps/index.tsx
+++ b/components/steps/index.tsx
@@ -13,7 +13,7 @@ export interface StepsProps extends StepsPropsType {
 export default class Steps extends React.Component<StepsProps, any> {
   static Step = (RcSteps as any).Step;
 
-  static defaultProps = {
+  static defaultProps: Partial<StepsProps> = {
     prefixCls: 'am-steps',
     iconPrefix: 'ant',
     labelPlacement: 'vertical',

--- a/components/switch/index.tsx
+++ b/components/switch/index.tsx
@@ -10,7 +10,7 @@ export interface SwitchProps extends SwitchPropsType {
 }
 
 export default class Switch extends React.Component<SwitchProps, any> {
-  static defaultProps = {
+  static defaultProps: Partial<SwitchProps> = {
     prefixCls: 'am-switch',
     name: '',
     checked: false,

--- a/components/white-space/index.tsx
+++ b/components/white-space/index.tsx
@@ -10,7 +10,7 @@ export interface WhiteSpaceProps extends WhiteSpacePropsType {
 }
 
 export default class WhiteSpace extends React.Component<WhiteSpaceProps, any> {
-  static defaultProps = {
+  static defaultProps: Partial<WhiteSpaceProps> = {
     prefixCls: 'am-whitespace',
     size: 'md',
   };

--- a/components/wing-blank/index.tsx
+++ b/components/wing-blank/index.tsx
@@ -9,7 +9,7 @@ export interface WingBlankProps extends WingBlankPropsType {
 }
 
 export default class WingBlank extends React.Component<WingBlankProps, any> {
-  static defaultProps = {
+  static defaultProps: Partial<WingBlankProps> = {
     prefixCls: 'am-wingblank',
     size: 'lg',
   };


### PR DESCRIPTION
The generated type for `InputItem.defaultProps.type` (string) is not the same as `InputItemPropsType.type` (union of string literals). This causes problem when using antd together with `styled-components`. 

![image](https://user-images.githubusercontent.com/510089/44268976-be208900-a265-11e8-9c64-d4ec2d076a58.png)

Similar practice can be found in `ListItem` and `AntTabBar`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/2785)
<!-- Reviewable:end -->
