### PR TITLE
fix: line break cause textareaItem word count corrupt for iOS （#1265)

### DIFF
--- a/components/textarea-item/index.tsx
+++ b/components/textarea-item/index.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import TouchFeedback from 'rmc-feedback';
 import { TextAreaItemPropsType } from './PropsType';
 import { Omit } from '../_util/types';
+import { IS_IOS } from '../_util/exenv';
 export type HTMLTextAreaProps = Omit<
   React.HTMLProps<HTMLInputElement>,
   | 'onChange'
@@ -216,8 +217,17 @@ export default class TextareaItem extends React.Component<
     const characterLength = countSymbols(value);
     const lengthCtrlProps: any = {};
     if (count! > 0) {
-      lengthCtrlProps.maxLength =
-        count! - characterLength + (value ? value.length : 0);
+      // Note: If in the iOS environment of dev-tools, It will fail.
+      if (IS_IOS) {
+        const entValue = value ? value.replace(regexAstralSymbols, '_') : '';
+        const entLen = entValue ? entValue.split('_').length - 1 : 0;
+        lengthCtrlProps.maxLength =
+          count! + entLen - characterLength + (value ? value.length : 0);
+      } else {
+        lengthCtrlProps.maxLength =
+          count! - characterLength + (value ? value.length : 0);
+      }
+
     }
     return (
       <div className={wrapCls}>


### PR DESCRIPTION
First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [x] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/2825)
<!-- Reviewable:end -->
