### PR TITLE
fix: add Carousel missing property-declaration

### DIFF
--- a/components/carousel/index.tsx
+++ b/components/carousel/index.tsx
@@ -3,6 +3,8 @@ import React, { CSSProperties } from 'react';
 import ReactCarousel from 'rmc-nuka-carousel';
 import { CarouselPropsType } from './PropsType';
 
+type IFrameOverFlow = 'visible' | 'hidden';
+
 export interface CarouselProps extends CarouselPropsType {
   className?: string;
   prefixCls?: string;
@@ -13,6 +15,9 @@ export interface CarouselProps extends CarouselPropsType {
   style?: CSSProperties;
   dotStyle?: CSSProperties;
   dotActiveStyle?: CSSProperties;
+  frameOverflow?: IFrameOverFlow;
+  cellSpacing?: number;
+  slideWidth?: string | number;
 }
 export interface CarouselState {
   selectedIndex?: number;


### PR DESCRIPTION
First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

---

`<Carousel />` Component missing three property-declaration.

`frameOverflow`, `cellSpacing` and `slideWidth`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/2848)
<!-- Reviewable:end -->
