### PR TITLE
fix: Enter long punctuation mark texarea-item without wrap

### DIFF
--- a/components/textarea-item/style/index.less
+++ b/components/textarea-item/style/index.less
@@ -97,7 +97,7 @@
     overflow: visible;
     display: block;
     resize: none;
-    word-break: break-all;
+    word-break: break-word;
     word-wrap: break-word;
 
     &::placeholder {


### PR DESCRIPTION
### 中文（简体）说明：
当我使用TextareaItem组件时，在多行文本框中输入长标点符号...............................或者。。。。。。。。。。。,组件并不能自动换行。原因是textarea css样式中的word-break:break-all和word-wrap:break-word共同使用的时候，长标点符号并不能换行

* 问题在华为荣耀honor 7c以及chrome浏览器上都经过测试，都出现了一样的问题
* 去掉word-break属性或者设置word-break: break-word;都可以解决这个问题

可在 https://mobile.ant.design/components/textarea-item-cn/ 中输入............进行测试
![image](https://user-images.githubusercontent.com/27266016/46711720-154c4400-cc80-11e8-992e-6fe697625768.png)
如图出现滚动条，我想这应该是个常见的bug，毕竟不是所有人都像我这么无聊去乱输入。


### English Description

When I use the TextareaItem component, enter a long punctuation in the multiline text box............................... or. . . . . . . . . . . The component does not automatically wrap. The reason is that when the word-break:break-all and word-wrap:break-word are used together in the textarea css style, the long punctuation does not wrap.

* The problem has been tested on Huawei  honor 7c and chrome browser, all have the same problem
* Removing the word-break attribute or setting word-break: break-word; can solve this problem.

参考链接：
* [word-break:break-all和word-wrap:break-word的区别](https://www.zhangxinxu.com/wordpress/2015/11/diff-word-break-break-all-word-wrap-break-word/)
* [MDN word-break](https://developer.mozilla.org/en-US/docs/Web/CSS/word-break)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/2881)
<!-- Reviewable:end -->
