### PR TITLE
action-sheet support badge  动作面板支持徽标

### DIFF
--- a/components/action-sheet/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/action-sheet/__tests__/__snapshots__/demo.test.js.snap
@@ -22,6 +22,18 @@ exports[`renders ./components/action-sheet/demo/basic.md correctly 1`] = `
     role="button"
   >
     <span>
+      showActionSheet&Badge
+    </span>
+  </a>
+  <div
+    class="am-whitespace am-whitespace-md"
+  />
+  <a
+    aria-disabled="false"
+    class="am-button"
+    role="button"
+  >
+    <span>
       showShareActionSheet
     </span>
   </a>

--- a/components/action-sheet/demo/basic.md
+++ b/components/action-sheet/demo/basic.md
@@ -85,9 +85,42 @@ class Test extends React.Component {
     });
   }
 
+  showActionSheetBadge = () => {
+    const BUTTONS = ['Operation1', 'Operation2', 'Operation3', 'Operation4', 'Operation5', 'Delete', 'Cancel'];
+    const BADGES = [{
+      index: 1,
+      dot: true,
+    }, {
+      index: 2,
+      text: 3100,
+    }, {
+      index: 3,
+      text: '推荐',
+    }, {
+      index: 4,
+      text: '···',
+    }];
+    ActionSheet.showActionSheetWithOptions({
+      options: BUTTONS,
+      cancelButtonIndex: BUTTONS.length - 1,
+      destructiveButtonIndex: BUTTONS.length - 2,
+      badges: BADGES,
+      // title: 'title',
+      message: 'I am description, description, description',
+      maskClosable: true,
+      'data-seed': 'logId',
+      wrapProps,
+    },
+    (buttonIndex) => {
+      this.setState({ clicked: BUTTONS[buttonIndex] });
+    });
+  }
+
   render() {
     return (<WingBlank>
       <Button onClick={this.showActionSheet}>showActionSheet</Button>
+      <WhiteSpace />
+      <Button onClick={this.showActionSheetBadge}>showActionSheet&Badge</Button>
       <WhiteSpace />
       <Button onClick={this.showShareActionSheet}>showShareActionSheet</Button>
       <WhiteSpace />

--- a/components/action-sheet/index.en-US.md
+++ b/components/action-sheet/index.en-US.md
@@ -20,6 +20,7 @@ The modal box pops up from the bottom, providing more than two actions related t
 Display a action sheet. The `options` object must contain one or more of:
 
 - options (array of strings) - a list of button titles (required)
+- badges (array of `{...Badges, index: number}`) -  a list of badges
 - cancelButtonIndex (int) - index of cancel button in `options`
 - destructiveButtonIndex (int) - index of destructive button in `options`
 - title (string) - a title to show above the action sheet

--- a/components/action-sheet/index.tsx
+++ b/components/action-sheet/index.tsx
@@ -123,7 +123,7 @@ function createActionSheet(
         badges.forEach(( element: BadgesOption ) => {
           if (element.index >= 0) {
             badgesMap[element.index] = (
-              <Badge {...element} className={`${prefixCls}-button-list-badge`}/>
+              <Badge {...element} />
             );
           }
         });
@@ -142,15 +142,22 @@ function createActionSheet(
                 onClick: () => cb(index),
                 role: 'button',
               };
+              let bContent = <div {...itemProps}>
+                {item}
+              </div>;
+              // 仅在设置徽标的情况下修改dom结构
+              if (badgesMap[index]) {
+                bContent = <div {...itemProps} className={`${itemProps.className} ${prefixCls}-button-list-badge`}>
+                  <span className={`${prefixCls}-button-list-item-content`}>{item}</span>
+                  {badgesMap[index]}
+                </div>;
+              }
               let bItem = (
                 <TouchFeedback
                   key={index}
                   activeClassName={`${prefixCls}-button-list-item-active`}
                 >
-                  <div {...itemProps}>
-                    <span className={`${prefixCls}-button-list-item-content`}>{item}</span>
-                    { badgesMap[index] }
-                  </div>
+                  {bContent}
                 </TouchFeedback>
               );
               if (
@@ -163,7 +170,7 @@ function createActionSheet(
                     activeClassName={`${prefixCls}-button-list-item-active`}
                   >
                     <div {...itemProps}>
-                      <span className={`${prefixCls}-button-list-item-content`}>{item}</span>
+                      {item}
                       {cancelButtonIndex === index ? (
                         <span className={`${prefixCls}-cancel-button-mask`} />
                       ) : null}

--- a/components/action-sheet/index.tsx
+++ b/components/action-sheet/index.tsx
@@ -5,6 +5,7 @@ import ReactDOM from 'react-dom';
 import Dialog from 'rmc-dialog';
 import TouchFeedback from 'rmc-feedback';
 import getDataAttr from '../_util/getDataAttr';
+import Badge, { BadgeProps } from '../badge';
 
 const NORMAL = 'NORMAL';
 const SHARE = 'SHARE';
@@ -28,10 +29,16 @@ export interface ShareOption {
 
 export interface ShareActionSheetWithOptions extends ActionSheetOptions {
   options: ShareOption[] | ShareOption[][];
+  badges?: BadgesOption[];
+}
+export interface BadgesOption extends BadgeProps{
+  index: number;
 }
 export interface ActionSheetWithOptions extends ActionSheetOptions {
   options: string[];
+  badges?: BadgesOption[];
 }
+
 export type ActionCallBack = (
   index: number,
   rowIndex?: number,
@@ -91,6 +98,7 @@ function createActionSheet(
     destructiveButtonIndex,
     cancelButtonIndex,
     cancelButtonText,
+    badges = [],
   } = props;
   const titleMsg = [
     title ? (
@@ -110,6 +118,16 @@ function createActionSheet(
     case NORMAL:
       mode = 'normal';
       const normalOptions = options as string[];
+      const badgesMap: any = {};
+      if(badges && badges.length > 0){
+        badges.forEach(( element: BadgesOption ) => {
+          if (element.index >= 0) {
+            badgesMap[element.index] = (
+              <Badge {...element} className={`${prefixCls}-button-list-badge`}/>
+            );
+          }
+        });
+      }
       children = (
         <div {...getDataAttr(props)}>
           {titleMsg}
@@ -129,7 +147,10 @@ function createActionSheet(
                   key={index}
                   activeClassName={`${prefixCls}-button-list-item-active`}
                 >
-                  <div {...itemProps}>{item}</div>
+                  <div {...itemProps}>
+                    <span className={`${prefixCls}-button-list-item-content`}>{item}</span>
+                    { badgesMap[index] }
+                  </div>
                 </TouchFeedback>
               );
               if (
@@ -142,7 +163,7 @@ function createActionSheet(
                     activeClassName={`${prefixCls}-button-list-item-active`}
                   >
                     <div {...itemProps}>
-                      {item}
+                      <span className={`${prefixCls}-button-list-item-content`}>{item}</span>
                       {cancelButtonIndex === index ? (
                         <span className={`${prefixCls}-cancel-button-mask`} />
                       ) : null}

--- a/components/action-sheet/index.zh-CN.md
+++ b/components/action-sheet/index.zh-CN.md
@@ -21,6 +21,7 @@ subtitle: 动作面板
 显示 action sheet，`options`对象必须包含以下的一个或者多个：
 
 - options (array of strings) - 按钮标题列表 (required)
+- badges (array of `{...Badges, index: number}`) -  徽标数列表
 - cancelButtonIndex (int) - 按钮列表中取消按钮的索引位置
 - destructiveButtonIndex (int) - 按钮列表中破坏性按钮（一般为删除）的索引位置
 - title (string) - 顶部标题

--- a/components/action-sheet/style/index.less
+++ b/components/action-sheet/style/index.less
@@ -37,23 +37,28 @@
 
     &-item {
       font-size: @actionsheet-item-font-size;
-      padding: 0;
+      padding: 0 8 * @hd;
       margin: 0;
       position: relative;
       height: @actionsheet-item-height;
       line-height: @actionsheet-item-height;
       box-sizing: border-box;
-      display: flex;
-      align-items: center;
-      justify-content: center;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      overflow-x: hidden;
       .hairline('top');
       &&-active {
         background-color: @fill-tap;
       }
     }
     &-badge {
-      margin-left: 8 * @hd;
-      flex-shrink: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      .am-badge {
+        margin-left: 8 * @hd;
+        flex-shrink: 0;
+      }
     }
     &-item-content {
       display: inline-block;
@@ -62,12 +67,12 @@
       text-overflow: ellipsis;
     }
     .@{ActionSheetPrefixCls}-cancel-button {
-      margin-top: @v-spacing-sm;
+      padding-top: @v-spacing-sm;
       position: relative;
 
       &-mask {
         position: absolute;
-        top: -@v-spacing-sm;
+        top: 0;
         left: 0;
         width: 100%;
         height: @v-spacing-sm;

--- a/components/action-sheet/style/index.less
+++ b/components/action-sheet/style/index.less
@@ -43,12 +43,24 @@
       height: @actionsheet-item-height;
       line-height: @actionsheet-item-height;
       box-sizing: border-box;
+      display: flex;
+      align-items: center;
+      justify-content: center;
       .hairline('top');
       &&-active {
         background-color: @fill-tap;
       }
     }
-
+    &-badge {
+      margin-left: 8 * @hd;
+      flex-shrink: 0;
+    }
+    &-item-content {
+      display: inline-block;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
     .@{ActionSheetPrefixCls}-cancel-button {
       margin-top: @v-spacing-sm;
       position: relative;

--- a/components/action-sheet/style/index.tsx
+++ b/components/action-sheet/style/index.tsx
@@ -1,2 +1,3 @@
 import '../../style/';
+import '../../badge/style/';
 import './index.less';


### PR DESCRIPTION
Extra checklist:

*isBugFix*

  * [ ] Fixed action-sheet item css problem when the options item is too long.  当option某项值过长时的样式问题

*isNewFeature*

  * [ ] Support badges in action-sheet item.  动作面板支持徽标


demo：
```
const BUTTONS = ['Operation1', 'Operation2', 'Operation3', 'Operation4', 'Operation5', 'Delete', 'Cancel'];
    const BADGES = [{
      // 对应options配置的下标，从0开始
      index: 1,
      dot: true,
    }, {
      index: 2,
      text: 3100,
    }, {
      index: 3,
      text: '推荐',
    }, {
      index: 4,
      text: '···',
    }];
    ActionSheet.showActionSheetWithOptions({
      options: BUTTONS,
      cancelButtonIndex: BUTTONS.length - 1,
      destructiveButtonIndex: BUTTONS.length - 2,
      // 徽标数组
      badges: BADGES,
      // title: 'title',
      message: 'I am description, description, description',
      maskClosable: true,
      'data-seed': 'logId',
      wrapProps,
    },
    (buttonIndex) => {
      this.setState({ clicked: BUTTONS[buttonIndex] });
    });
```
demo image:
![image](https://user-images.githubusercontent.com/8652036/48200952-a73c8f00-e39b-11e8-9e26-cd94eeadf01a.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/2948)
<!-- Reviewable:end -->
