### PR TITLE
Fix#3000 and Fix inputItem make Picker unable to click in Wechat with IOS12;

### DIFF
--- a/components/input-item/index.tsx
+++ b/components/input-item/index.tsx
@@ -161,10 +161,13 @@ class InputItem extends React.Component<InputItemProps, any> {
       }, 200);
     }
     if (this.props.onBlur) {
-      // fix ios12 wechat browser click failure after input
-      if (document.body) {
-        document.body.scrollTop = document.body.scrollTop;
-      }
+      // fix autoFocus item blur with flash
+      setTimeout(() => {
+        // fix ios12 wechat browser click failure after input
+        if (document.body) {
+          document.body.scrollTop = document.body.scrollTop;
+        }
+      },100);
       this.props.onBlur(value);
     }
   }

--- a/components/input-item/index.tsx
+++ b/components/input-item/index.tsx
@@ -161,6 +161,10 @@ class InputItem extends React.Component<InputItemProps, any> {
       }, 200);
     }
     if (this.props.onBlur) {
+      // fix ios12 wechat browser click failure after input
+      if (document.body) {
+        document.body.scrollTop = document.body.scrollTop;
+      }
       this.props.onBlur(value);
     }
   }

--- a/components/search-bar/index.tsx
+++ b/components/search-bar/index.tsx
@@ -164,6 +164,13 @@ export default class SearchBar extends React.Component<
       this.blurFromOnClear = false;
     });
     if (this.props.onBlur) {
+      // fix autoFocus item blur with flash
+      setTimeout(() => {
+        // fix ios12 wechat browser click failure after input
+        if (document.body) {
+          document.body.scrollTop = document.body.scrollTop;
+        }
+      },100);
       this.props.onBlur();
     }
   }

--- a/components/textarea-item/index.tsx
+++ b/components/textarea-item/index.tsx
@@ -137,6 +137,13 @@ export default class TextareaItem extends React.Component<
     }, 100);
     const value = e.currentTarget.value;
     if (this.props.onBlur) {
+      // fix autoFocus item blur with flash
+      setTimeout(() => {
+        // fix ios12 wechat browser click failure after input
+        if (document.body) {
+          document.body.scrollTop = document.body.scrollTop;
+        }
+      },100);
       this.props.onBlur(value);
     }
   }


### PR DESCRIPTION
First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [x] fix while height over 100% input-item make picker can't touch in wechat with ios 12.

#3000 fix it;

repo: https://codesandbox.io/s/j2j44wxj95
device: ios12.1,iphoneXr/iphone 8p/iphone 6s
software: wechat 7.0.0

zh:
修复IOS12.1下微信6.7.4~7.0.0版本网页中：
当小键盘弹出收缩时，会导致body重新渲染，并且致使触摸层错位。
已提交repo：https://codesandbox.io/s/j2j44wxj95
重现步骤为（PS：Safari正常）：
1. 选中最下方input-item，输入任意字符；
2. 在小键盘没有缩下去情况下点击picker组件；
3. 点击Picker确认发现点击无效。
4. 长按界面当出现选择光标时发现确认键与实际渲染位置不符。

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/3017)
<!-- Reviewable:end -->
