### PR TITLE
fix: react types error with React.MemoExoticComponent and others

### DIFF
--- a/components/date-picker/index.tsx
+++ b/components/date-picker/index.tsx
@@ -117,7 +117,7 @@ export default class DatePicker extends React.Component<PropsType, any> {
       >
         {children &&
           React.isValidElement(children) &&
-          React.cloneElement<object, object>(children, {
+          React.cloneElement<{extra?: string}>(children, {
             extra: value ? formatFn(this, value) : this.props.extra || extra,
           })}
       </PopupDatePicker>

--- a/components/list/PropsType.tsx
+++ b/components/list/PropsType.tsx
@@ -23,5 +23,5 @@ export interface ListItemPropsType {
 export interface BriefProps {
   children?: ReactNode;
   wrap?: boolean;
-  style?: React.CSSProperties | {} | Array<{}>;
+  style?: React.CSSProperties;
 }

--- a/components/picker/AbstractPicker.tsx
+++ b/components/picker/AbstractPicker.tsx
@@ -207,7 +207,7 @@ export default abstract class AbstractPicker extends React.Component<
         {children &&
           typeof children !== 'string' &&
           React.isValidElement(children) &&
-          React.cloneElement<object, object>(children, {
+          React.cloneElement<{extra?: string}>(children, {
             extra: this.getSel() || extra || _locale.extra,
           })}
       </RMCPopupCascader>

--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
   },
   "devDependencies": {
     "@types/prop-types": "^15.5.2",
-    "@types/react": "~16.0.36",
-    "@types/react-dom": "16.0.3",
+    "@types/react": "^16.0.36",
+    "@types/react-dom": "^16.0.3",
     "antd": "3.x",
     "antd-mobile-demo-data": "^0.2.0",
     "antd-tools": "^5.2.0",


### PR DESCRIPTION
@types/react 的版本太低了，新的某些 types api 没有，比如 hoist-non-react-statics 里用到的 MemoExoticComponent

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/3186)
<!-- Reviewable:end -->
