### PR TITLE
fix: iOS9以下svg引起的Modal展示问题

### DIFF
--- a/components/icon/loadSprite.tsx
+++ b/components/icon/loadSprite.tsx
@@ -6,7 +6,7 @@ const svgSprite = (contents: string) => `
     xmlns="http://www.w3.org/2000/svg"
     xmlns:xlink="http://www.w3.org/1999/xlink"
     id="__ANTD_MOBILE_SVG_SPRITE_NODE__"
-    style="position:absolute;width:0;height:0"
+    style="display:none;overflow:hidden;width:0;height:0"
   >
     <defs>
       ${contents}

--- a/components/modal/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/modal/__tests__/__snapshots__/demo.test.js.snap
@@ -67,9 +67,23 @@ exports[`renders ./components/modal/demo/basic.md correctly 1`] = `
     class="am-button"
     role="button"
   >
+    <svg
+      class="am-icon am-icon-up am-icon-md"
+    >
+      <use
+        href="#up"
+      />
+    </svg>
     <span>
       basic
     </span>
+    <svg
+      class="am-icon am-icon-up am-icon-md"
+    >
+      <use
+        href="#up"
+      />
+    </svg>
   </a>
   <div
     class="am-whitespace am-whitespace-md"

--- a/components/modal/demo/basic.md
+++ b/components/modal/demo/basic.md
@@ -14,7 +14,7 @@ title:
 Basic Modal.
 
 ````jsx
-import { Modal, List, Button, WhiteSpace, WingBlank } from 'antd-mobile';
+import { Modal, List, Button, WhiteSpace, WingBlank, Icon } from 'antd-mobile';
 
 function closest(el, selector) {
   const matchesSelector = el.matches || el.webkitMatchesSelector || el.mozMatchesSelector || el.msMatchesSelector;
@@ -61,7 +61,7 @@ class App extends React.Component {
   render() {
     return (
       <WingBlank>
-        <Button onClick={this.showModal('modal1')}>basic</Button>
+        <Button onClick={this.showModal('modal1')}><Icon type="up" />basic<Icon type="up" /></Button>
         <WhiteSpace />
         <Modal
           visible={this.state.modal1}


### PR DESCRIPTION
业务线反馈在iOS 9.2的真机上Modal无法正常展示，初步排查后发现是由于同时使用了Icon组件，经过详细定位后发现是引入Svg的时机问题，如果Svg延后引入就没问题，和 https://github.com/ant-design/ant-design-mobile/blob/caeff3da09935a70814cc7979d604310b7e3522f/components/icon/loadSprite.tsx#L3 描述的问题有点类似，经测试发现把Svg的样式`position: absolute`删除即可解决问题，实测在iOS8、iOS9以及最新的iOS版本均可正常展示

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/3229)
<!-- Reviewable:end -->
