### PR TITLE
fix: 升级antd-mobile-demo-data修复部分Demo在iOS9下白屏的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@types/react": "^16.0.36",
     "@types/react-dom": "^16.0.3",
     "antd": "3.x",
-    "antd-mobile-demo-data": "^0.2.0",
+    "antd-mobile-demo-data": "^0.3.0",
     "antd-tools": "^5.2.0",
     "babel-eslint": "^7.2.3",
     "babel-plugin-import": "^1.6.2",

--- a/site/desktop/src/template/Content/Demo.jsx
+++ b/site/desktop/src/template/Content/Demo.jsx
@@ -121,7 +121,7 @@ export default class Demo extends React.Component {
         'rc-form@1/dist/rc-form.min.js',
         'antd-mobile@2/dist/antd-mobile.min.js',
         'array-tree-filter@2',
-        'antd-mobile-demo-data@0.2',
+        'antd-mobile-demo-data@0.3',
       ]
         .map(url => `https://unpkg.com/${url}`)
         .concat(['https://as.alipayobjects.com/g/component/fastclick/1.0.6/fastclick.js'])


### PR DESCRIPTION
Ref: https://github.com/warmhug/antd-mobile-demo-data/pull/4

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/3292)
<!-- Reviewable:end -->
