### PR TITLE
fix: ios上数字输入框光标闪烁问题，数字输入框左对齐时光标不居中问题

### DIFF
--- a/components/input-item/style/custom-keyboard.less
+++ b/components/input-item/style/custom-keyboard.less
@@ -18,8 +18,8 @@
         left: 0;
         width: 100%;
         height: 100%;
-        padding-right: 1.5 * @hd;
-        margin-right: 3.5 * @hd;
+        padding-right: 2 * @hd;
+        margin-right: 3 * @hd;
         text-decoration: rtl;
         text-align: right;
         color: #000;

--- a/components/input-item/style/custom-keyboard.less
+++ b/components/input-item/style/custom-keyboard.less
@@ -41,8 +41,8 @@
           &::after {
             content: "";
             position: absolute;
-            top: 10%;
             right: 0;
+            top: 10%;
             height: 80%;
             border-right: 1.5 * @hd solid @keyboard-confirm-color;
             animation: keyboard-cursor infinite 1s step-start;
@@ -167,7 +167,7 @@
     opacity: 0;
   }
 
-  100% {
+  to {
     opacity: 1;
   }
 }

--- a/components/input-item/style/custom-keyboard.less
+++ b/components/input-item/style/custom-keyboard.less
@@ -34,11 +34,15 @@
         &.focus {
           transition: color .2s;
 
-          &:after {
+          &::before {
+            content: "";
+          }
+
+          &::after {
             content: "";
             position: absolute;
-            right: 0;
             top: 10%;
+            right: 0;
             height: 80%;
             border-right: 1.5 * @hd solid @keyboard-confirm-color;
             animation: keyboard-cursor infinite 1s step-start;
@@ -60,6 +64,7 @@
           text-align: left;
           &.focus:after {
             position: relative;
+            top: auto;
           }
         }
         .fake-input-placeholder {
@@ -162,7 +167,7 @@
     opacity: 0;
   }
 
-  to {
+  100% {
     opacity: 1;
   }
 }

--- a/components/input-item/style/custom-keyboard.less
+++ b/components/input-item/style/custom-keyboard.less
@@ -18,7 +18,8 @@
         left: 0;
         width: 100%;
         height: 100%;
-        margin-right: 5 * @hd;
+        padding-right: 1.5 * @hd;
+        margin-right: 3.5 * @hd;
         text-decoration: rtl;
         text-align: right;
         color: #000;
@@ -41,7 +42,7 @@
           &::after {
             content: "";
             position: absolute;
-            right: 0;
+            right: 1.5 * @hd;
             top: 10%;
             height: 80%;
             border-right: 1.5 * @hd solid @keyboard-confirm-color;
@@ -63,8 +64,7 @@
         .fake-input {
           text-align: left;
           &.focus:after {
-            position: relative;
-            top: auto;
+            position: static;
           }
         }
         .fake-input-placeholder {
@@ -160,14 +160,14 @@
 
 @keyframes keyboard-cursor {
   0% {
-    opacity: 1;
-  }
-
-  50% {
     opacity: 0;
   }
 
-  to {
+  50% {
     opacity: 1;
+  }
+
+  to {
+    opacity: 0;
   }
 }


### PR DESCRIPTION
修复ios数字键盘after + animation: infinte 导致before元素重复创建问题
修复ios数字键盘左对齐光标不居中问题

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/3385)
<!-- Reviewable:end -->
