### PR TITLE
fix: ImagePicker types

### DIFF
--- a/components/image-picker/PropsType.tsx
+++ b/components/image-picker/PropsType.tsx
@@ -1,16 +1,21 @@
-// import * as React from 'react';
+import * as React from "react";
+
+interface ImageFile {
+  url: string;
+  [key: string]: any
+}
 
 export interface ImagePickerPropTypes {
-  style?: {};
-  files?: Array<{}>;
-  onChange?: (files: Array<{}>, operationType: string, index?: number) => void;
-  onImageClick?: (index?: number, files?: Array<{}>) => void;
-  onAddImageClick?: () => void;
+  style?: React.CSSProperties;
+  files?: Array<ImageFile>;
+  onChange?: (files: Array<ImageFile>, operationType: string, index?: number) => void;
+  onImageClick?: (index?: number, files?: Array<ImageFile>) => void;
+  onAddImageClick?: (e: React.MouseEvent) => void;
   onFail?: (msg: string) => void;
   selectable?: boolean;
   multiple?: boolean;
   accept?: string;
   length?: number | string;
   capture?: any; // 本应该是boolean | string; 但是因为@types/react中interface InputHTMLAttributes<T>定义问题，写成any跳过ts检查
-  disableDelete?: boolean, // 是否隐藏删除按钮，默认false
+  disableDelete?: boolean; // 是否隐藏删除按钮，默认false
 }


### PR DESCRIPTION
First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [ ] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.

好久不见!

files 数组中的文件要指定类型, 使用 `{}` 会造成不便.
onAddImageClick 是有参数的, 示例 "自定义选择图片的方法" 中有用到.

更好的实现是泛型组件:
```tsx
type MyFile = { url: string; id: number }

  <ImagePicker<MyFile> />
```

不知道我们能否接受.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/3491)
<!-- Reviewable:end -->
