### PR TITLE
fix(stepper): 修复stepper组件ts声明没有style的问题

### DIFF
--- a/components/stepper/index.tsx
+++ b/components/stepper/index.tsx
@@ -8,6 +8,7 @@ export interface StepProps extends StepPropsType {
   prefixCls?: string;
   showNumber?: boolean;
   className?: string;
+  style?: React.CSSProperties;
 }
 
 export default class Stepper extends React.Component<StepProps, any> {


### PR DESCRIPTION
Stepper组件使用官网中的示例时，style属性会报ts类型检查错误，代码如下：

https://codesandbox.io/s/nostalgic-cherry-tt7pw?file=/src/App.tsx

因此在StepProps的ts声明中增加style。

错误提示如下：

```
No overload matches this call.
  Overload 1 of 2, '(props: Readonly<StepProps>): Stepper', gave the following error.
    Type '{ style: { width: string; minWidth: string; backgroundColor: string; }; showNumber: true; max: number; min: number; value: number; onChange: (value: number) => void; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Stepper> & Pick<Readonly<StepProps> & Readonly<{ ...; }>, "children" | ... 11 more ... | "name"> & Partial<...> & Partial<...>'.
      Property 'style' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<Stepper> & Pick<Readonly<StepProps> & Readonly<{ ...; }>, "children" | ... 11 more ... | "name"> & Partial<...> & Partial<...>'.
  Overload 2 of 2, '(props: StepProps, context?: any): Stepper', gave the following error.
    Type '{ style: { width: string; minWidth: string; backgroundColor: string; }; showNumber: true; max: number; min: number; value: number; onChange: (value: number) => void; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Stepper> & Pick<Readonly<StepProps> & Readonly<{ ...; }>, "children" | ... 11 more ... | "name"> & Partial<...> & Partial<...>'.
      Property 'style' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<Stepper> & Pick<Readonly<StepProps> & Readonly<{ ...; }>, "children" | ... 11 more ... | "name"> & Partial<...> & Partial<...>'.ts(2769)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/3614)
<!-- Reviewable:end -->
