### PR TITLE
fix: CustomKeyboard container's height is not restored to zero on dis…

### DIFF
--- a/components/input-item/CustomInput.tsx
+++ b/components/input-item/CustomInput.tsx
@@ -191,9 +191,6 @@ class NumberInput extends React.Component<NumberInputProps, any> {
   }
 
   onInputBlur = (value: string) => {
-    if (IS_REACT_16) {
-      this.keyBoard = null;
-    }
     const { focus } = this.state;
     if (focus) {
       this.setState({
@@ -202,6 +199,9 @@ class NumberInput extends React.Component<NumberInputProps, any> {
       this.props.onBlur!(value);
       setTimeout(() => {
         this.unLinkInput();
+        if (IS_REACT_16) {
+          this.keyBoard = null;
+        }
       }, 50);
     }
   }


### PR DESCRIPTION
when set autoAdjustHeight property to true on InputItem, keyboard height is set to Portal container when InputItem get focus.
```javascript
if (this.props.autoAdjustHeight) {
  const keyBoardHeight = customNumberKeyboard.antmKeyboard.offsetHeight;
  this.getContainer().style.height = `${keyBoardHeight}px`;
  ...
}
```

customNumberKeyboard.antmKeyboard is set by using ref callback.
```javascript
// CustomKeyboard
<div className={wrapperCls} ref={el => (this.antmKeyboard = el)} {...wrapProps}>
...
</div>
```

on InputItem blur, CustomKeyboard is unmounted with Portal  by assignning null to this.keyBoard, which makes customNumberKeyboard.antmKeyboard becomes null. so unLinkInput does not work as expected to restore Portal container's height to 0px.
```javascript
  onInputBlur = (value: string) => {
    if (IS_REACT_16) {
      this.keyBoard = null;
    }
    const { focus } = this.state;
    if (focus) {
      this.setState({
        focus: false,
      });
      this.props.onBlur!(value);
      setTimeout(() => {
        this.unLinkInput();
      }, 50);
    }
  }
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ant-design/ant-design-mobile/3688)
<!-- Reviewable:end -->
