### PR TITLE
Fix checkbox error when initial values is no a array

### DIFF
--- a/src/components/checkbox/index.tsx
+++ b/src/components/checkbox/index.tsx
@@ -31,7 +31,7 @@ const Checkbox: FC<CheckboxProps> = props => {
   let disabled = props.disabled
 
   const { value } = props
-  if (groupContext && value) {
+  if (groupContext && Array.isArray(groupContext.value) && value) {
     checked = groupContext.value.includes(value)
     setChecked = (checked: boolean) => {
       if (checked) {


### PR DESCRIPTION
当没有初始化数据，或者初始化数据不是数组时，checkbox 会报错误
![image](https://user-images.githubusercontent.com/11746742/127974822-dc7915f9-ed8b-43fd-af8d-908868f91dc8.png)

重现代码片段
```ts
<Form
            form={form}
            initialValues={
              {
                // checkbox: [],
              }
            }
          >
            <Form.Item name="checkbox" label="字段B" required>
              <Checkbox.Group>
                <Space direction="vertical">
                  <Checkbox value="1">选项1</Checkbox>
                  <Checkbox value="2">选项2</Checkbox>
                  <Checkbox value="3" disabled>
                    选项3
                  </Checkbox>
                </Space>
              </Checkbox.Group>
            </Form.Item>
          </Form>
```
* [ ] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [ ] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [ ] Rebase before creating a PR to keep commit history clear.
* [ ] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.
