### PR TITLE
fix: text-area showCount warning

### DIFF
--- a/src/components/text-area/index.tsx
+++ b/src/components/text-area/index.tsx
@@ -51,6 +51,7 @@ const TextArea = forwardRef<TextAreaRef, TextAreaProps>(
       onChange: outerOnChange,
       rows: rows,
       autoSize: autoSize,
+      showCount,
       ...textAreaProps
     } = props
     const [value, setValue] = useControllableValue<string>(props, {
@@ -110,7 +111,7 @@ const TextArea = forwardRef<TextAreaRef, TextAreaProps>(
             props.onBlur?.(e)
           }}
         />
-        {props.showCount && (
+        {showCount && (
           <div className={`${classPrefix}-count`}>
             {props.maxLength === undefined
               ? value.length


### PR DESCRIPTION
Fix: React does not recognize the `showCount` prop on a DOM element.
![image](https://user-images.githubusercontent.com/11746742/127977292-282d6679-c130-4efc-85fb-ca01db981fb6.png)

* [ ] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [ ] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [ ] Rebase before creating a PR to keep commit history clear.
* [ ] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.
