### PR TITLE
chore: space code style & supports number as size prop

### DIFF
--- a/src/components/space/index.tsx
+++ b/src/components/space/index.tsx
@@ -1,52 +1,58 @@
-import React, { FC } from 'react'
+import React from 'react'
 import classNames from 'classnames'
 import { ElementProps } from '../../utils/element-props'
+import { withDefaultProps } from '../../utils/with-default-props'
 
 const classPrefix = `am-space`
 
 export type SpaceProps = {
-  size?: string | [string, string]
+  size?: number | number[] | string | string[]
   direction?: 'horizontal' | 'vertical'
   align?: 'start' | 'end' | 'center' | 'baseline'
   wrap?: boolean
   block?: boolean
 } & ElementProps
 
-const Space: FC<SpaceProps> = props => {
-  const { size = 'small', direction = 'horizontal' } = props
-  const style: any = props.style ?? {}
-  let sizeStyle: any
-  if (props.size) {
-    const [horizontalSize, verticalSize] = Array.isArray(size)
-      ? size
-      : [size, size]
-    sizeStyle = {
-      '--vertical-size': verticalSize,
-      '--horizontal-size': horizontalSize,
+const Space = withDefaultProps({ direction: 'horizontal' })<SpaceProps>(
+  props => {
+    const { size, direction, style = {} } = props
+    let sizeStyle: any = {}
+    if (size) {
+      const [horizontalSize, verticalSize] = Array.isArray(size)
+        ? size
+        : [size, size]
+      sizeStyle = {
+        '--vertical-size':
+          typeof verticalSize === 'number' ? `${verticalSize}px` : verticalSize,
+        '--horizontal-size':
+          typeof horizontalSize === 'number'
+            ? `${horizontalSize}px`
+            : horizontalSize,
+      }
     }
+    return (
+      <div
+        className={classNames(
+          classPrefix,
+          {
+            [`${classPrefix}-wrap`]: props.wrap,
+            [`${classPrefix}-block`]: props.block,
+            [`${classPrefix}-${direction}`]: true,
+            [`${classPrefix}-align-${props.align}`]: !!props.align,
+          },
+          props.className
+        )}
+        style={{
+          ...sizeStyle,
+          ...style,
+        }}
+      >
+        {React.Children.map(props.children, child => {
+          return <div className={`${classPrefix}-item`}>{child}</div>
+        })}
+      </div>
+    )
   }
-  return (
-    <div
-      className={classNames(
-        classPrefix,
-        {
-          [`${classPrefix}-wrap`]: props.wrap,
-          [`${classPrefix}-block`]: props.block,
-        },
-        `${classPrefix}-${direction}`,
-        props.align && `${classPrefix}-align-${props.align}`,
-        props.className
-      )}
-      style={{
-        ...sizeStyle,
-        ...style,
-      }}
-    >
-      {React.Children.map(props.children, child => {
-        return <div className={`${classPrefix}-item`}>{child}</div>
-      })}
-    </div>
-  )
-}
+)
 
 export default Space


### PR DESCRIPTION
看文档应该只支持直接配置，不支持 'small' 之类的配置。
上面判断了 props.size 下面取的是 size ，虽然都一样，但我还是忍不住调整一下

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [ ] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [ ] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [ ] Rebase before creating a PR to keep commit history clear.
* [ ] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.
