### PR TITLE
Fix missing await in dialog demo

### DIFF
--- a/src/components/dialog/demos/index.tsx
+++ b/src/components/dialog/demos/index.tsx
@@ -184,7 +184,7 @@ export default () => {
           <Button
             block
             onClick={async () => {
-              const result = Dialog.confirm({
+              const result = await Dialog.confirm({
                 content: '人在天边月上明',
               })
               if (result) {


### PR DESCRIPTION
**问题**：在 [v5 alpha (Poplar)](https://next.mobile.ant.design/components/dialog) 网站上，组件列表 -> Dialog -> **等待 confirm 完成** 的Demo 中，点击 **等待 confirm 完成** 按钮就会立即弹出 toast 提示。
**原因：是因为执行代码中缺少了 await 关键字。**


目前已经将 await 添加完成。在点击 **等待 confirm 完成** 按钮时不会弹出提示，在点击 *确定* 或者 *取消* 按钮后，才会弹出对应的 toast 提示。

First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.
