### PR TITLE
style: 删除多余的 CSS 代码

### DIFF
--- a/src/components/picker/picker.less
+++ b/src/components/picker/picker.less
@@ -3,8 +3,7 @@
 .@{class-prefix-picker} {
   width: 100%;
   height: 300px;
-  overflow-y: hidden;
-  overflow-x: hidden;
+  overflow: hidden;
   position: relative;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
`overflow: hidden` 本身已经是 `overflow-y: hidden; overflow-x: hidden;的简写方式` 

截图为`Edge` 浏览器示意图
![image](https://user-images.githubusercontent.com/11674203/131271389-22306268-89b1-4d57-9578-88f8bde43c30.png)
