### PR TITLE
fix: IndexBar children type

### DIFF
--- a/src/components/index-bar/index-bar.tsx
+++ b/src/components/index-bar/index-bar.tsx
@@ -19,6 +19,7 @@ export type IndexBarProps = {
   className?: string
   sticky?: boolean
   stickyOffsetTop?: number
+  children?: React.ReactNode
 } & NativeProps
 
 export type IndexBarRef = {


### PR DESCRIPTION
fix IndexBar children type

![image](https://user-images.githubusercontent.com/18393754/133365893-beec7d87-c416-4a0b-b322-08040db1af35.png)

