### PR TITLE
fix: ImageUploader delete task failed

### DIFF
--- a/src/components/image-uploader/image-uploader.tsx
+++ b/src/components/image-uploader/image-uploader.tsx
@@ -186,7 +186,7 @@ export const ImageUploader: FC<ImageUploaderProps> = p => {
             deletable={task.status !== 'pending'}
             status={task.status}
             onDelete={() => {
-              setValue(value.filter(x => x.url !== task.url))
+              setTasks(tasks.filter(x => x.id !== task.id))
             }}
           />
         ))}


### PR DESCRIPTION
当task上传失败status为fail时，onDelete回调不能正确删除该图片