### PR TITLE
feat: 添加showPercent API，同时解决display的时候，进度条消失

### DIFF
--- a/src/components/progress-bar/demos/index.tsx
+++ b/src/components/progress-bar/demos/index.tsx
@@ -39,6 +39,9 @@ export default () => {
           <ProgressBar percent={100} strokeWidth={8} />
         </Space>
       </DemoBlock>
+      <DemoBlock title='显示进度百分比'>
+        <ProgressBar percent={60} showPercent />
+      </DemoBlock>
       <DemoBlock title='指定颜色'>
         <ProgressBar percent={100} strokeColor='#FF3141' />
       </DemoBlock>

--- a/src/components/progress-bar/index.md
+++ b/src/components/progress-bar/index.md
@@ -6,8 +6,9 @@
 
 ### ProgressBar
 
-| 参数        | 说明              | 类型   | 默认值    |
-| ----------- | ----------------- | ------ | --------- |
-| percent     | 百分比            | number | 0         |
-| strokeColor | 进度条颜色        | string | `#1677FF` |
-| strokeWidth | 线条宽度，单位 px | number | 3         |
+| 参数        | 说明              | 类型    | 默认值    |
+| ----------- | ----------------- | ------- | --------- |
+| percent     | 百分比            | number  | 0         |
+| showPercent | 是否展示百分比    | boolean | false     |
+| strokeColor | 进度条颜色        | string  | `#1677FF` |
+| strokeWidth | 线条宽度，单位 px | number  | 3         |

--- a/src/components/progress-bar/progress-bar.tsx
+++ b/src/components/progress-bar/progress-bar.tsx
@@ -46,7 +46,7 @@ export const ProgressBar = withDefaultProps({
   return (
     <div
       className={classNames(classPrefix, props.className)}
-      style={{ display: 'flex' }}
+      style={{ ...props.style, display: 'flex' }}
     >
       <div className={`${classPrefix}-trail`} style={trailStyle}>
         <div className={classNames(`${classPrefix}-path`)} style={pathStyle} />

--- a/src/components/progress-bar/progress-bar.tsx
+++ b/src/components/progress-bar/progress-bar.tsx
@@ -8,6 +8,7 @@ const classPrefix = `am-progress-bar`
 
 export type ProgressBarProps = {
   percent?: number
+  showPercent?: boolean
   strokeWidth?: number
   strokeColor?: string
 } & ElementProps
@@ -15,6 +16,7 @@ export type ProgressBarProps = {
 export const ProgressBar = withDefaultProps({
   percent: 0,
   strokeColor: '#1677FF',
+  showPercent: false,
 })<ProgressBarProps>(props => {
   let { strokeWidth } = props
   if (strokeWidth === undefined) {
@@ -22,6 +24,7 @@ export const ProgressBar = withDefaultProps({
   }
 
   const trailStyle = {
+    width: '100%',
     height: `${strokeWidth}px`,
     borderRadius: `${strokeWidth / 2}px`,
     background: '#e5e5e5',
@@ -35,14 +38,27 @@ export const ProgressBar = withDefaultProps({
     transition: 'width 0.3s',
   }
 
+  const percentStyle = {
+    marginLeft: '12px',
+    lineHeight: `${strokeWidth}px`,
+    color: props.strokeColor,
+  }
   return (
     <div
       className={classNames(classPrefix, props.className)}
-      style={props.style}
+      style={{ display: 'flex' }}
     >
       <div className={`${classPrefix}-trail`} style={trailStyle}>
         <div className={classNames(`${classPrefix}-path`)} style={pathStyle} />
       </div>
+      {props.showPercent && (
+        <div
+          className={classNames(`${classPrefix}-percent`)}
+          style={percentStyle}
+        >
+          {props.percent + '%'}
+        </div>
+      )}
     </div>
   )
 })


### PR DESCRIPTION
目前的progressBar设定display：flex会导致进度条消失。
![image](https://user-images.githubusercontent.com/35098134/135196051-d1322c7a-d22a-4e16-94dc-2161719f9f2a.png)
添加了一个api，显示百分比，同时解决display：flex会导致进度条消失