### PR TITLE
chore: pre-commit add shebang

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,3 @@
+#!/bin/sh
+
 yarn pretty-quick --staged


### PR DESCRIPTION
修复window bash执行husky pre-commit 异常

```
error: cannot spawn .husky/pre-commit: No such file or directory
```