### PR TITLE
fix: ellipsis mixcalculated

### DIFF
--- a/src/components/ellipsis/ellipsis.tsx
+++ b/src/components/ellipsis/ellipsis.tsx
@@ -42,10 +42,12 @@ export const Ellipsis = withDefaultProps(defaultProps)<EllipsisProps>(props => {
     container.style.webkitBoxOrient = 'unset'
     container.style.display = 'block'
     const lineHeight = pxToNumber(originStyle.lineHeight)
-    const maxHeight =
-      Math.floor(lineHeight) * props.rows +
-      pxToNumber(originStyle.paddingTop) +
-      pxToNumber(originStyle.paddingBottom)
+    const maxHeight = Math.round(
+      lineHeight * props.rows +
+        pxToNumber(originStyle.paddingTop) +
+        pxToNumber(originStyle.paddingBottom)
+    )
+
     container.innerText = props.content
     document.body.appendChild(container)
     if (container.offsetHeight <= maxHeight) {
@@ -118,7 +120,7 @@ export const Ellipsis = withDefaultProps(defaultProps)<EllipsisProps>(props => {
       setEllipsised(
         props.direction === 'middle'
           ? checkMiddle([0, middle], [middle, end])
-          : check(0, props.content.length)
+          : check(0, end)
       )
     }
     document.body.removeChild(container)


### PR DESCRIPTION
#4085 

错误原因：如果不对 `maxHeight` 四舍五入或者向上取整的话，且如果lineHeight/paddingTop/paddingBottom中存在小数，就有可能导致 `container.offsetHeight`始终比`maxHeight`大1，就导致二分查找时对比出错。

另外：希望可以调整一下`check`函数中每个`props.direction`的判断顺序，else是end，这样假如用户填了一个其他值，默认为后面省略，还是比较符合常用习惯的。