### PR TITLE
style: Dialog 底部最后一个按钮的“border-right: none;”样式无效

### DIFF
--- a/src/components/dialog/dialog.less
+++ b/src/components/dialog/dialog.less
@@ -57,7 +57,7 @@
             font-weight: bold;
           }
           border-right: solid 0.5px var(--adm-border-color);
-          :last-child {
+          &:last-child {
             border-right: none;
           }
         }


### PR DESCRIPTION
:last-child前面添加了&