### PR TITLE
fix: swiper item click event can not be triggered

### DIFF
--- a/src/components/swiper/swiper.tsx
+++ b/src/components/swiper/swiper.tsx
@@ -160,7 +160,6 @@ export const Swiper = forwardRef(
           rubberband: true,
           axis: 'x',
           preventScroll: true,
-          preventDefault: true,
           pointer: {
             touch: true,
           },


### PR DESCRIPTION
部分浏览器/Webview里，Swiper Item点击事件没有触发。

存在问题的设备：

设备：小米11
浏览器：微信自带、夸克、UC

设备：iPhone 12
浏览器：微信自带

去掉`preventDefault: true`之后，这些浏览器可以触发点击事件。
