### PR TITLE
fix: (Picker) touchmove event is blocked

### DIFF
--- a/src/components/picker-view/column.tsx
+++ b/src/components/picker-view/column.tsx
@@ -1,11 +1,12 @@
 import React, { FC, useLayoutEffect, useRef, useState } from 'react'
 import { useSpring, animated } from '@react-spring/web'
 import { useDrag } from '@use-gesture/react'
-import { convertPx } from '../../utils/convert-px'
-import { rubberbandIfOutOfBounds } from '../../utils/rubberband'
-import { bound } from '../../utils/bound'
-import { PickerColumnItem, PickerValue } from './index'
 import { useDebounceFn } from 'ahooks'
+import { bound } from '../../utils/bound'
+import { convertPx } from '../../utils/convert-px'
+import { canUseDom } from '../../utils/can-use-dom'
+import { rubberbandIfOutOfBounds } from '../../utils/rubberband'
+import { PickerColumnItem, PickerValue } from './index'
 
 const classPrefix = `adm-picker-view`
 
@@ -92,6 +93,7 @@ export const Column: FC<Props> = props => {
       axis: 'y',
       from: () => [0, y.get()],
       filterTaps: true,
+      window: canUseDom ? document.body : undefined,
     }
   )
 


### PR DESCRIPTION
修复：https://github.com/ant-design/ant-design-mobile/issues/4180

bug原因说明：

1. 小米自带的浏览器不支持`pointer event`，而`picker-view\column.tsx`里的`useDrag`的实现默认是采用`pointer`事件来实现（当浏览器不支持时，会使用`touch`事件），这就是为什么其他浏览器没出现这个问题，而小米浏览器出现这个问题的原因（useDrag里增加参数`pointer: {touch: true}`可以在其他正常的浏览器中复现）。
2. 当采用`touch`事件实现时，`touchmove`事件被`Popup`里的`useLockScroll`里的`stopPropagation`阻止了。
3. useDrag里的touchmove默认是冒泡事件，且该事件**默认绑定到window对象**中，于是就被阻止传播了。

修复方式：
1. `useDrag`的参数里增加`eventOptions: {capture: true}`，也就是将touch相关事件改成捕获事件。
2. `useDrag`的参数里增加`window: document`，和`useLockScroll`里的touchmove事件绑定的节点相同或者次一级，避免被阻止。
3. `useLockScroll`里删除`stopPropagation`。

这里我采用的是第二种修复方式，支持ssr，设置`window: document.body`，比`useLockScroll`里的还次一级，保险一点，避免还有未知的浏览器事件兼容性问题。
