### PR TITLE
fix: (ImageUploader) event.target is null inside callback due to React event pooling

### DIFF
--- a/src/components/image-uploader/image-uploader.tsx
+++ b/src/components/image-uploader/image-uploader.tsx
@@ -82,6 +82,7 @@ export const ImageUploader: FC<ImageUploaderProps> = p => {
   const { maxCount, onPreview } = props
 
   async function onChange(e: React.ChangeEvent<HTMLInputElement>) {
+    e.persist()
     const { files: rawFiles } = e.target
     if (!rawFiles) return
     let files = [].slice.call(rawFiles) as File[]


### PR DESCRIPTION
fix the event.target is null 