### PR TITLE
fix: (lodash) Modify the way of dependency loading to avoid excessive package size.

### DIFF
--- a/src/utils/merge-locale.ts
+++ b/src/utils/merge-locale.ts
@@ -1,4 +1,5 @@
-import { cloneDeep, merge } from 'lodash'
+import cloneDeep from 'lodash/cloneDeep'
+import merge from 'lodash/merge'
 
 export function mergeLocale<T, P>(base: T, patch: P): T {
   return merge(cloneDeep(base), patch)

--- a/src/utils/use-lazy-memo.tsx
+++ b/src/utils/use-lazy-memo.tsx
@@ -1,4 +1,4 @@
-import { memoize } from 'lodash'
+import memoize from 'lodash/memoize'
 import { DependencyList, useMemo } from 'react'
 
 export function useLazyMemo<T>(


### PR DESCRIPTION
Modify the way of dependency loading to avoid excessive package size.

![image](https://user-images.githubusercontent.com/20221600/139428339-20b25684-36e8-40cf-b25f-c5dc473464d0.png)




