### PR TITLE
fix: (Space) remove value of `baseline` from `justify` prop

### DIFF
--- a/src/components/space/index.en.md
+++ b/src/components/space/index.en.md
@@ -4,13 +4,13 @@
 
 ### Props
 
-| Name      | Description                                                   | Type                                                                                           | Default        |
-| --------- | ------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | -------------- |
-| justify   | Align the items on the main axis.                             | `'start' \| 'end' \| 'center' \| 'baseline' \| 'between' \| 'around' \| 'evenly' \| 'stretch'` | -              |
-| align     | Align the items on the cross axis.                            | `'start' \| 'end' \| 'center' \| 'baseline'`                                                   | -              |
-| direction | The spacing direction.                                        | `'vertical' \| 'horizontal'`                                                                   | `'horizontal'` |
-| wrap      | Should line break automatically, work only with `horizontal`. | `boolean`                                                                                      | `false`        |
-| block     | Should render as block element.                               | `boolean`                                                                                      | `false`        |
+| Name      | Description                                                   | Type                                                                             | Default        |
+| --------- | ------------------------------------------------------------- | -------------------------------------------------------------------------------- | -------------- |
+| justify   | Align the items on the main axis.                             | `'start' \| 'end' \| 'center' \| 'between' \| 'around' \| 'evenly' \| 'stretch'` | -              |
+| align     | Align the items on the cross axis.                            | `'start' \| 'end' \| 'center' \| 'baseline'`                                     | -              |
+| direction | The spacing direction.                                        | `'vertical' \| 'horizontal'`                                                     | `'horizontal'` |
+| wrap      | Should line break automatically, work only with `horizontal`. | `boolean`                                                                        | `false`        |
+| block     | Should render as block element.                               | `boolean`                                                                        | `false`        |
 
 ### CSS Variables
 

--- a/src/components/space/index.zh.md
+++ b/src/components/space/index.zh.md
@@ -4,13 +4,13 @@
 
 ### 属性
 
-| 属性      | 说明                                   | 类型                                                                                           | 默认值         |
-| --------- | -------------------------------------- | ---------------------------------------------------------------------------------------------- | -------------- |
-| justify   | 主轴对齐方式                           | `'start' \| 'end' \| 'center' \| 'baseline' \| 'between' \| 'around' \| 'evenly' \| 'stretch'` | -              |
-| align     | 交叉轴对齐方式                         | `'start' \| 'end' \| 'center' \| 'baseline'`                                                   | -              |
-| direction | 间距方向                               | `'vertical' \| 'horizontal'`                                                                   | `'horizontal'` |
-| wrap      | 是否自动换行，仅在 `horizontal` 时有效 | `boolean`                                                                                      | `false`        |
-| block     | 是否渲染为块级元素                     | `boolean`                                                                                      | `false`        |
+| 属性      | 说明                                   | 类型                                                                             | 默认值         |
+| --------- | -------------------------------------- | -------------------------------------------------------------------------------- | -------------- |
+| justify   | 主轴对齐方式                           | `'start' \| 'end' \| 'center' \| 'between' \| 'around' \| 'evenly' \| 'stretch'` | -              |
+| align     | 交叉轴对齐方式                         | `'start' \| 'end' \| 'center' \| 'baseline'`                                     | -              |
+| direction | 间距方向                               | `'vertical' \| 'horizontal'`                                                     | `'horizontal'` |
+| wrap      | 是否自动换行，仅在 `horizontal` 时有效 | `boolean`                                                                        | `false`        |
+| block     | 是否渲染为块级元素                     | `boolean`                                                                        | `false`        |
 
 ### CSS 变量
 

--- a/src/components/space/space.less
+++ b/src/components/space/space.less
@@ -61,9 +61,6 @@
     &-end {
       justify-content: flex-end;
     }
-    &-baseline {
-      justify-content: baseline;
-    }
     &-between {
       justify-content: space-between;
     }

--- a/src/components/space/space.tsx
+++ b/src/components/space/space.tsx
@@ -12,7 +12,6 @@ export type SpaceProps = {
     | 'start'
     | 'end'
     | 'center'
-    | 'baseline'
     | 'between'
     | 'around'
     | 'evenly'

--- a/src/components/space/tests/space.test.tsx
+++ b/src/components/space/tests/space.test.tsx
@@ -46,6 +46,19 @@ test('renders with direction', () => {
   expect(amSpace).toHaveClass(`${classPrefix}-vertical`)
 })
 
+test('renders with justify', () => {
+  const justify = 'center'
+  const { container } = render(
+    <Space justify={justify}>
+      <div>block1</div>
+      <div>block2</div>
+      <div>block3</div>
+    </Space>
+  )
+  const amSpace = container.getElementsByClassName('adm-space')[0]
+  expect(amSpace).toHaveClass(`${classPrefix}-justify-${justify}`)
+})
+
 test('renders with align', () => {
   const align = 'end'
   const { container } = render(


### PR DESCRIPTION
CSS `justify-content` 并不支持 `baseline`，所以在 Space 组件中进行了移除。

https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content