### PR TITLE
fix: set pointer.touch to true to fix drag gesture on some mobile devices

### DIFF
--- a/src/components/image-viewer/slides.tsx
+++ b/src/components/image-viewer/slides.tsx
@@ -55,6 +55,7 @@ export const Slides: FC<{
       },
       rubberband: true,
       axis: 'x',
+      pointer: { touch: true },
     }
   )
 

--- a/src/components/picker-view/column.tsx
+++ b/src/components/picker-view/column.tsx
@@ -92,6 +92,7 @@ export const Column: FC<Props> = props => {
       axis: 'y',
       from: () => [0, y.get()],
       filterTaps: true,
+      pointer: { touch: true },
     }
   )
 

--- a/src/components/slider/thumb.tsx
+++ b/src/components/slider/thumb.tsx
@@ -37,6 +37,7 @@ const Thumb: FC<ThumbProps> = props => {
     },
     {
       axis: 'x',
+      pointer: { touch: true },
     }
   )
 

--- a/src/components/swipe-action/swipe-action.tsx
+++ b/src/components/swipe-action/swipe-action.tsx
@@ -120,6 +120,7 @@ export const SwipeAction = forwardRef<SwipeActionRef, SwipeActionProps>(
         // rubberband: true,
         axis: 'x',
         preventScroll: true,
+        pointer: { touch: true },
       }
     )
 


### PR DESCRIPTION
将 `useDrag` 的 `pointer` 参数设置为 `{ touch: true }`，解决部分机械无法拖动的 bug。 #4303 