### PR TITLE
feat: (Dropdown) add `closeOnMaskClick` prop

### DIFF
--- a/src/components/dropdown/demos/demo1.tsx
+++ b/src/components/dropdown/demos/demo1.tsx
@@ -112,32 +112,6 @@ export default () => {
           </Dropdown.Item>
         </Dropdown>
       </DemoBlock>
-      <DemoBlock title='点击遮罩后自动隐藏' padding={'0'}>
-        <Dropdown closeOnMaskClick>
-          <Dropdown.Item key='sorter' title='排序'>
-            <div style={{ padding: 12 }}>
-              排序内容
-              <br />
-              排序内容
-              <br />
-              排序内容
-              <br />
-              排序内容
-              <br />
-            </div>
-          </Dropdown.Item>
-          <Dropdown.Item key='bizop' title='商机筛选'>
-            <div style={{ padding: 12 }}>
-              商机筛选内容
-              <br />
-              商机筛选内容
-              <br />
-              商机筛选内容
-              <br />
-            </div>
-          </Dropdown.Item>
-        </Dropdown>
-      </DemoBlock>
     </div>
   )
 }

--- a/src/components/dropdown/demos/demo1.tsx
+++ b/src/components/dropdown/demos/demo1.tsx
@@ -112,6 +112,32 @@ export default () => {
           </Dropdown.Item>
         </Dropdown>
       </DemoBlock>
+      <DemoBlock title='点击遮罩后自动隐藏' padding={'0'}>
+        <Dropdown closeOnMaskClick>
+          <Dropdown.Item key='sorter' title='排序'>
+            <div style={{ padding: 12 }}>
+              排序内容
+              <br />
+              排序内容
+              <br />
+              排序内容
+              <br />
+              排序内容
+              <br />
+            </div>
+          </Dropdown.Item>
+          <Dropdown.Item key='bizop' title='商机筛选'>
+            <div style={{ padding: 12 }}>
+              商机筛选内容
+              <br />
+              商机筛选内容
+              <br />
+              商机筛选内容
+              <br />
+            </div>
+          </Dropdown.Item>
+        </Dropdown>
+      </DemoBlock>
     </div>
   )
 }

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -20,6 +20,7 @@ const classPrefix = `adm-dropdown`
 export type DropdownProps = {
   activeKey?: string | null
   defaultActiveKey?: string | null
+  closeOnMaskClick?: boolean
   onChange?: (key: string | null) => void
   // mask?: boolean;
 } & NativeProps
@@ -104,6 +105,13 @@ const Dropdown: FC<DropdownProps> & {
         bodyClassName={`${classPrefix}-popup-body`}
         style={{ top }}
         forceRender={popupForceRender}
+        onMaskClick={
+          props.closeOnMaskClick
+            ? () => {
+                changeActive(null)
+              }
+            : undefined
+        }
       >
         <div ref={contentRef}>
           {items.map(item => {

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -27,6 +27,7 @@ export type DropdownProps = {
 
 const defaultProps = {
   defaultActiveKey: null,
+  closeOnMaskClick: true,
 }
 
 const Dropdown: FC<DropdownProps> & {

--- a/src/components/dropdown/index.en.md
+++ b/src/components/dropdown/index.en.md
@@ -20,3 +20,4 @@
 | forceRender         | Whether to render the content even if it is not active       | `boolean`   | `false` |
 | destroyOnClose      | Unmount content when not visible                             | `boolean`   | `false` |
 | closeOnContentClick | Whether to automatically close after clicking on the content | `boolean`   | `false` |
+| closeOnMaskClick    | Whether to automatically close after clicking on the mask    | `boolean`   | `false` |

--- a/src/components/dropdown/index.en.md
+++ b/src/components/dropdown/index.en.md
@@ -20,4 +20,4 @@
 | forceRender         | Whether to render the content even if it is not active       | `boolean`   | `false` |
 | destroyOnClose      | Unmount content when not visible                             | `boolean`   | `false` |
 | closeOnContentClick | Whether to automatically close after clicking on the content | `boolean`   | `false` |
-| closeOnMaskClick    | Whether to automatically close after clicking on the mask    | `boolean`   | `false` |
+| closeOnMaskClick    | Whether to automatically close after clicking on the mask    | `boolean`   | `true`  |

--- a/src/components/dropdown/index.zh.md
+++ b/src/components/dropdown/index.zh.md
@@ -20,4 +20,4 @@
 | forceRender         | 被隐藏时是否渲染 `DOM` 结构  | `boolean`   | `false` |
 | destroyOnClose      | 不可见时卸载内容             | `boolean`   | `false` |
 | closeOnContentClick | 是否在点击下拉内容后自动隐藏 | `boolean`   | `false` |
-| closeOnMaskClick    | 是否在点击遮罩后自动隐藏     | `boolean`   | `false` |
+| closeOnMaskClick    | 是否在点击遮罩后自动隐藏     | `boolean`   | `true`  |

--- a/src/components/dropdown/index.zh.md
+++ b/src/components/dropdown/index.zh.md
@@ -20,3 +20,4 @@
 | forceRender         | 被隐藏时是否渲染 `DOM` 结构  | `boolean`   | `false` |
 | destroyOnClose      | 不可见时卸载内容             | `boolean`   | `false` |
 | closeOnContentClick | 是否在点击下拉内容后自动隐藏 | `boolean`   | `false` |
+| closeOnMaskClick    | 是否在点击遮罩后自动隐藏     | `boolean`   | `false` |


### PR DESCRIPTION
issue：https://github.com/ant-design/ant-design-mobile/issues/4310

为 `Dropdown` 组件新增 `closeOnMaskClick` 属性，默认为 `true`，表示是否开启「点击遮罩关闭下拉菜单」。
