### PR TITLE
feat: (Form) add labelLayout prop for Form.Item

### DIFF
--- a/src/components/form/demos/demo1.tsx
+++ b/src/components/form/demos/demo1.tsx
@@ -106,6 +106,7 @@ export default () => {
           <Form.Item
             name='姓名'
             label='姓名'
+            labelLayout={['required', 'label', 'help']}
             rules={[{ required: true, message: '姓名不能为空' }]}
           >
             <Input onChange={console.log} placeholder='请输入姓名' />

--- a/src/components/form/form-item.less
+++ b/src/components/form/form-item.less
@@ -15,6 +15,11 @@
       margin-left: 4px;
       color: var(--adm-color-danger);
       user-select: none;
+
+      &-first {
+        margin-left: 0;
+        margin-right: 4px;
+      }
     }
   }
 

--- a/src/components/form/form-item.tsx
+++ b/src/components/form/form-item.tsx
@@ -23,6 +23,8 @@ type RcFieldProps = Omit<FieldProps, 'children'>
 
 const classPrefix = `adm-form-item`
 
+type LabelLayoutElement = 'label' | 'required' | 'help'
+
 export type FormItemProps = RcFieldProps &
   NativeProps &
   Pick<ListItemProps, 'style' | 'onClick' | 'extra'> & {
@@ -35,6 +37,7 @@ export type FormItemProps = RcFieldProps &
     hidden?: boolean
     layout?: FormLayout
     children: ChildrenType
+    labelLayout?: LabelLayoutElement[]
   }
 
 interface MemoInputProps {
@@ -61,6 +64,7 @@ type FormItemLayoutProps = Pick<
   | 'hidden'
   | 'layout'
   | 'extra'
+  | 'labelLayout'
 > & {
   htmlFor?: string
   errors?: string[]
@@ -88,11 +92,31 @@ const FormItemLayout: React.FC<FormItemLayoutProps> = props => {
 
   const feedback = hasFeedback && errors && errors.length > 0 ? errors[0] : null
 
+  const labelLayout = props.labelLayout || ['label', 'required', 'help']
+  const _rendelLabel = label
+  const _renderRequired = required && (
+    <span
+      className={classNames(`${classPrefix}-label-required`, {
+        [`${classPrefix}-label-required-first`]: labelLayout[0] === 'required',
+      })}
+    >
+      *
+    </span>
+  )
+  const _renderHelp = help && (
+    <span className={`${classPrefix}-label-help`}>{help}</span>
+  )
+  const _renderLabelMap = {
+    label: _rendelLabel,
+    required: _renderRequired,
+    help: _renderHelp,
+  }
+
   const labelElement = label ? (
     <label className={`${classPrefix}-label`} htmlFor={htmlFor}>
-      {label}
-      {required && <span className={`${classPrefix}-label-required`}>*</span>}
-      {help && <span className={`${classPrefix}-label-help`}>{help}</span>}
+      {_renderLabelMap[labelLayout[0]]}
+      {_renderLabelMap[labelLayout[1]]}
+      {_renderLabelMap[labelLayout[2]]}
     </label>
   ) : null
 
@@ -143,6 +167,7 @@ export const FormItem: FC<FormItemProps> = props => {
     onClick,
     shouldUpdate,
     dependencies,
+    labelLayout,
     ...fieldProps
   } = props
 
@@ -208,6 +233,7 @@ export const FormItem: FC<FormItemProps> = props => {
         onClick={onClick}
         hidden={hidden}
         layout={layout}
+        labelLayout={labelLayout}
       >
         <NoStyleItemContext.Provider value={onSubMetaChange}>
           {baseChildren}

--- a/src/components/form/index.en.md
+++ b/src/components/form/index.en.md
@@ -20,6 +20,7 @@ See for other parameters https://www.npmjs.com/package/rc-field-form
 | Name        | Description                          | Type                         | Default                                                               |
 | ----------- | ------------------------------------ | ---------------------------- | --------------------------------------------------------------------- |
 | label       | Label name                           | `string`                     | --                                                                    |
+| labelLayout | Label layout                         | `LabelLayoutElement[]`       | `['label', 'required', 'help']`                                       |
 | help        | Prompt text                          | `string`                     | --                                                                    |
 | extra       | The right area of the form item.     | `ReactNode`                  | --                                                                    |
 | required    | Whether it is required               | `boolean`                    | `false`（if `rules` is set, it would be judged according to `rules`） |

--- a/src/components/form/index.zh.md
+++ b/src/components/form/index.zh.md
@@ -20,6 +20,7 @@
 | 属性        | 说明                       | 类型                         | 默认值                                             |
 | ----------- | -------------------------- | ---------------------------- | -------------------------------------------------- |
 | label       | 标签名                     | `string`                     | --                                                 |
+| labelLayout | 标签名布局                 | `LabelLayoutElement[]`       | `['label', 'required', 'help']`                    |
 | help        | 提示文本                   | `string`                     | --                                                 |
 | extra       | 表单项右侧区域             | `ReactNode`                  | --                                                 |
 | required    | 是否必选                   | `boolean`                    | `false`（如有设置 `rules`，则会根据 `rules` 判断） |


### PR DESCRIPTION
实际项目中有将必填项的 `*` 放在表单项最前面的需求, 目前ant design mobile没有相关支持