### PR TITLE
fix: (Picker) `context` param in `onSelect` and `onConfirm` return outdated data

### DIFF
--- a/src/components/picker/demos/index.tsx
+++ b/src/components/picker/demos/index.tsx
@@ -26,7 +26,13 @@ function BasicDemo() {
           setVisible(false)
         }}
         value={value}
-        onConfirm={setValue}
+        onSelect={(v, c) => {
+          console.log('onSelect', v, c.items)
+        }}
+        onConfirm={(v, c) => {
+          console.log('onConfirm', v, c.items)
+          setValue(v)
+        }}
       />
     </>
   )

--- a/src/components/picker/demos/index.tsx
+++ b/src/components/picker/demos/index.tsx
@@ -26,11 +26,7 @@ function BasicDemo() {
           setVisible(false)
         }}
         value={value}
-        onSelect={(v, c) => {
-          console.log('onSelect', v, c.items)
-        }}
         onConfirm={(v, c) => {
-          console.log('onConfirm', v, c.items)
           setValue(v)
         }}
       />
@@ -58,8 +54,8 @@ function RenderChildrenDemo() {
         }}
         value={value}
         onConfirm={setValue}
-        onSelect={val => {
-          console.log('onSelect', val)
+        onSelect={(val, context) => {
+          console.log('onSelect', val, context.items)
         }}
       >
         {items => {

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -141,7 +141,6 @@ export const Picker: FC<PickerProps> = p => {
   const generateItems = useMemo(() => {
     return memoize(
       (val: PickerValue[]) => {
-        console.log('generateItems')
         return val.map((v, index) => {
           const column = columns[index]
           if (!column) return null

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, ReactNode, FC } from 'react'
+import React, { useState, useEffect, ReactNode, FC, useMemo } from 'react'
 import Popup, { PopupProps } from '../popup'
 import { mergeProps } from '../../utils/with-default-props'
 import { NativeProps, withNativeProps } from '../../utils/native-props'
@@ -7,7 +7,7 @@ import { PickerColumn, PickerColumnItem, PickerValue } from './index'
 import PickerView from '../picker-view'
 import { useColumns } from '../picker-view/use-columns'
 import { useConfig } from '../config-provider'
-import { useLazyMemo } from '../../utils/use-lazy-memo'
+import memoize from 'lodash/memoize'
 
 const classPrefix = `adm-picker`
 
@@ -49,21 +49,21 @@ export const Picker: FC<PickerProps> = p => {
     p
   )
 
-  const controllable = usePropsValue({
+  const [value, setValue] = usePropsValue({
     value: props.value,
     defaultValue: props.defaultValue,
     onChange: val => {
-      props.onConfirm?.(val, context(val))
+      props.onConfirm?.(val, generateContext(val))
     },
   })
-  const value = controllable[0] as PickerValue[]
-  const setValue = controllable[1]
 
-  const context: (val: PickerValue[]) => PickerValueContext = val => ({
-    get items() {
-      return getItems(val)
-    },
-  })
+  function generateContext(val: PickerValue[]): PickerValueContext {
+    return {
+      get items() {
+        return generateItems(val)
+      },
+    }
+  }
 
   const [innerValue, setInnerValue] = useState<PickerValue[]>(value)
   useEffect(() => {
@@ -111,7 +111,7 @@ export const Picker: FC<PickerProps> = p => {
           onChange={val => {
             setInnerValue(val)
             if (props.visible) {
-              props.onSelect?.(val, context(val))
+              props.onSelect?.(val, generateContext(val))
             }
           }}
         />
@@ -138,21 +138,24 @@ export const Picker: FC<PickerProps> = p => {
     </Popup>
   )
 
-  const getItems = useLazyMemo(
-    (val: PickerValue[]) => {
-      return val.map((v, index) => {
-        const column = columns[index]
-        if (!column) return null
-        return column.find(item => item.value === v) ?? null
-      })
-    },
-    [columns]
-  )
+  const generateItems = useMemo(() => {
+    return memoize(
+      (val: PickerValue[]) => {
+        console.log('generateItems')
+        return val.map((v, index) => {
+          const column = columns[index]
+          if (!column) return null
+          return column.find(item => item.value === v) ?? null
+        })
+      },
+      val => JSON.stringify(val)
+    )
+  }, [columns])
 
   return (
     <>
       {popupElement}
-      {props.children?.(getItems(value))}
+      {props.children?.(generateItems(value))}
     </>
   )
 }

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -53,17 +53,17 @@ export const Picker: FC<PickerProps> = p => {
     value: props.value,
     defaultValue: props.defaultValue,
     onChange: val => {
-      props.onConfirm?.(val, context)
+      props.onConfirm?.(val, context(val))
     },
   })
   const value = controllable[0] as PickerValue[]
   const setValue = controllable[1]
 
-  const context: PickerValueContext = {
+  const context: (val: PickerValue[]) => PickerValueContext = val => ({
     get items() {
-      return getItems()
+      return getItems(val)
     },
-  }
+  })
 
   const [innerValue, setInnerValue] = useState<PickerValue[]>(value)
   useEffect(() => {
@@ -111,7 +111,7 @@ export const Picker: FC<PickerProps> = p => {
           onChange={val => {
             setInnerValue(val)
             if (props.visible) {
-              props.onSelect?.(val, context)
+              props.onSelect?.(val, context(val))
             }
           }}
         />
@@ -138,18 +138,21 @@ export const Picker: FC<PickerProps> = p => {
     </Popup>
   )
 
-  const getItems = useLazyMemo(() => {
-    return value.map((v, index) => {
-      const column = columns[index]
-      if (!column) return null
-      return column.find(item => item.value === v) ?? null
-    })
-  }, [value, columns])
+  const getItems = useLazyMemo(
+    (val: PickerValue[]) => {
+      return val.map((v, index) => {
+        const column = columns[index]
+        if (!column) return null
+        return column.find(item => item.value === v) ?? null
+      })
+    },
+    [columns]
+  )
 
   return (
     <>
       {popupElement}
-      {props.children?.(getItems())}
+      {props.children?.(getItems(value))}
     </>
   )
 }

--- a/src/utils/use-lazy-memo.tsx
+++ b/src/utils/use-lazy-memo.tsx
@@ -1,9 +1,9 @@
 import memoize from 'lodash/memoize'
 import { DependencyList, useMemo } from 'react'
 
-export function useLazyMemo<T>(
-  factory: () => T,
+export function useLazyMemo<V, T>(
+  factory: (v?: V) => T,
   deps: DependencyList
-): () => T {
+): (v?: V) => T {
   return useMemo(() => memoize(factory), deps)
 }

--- a/src/utils/use-lazy-memo.tsx
+++ b/src/utils/use-lazy-memo.tsx
@@ -1,9 +1,0 @@
-import memoize from 'lodash/memoize'
-import { DependencyList, useMemo } from 'react'
-
-export function useLazyMemo<V, T>(
-  factory: (v?: V) => T,
-  deps: DependencyList
-): (v?: V) => T {
-  return useMemo(() => memoize(factory), deps)
-}


### PR DESCRIPTION
Picker 的 `onSelect` 和 `onConfirm` 都拥有第二个参数：`context`，但它现在存在以下两个问题：

### 1. 数据不同步

点开一个 Picker，直接输出 `onSelect` 的 `value` 和 `context`，可以看到：

![image](https://user-images.githubusercontent.com/51314472/141643449-035568dc-5f4d-4413-8293-a3cf1d119cb3.png)

confirm 一个选项之后（示例中 confirm 了['C', '1']），输出会是：

![image](https://user-images.githubusercontent.com/51314472/141643489-11d4da03-434a-4888-a97b-3a89307cd2b4.png)

可见 `context` 中的值好像和 `value` 相比「慢了一步」，这是因为代码实现中，计算 `context` 的函数 `getItems` 中的依赖项 `value` 是组件内 confirmed 后的 `value` 值，也就是说，只有进行 confirmed 后才能改变 `value` ，从而触发 `getItems` 的重新计算。

![image](https://user-images.githubusercontent.com/51314472/141643599-237ddded-9d09-43b0-88c5-4bf6313897d0.png)

而作为一个受控组件，在 `onConfirm` 的回调触发时，该组件的新 `value` 还没有被 set。如下图， `onConfirm` 触发了 `setValue`，之后该组件的 `value` 值才会改变。也就是说，`onConfirm` 触发时组件内的 `value` 还是上一次触发 set 的值

![image](https://user-images.githubusercontent.com/51314472/141643753-036e3b84-011f-4e94-915a-be451a24f530.png)

这是导致当前 `onSelect` 和 `onConfirm` 的参数中 `value` 值与 `context` 值不同步的原因。

</br>

### 2. onSelect 返回的 `context` 是 confirmed 的，而不是 selecting 的

依旧是获取 `context` 的 `getItems` 函数的问题，这里的依赖 `value` 是组件 confirmed 后的值，也就是说当前 `onSelect` 的参数 `context` 中只会出现 `onConfirm` 的值。

![image](https://user-images.githubusercontent.com/51314472/141643937-12ff20aa-fa31-4645-9fa3-9ebce139a854.png)

于是会导致下图的问题：
当我在 confirm 一个选项之后（示例中 confirm 了['C', '1']），`onSelect` 的 `context` 始终会返回 ['C', '1'] 的数据

![image](https://user-images.githubusercontent.com/51314472/141644056-853aca1c-5bdc-42c2-a694-9b3e0b5d1e31.png)

</br>

综上，我试着修复了一下这两个问题，但我不确定这样做是否正确或最优 😶

