### PR TITLE
fix: 修复在Dropdown中的input点击清除按钮会触发useClickAway，导致关闭Popup的问题

### DIFF
--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -118,20 +118,19 @@ export const Input = forwardRef<InputRef, InputProps>((p, ref) => {
         onKeyDown={handleKeydown}
         onKeyUp={props.onKeyUp}
       />
-      {props.clearable && !!value && hasFocus && (
-        <div
-          className={`${classPrefix}-clear`}
-          onMouseDown={e => {
-            e.preventDefault()
-          }}
-          onClick={() => {
-            setValue('')
-            props.onClear?.()
-          }}
-        >
-          <CloseCircleFill />
-        </div>
-      )}
+      <div
+        style={{display: props.clearable && !!value && hasFocus ? 'block' : 'none'}}
+        className={`${classPrefix}-clear`}
+        onMouseDown={e => {
+          e.preventDefault()
+        }}
+        onClick={() => {
+          setValue('')
+          props.onClear?.()
+        }}
+      >
+        <CloseCircleFill />
+      </div>
     </div>
   )
 })


### PR DESCRIPTION
问题触发场景：
在Dropdown组件中使用Search组件，点击input的清除按钮会关闭当前Dropdown.Item对应的Popup

推测原因：
input的清除按钮使用了条件渲染，而使用useClickAway要注册ref，注册时input的清除按钮没有渲染，导致其被视作useClickAway触发的区域

解决办法：
使用display的切换替代条件渲染