### PR TITLE
feat: (PickerView) onChange add context param

### DIFF
--- a/src/components/picker-view/demos/basic.tsx
+++ b/src/components/picker-view/demos/basic.tsx
@@ -22,9 +22,9 @@ export default () => {
         <PickerView
           columns={columns}
           value={value}
-          onChange={(val, context) => {
+          onChange={(val, extend) => {
             setValue(val)
-            console.log('onChange', val, context.items)
+            console.log('onChange', val, extend.items)
           }}
         />
       </DemoBlock>

--- a/src/components/picker-view/demos/basic.tsx
+++ b/src/components/picker-view/demos/basic.tsx
@@ -1,5 +1,5 @@
 import { PickerView } from 'antd-mobile'
-import React from 'react'
+import React, { useState } from 'react'
 import { DemoBlock } from 'demos'
 
 const columns = [
@@ -8,6 +8,8 @@ const columns = [
 ]
 
 export default () => {
+  const [value, setValue] = useState<(string | null)[]>(['A', '1'])
+
   return (
     <>
       <DemoBlock title='基础用法' padding='0'>
@@ -17,7 +19,14 @@ export default () => {
         <PickerView columns={columns} style={{ '--height': '500px' }} />
       </DemoBlock>
       <DemoBlock title='受控模式' padding='0'>
-        <PickerView columns={columns} value={['A', '1']} />
+        <PickerView
+          columns={columns}
+          value={value}
+          onChange={(val, context) => {
+            setValue(val)
+            console.log('onChange', val, context.items)
+          }}
+        />
       </DemoBlock>
     </>
   )

--- a/src/components/picker-view/index.en.md
+++ b/src/components/picker-view/index.en.md
@@ -11,9 +11,9 @@ PickerView is the content area of Picker.
 | columns      | Options to configure each column       | `PickerColumn[] \| ((value: PickerValue[]) => PickerColumn[])` | -       |
 | value        | Selected options                       | `PickerValue[]`                                                | -       |
 | defaultValue | Default selected options               | `PickerValue[]`                                                | -       |
-| onChange     | Triggered when the options are changed | `(value: PickerValue[]) => void`                               | -       |
+| onChange     | Triggered when the options are changed | `(value: PickerValue[], context: PickerValueContext) => void`  | -       |
 
-For the type definition of `PickerColumnItem` `PickerColumn` `PickerValue`, please refer to the document of [Picker](./picker).
+For the type definition of `PickerColumnItem` `PickerColumn` `PickerValue` `PickerValueContext`, please refer to the document of [Picker](./picker).
 
 ## CSS Variables
 

--- a/src/components/picker-view/index.en.md
+++ b/src/components/picker-view/index.en.md
@@ -11,9 +11,9 @@ PickerView is the content area of Picker.
 | columns      | Options to configure each column       | `PickerColumn[] \| ((value: PickerValue[]) => PickerColumn[])` | -       |
 | value        | Selected options                       | `PickerValue[]`                                                | -       |
 | defaultValue | Default selected options               | `PickerValue[]`                                                | -       |
-| onChange     | Triggered when the options are changed | `(value: PickerValue[], context: PickerValueContext) => void`  | -       |
+| onChange     | Triggered when the options are changed | `(value: PickerValue[], extend: PickerValueExtend) => void`    | -       |
 
-For the type definition of `PickerColumnItem` `PickerColumn` `PickerValue` `PickerValueContext`, please refer to the document of [Picker](./picker).
+For the type definition of `PickerColumnItem` `PickerColumn` `PickerValue` `PickerValueExtend`, please refer to the document of [Picker](./picker).
 
 ## CSS Variables
 

--- a/src/components/picker-view/index.ts
+++ b/src/components/picker-view/index.ts
@@ -6,7 +6,7 @@ export type {
   PickerValue,
   PickerColumnItem,
   PickerColumn,
-  PickerValueContext,
+  PickerValueExtend,
 } from './picker-view'
 
 export default PickerView

--- a/src/components/picker-view/index.ts
+++ b/src/components/picker-view/index.ts
@@ -6,6 +6,7 @@ export type {
   PickerValue,
   PickerColumnItem,
   PickerColumn,
+  PickerValueContext,
 } from './picker-view'
 
 export default PickerView

--- a/src/components/picker-view/index.zh.md
+++ b/src/components/picker-view/index.zh.md
@@ -11,9 +11,9 @@ PickerView 是 Picker 的内容区域。
 | columns      | 配置每一列的选项 | `PickerColumn[] \| ((value: PickerValue[]) => PickerColumn[])` | -      |
 | value        | 选中项           | `PickerValue[]`                                                | -      |
 | defaultValue | 默认选中项       | `PickerValue[]`                                                | -      |
-| onChange     | 选项改变时触发   | `(value: PickerValue[]) => void`                               | -      |
+| onChange     | 选项改变时触发   | `(value: PickerValue[], context: PickerValueContext) => void`  | -      |
 
-关于 `PickerColumnItem` `PickerColumn` `PickerValue` 的类型定义，请参考 [Picker](./picker) 的文档。
+关于 `PickerColumnItem` `PickerColumn` `PickerValue` `PickerValueContext` 的类型定义，请参考 [Picker](./picker) 的文档。
 
 ## CSS 变量
 

--- a/src/components/picker-view/index.zh.md
+++ b/src/components/picker-view/index.zh.md
@@ -11,9 +11,9 @@ PickerView 是 Picker 的内容区域。
 | columns      | 配置每一列的选项 | `PickerColumn[] \| ((value: PickerValue[]) => PickerColumn[])` | -      |
 | value        | 选中项           | `PickerValue[]`                                                | -      |
 | defaultValue | 默认选中项       | `PickerValue[]`                                                | -      |
-| onChange     | 选项改变时触发   | `(value: PickerValue[], context: PickerValueContext) => void`  | -      |
+| onChange     | 选项改变时触发   | `(value: PickerValue[], extend: PickerValueExtend) => void`    | -      |
 
-关于 `PickerColumnItem` `PickerColumn` `PickerValue` `PickerValueContext` 的类型定义，请参考 [Picker](./picker) 的文档。
+关于 `PickerColumnItem` `PickerColumn` `PickerValue` `PickerValueExtend` 的类型定义，请参考 [Picker](./picker) 的文档。
 
 ## CSS 变量
 

--- a/src/components/picker-view/picker-view.tsx
+++ b/src/components/picker-view/picker-view.tsx
@@ -4,10 +4,15 @@ import { mergeProps } from '../../utils/with-default-props'
 import { Column } from './column'
 import { useColumns } from './use-columns'
 import { NativeProps, withNativeProps } from '../../utils/native-props'
+import { usePickerContext } from './use-picker-context'
 
 const classPrefix = `adm-picker-view`
 
 export type PickerValue = string | null
+
+export type PickerValueContext = {
+  items: (PickerColumnItem | null)[]
+}
 
 export type PickerColumnItem = {
   label: string
@@ -20,7 +25,7 @@ export type PickerViewProps = {
   columns: PickerColumn[] | ((value: PickerValue[]) => PickerColumn[])
   value?: PickerValue[]
   defaultValue?: PickerValue[]
-  onChange?: (value: PickerValue[]) => void
+  onChange?: (value: PickerValue[], context: PickerValueContext) => void
 } & NativeProps<'--height'>
 
 const defaultProps = {
@@ -29,8 +34,14 @@ const defaultProps = {
 
 export const PickerView: FC<PickerViewProps> = p => {
   const props = mergeProps(defaultProps, p)
-  const [value, setValue] = usePropsValue(props)
+  const [value, setValue] = usePropsValue({
+    ...props,
+    onChange: val => {
+      props.onChange?.(val, generateContext(val))
+    },
+  })
   const columns = useColumns(props.columns, value)
+  const generateContext = usePickerContext(columns)
 
   return withNativeProps(
     props,

--- a/src/components/picker-view/picker-view.tsx
+++ b/src/components/picker-view/picker-view.tsx
@@ -4,13 +4,13 @@ import { mergeProps } from '../../utils/with-default-props'
 import { Column } from './column'
 import { useColumns } from './use-columns'
 import { NativeProps, withNativeProps } from '../../utils/native-props'
-import { usePickerContext } from './use-picker-context'
+import { usePickerValueExtend } from './use-picker-value-extend'
 
 const classPrefix = `adm-picker-view`
 
 export type PickerValue = string | null
 
-export type PickerValueContext = {
+export type PickerValueExtend = {
   items: (PickerColumnItem | null)[]
 }
 
@@ -25,7 +25,7 @@ export type PickerViewProps = {
   columns: PickerColumn[] | ((value: PickerValue[]) => PickerColumn[])
   value?: PickerValue[]
   defaultValue?: PickerValue[]
-  onChange?: (value: PickerValue[], context: PickerValueContext) => void
+  onChange?: (value: PickerValue[], extend: PickerValueExtend) => void
 } & NativeProps<'--height'>
 
 const defaultProps = {
@@ -37,11 +37,11 @@ export const PickerView: FC<PickerViewProps> = p => {
   const [value, setValue] = usePropsValue({
     ...props,
     onChange: val => {
-      props.onChange?.(val, generateContext(val))
+      props.onChange?.(val, generateValueExtend(val))
     },
   })
   const columns = useColumns(props.columns, value)
-  const generateContext = usePickerContext(columns)
+  const generateValueExtend = usePickerValueExtend(columns)
 
   return withNativeProps(
     props,

--- a/src/components/picker-view/use-picker-context.tsx
+++ b/src/components/picker-view/use-picker-context.tsx
@@ -1,0 +1,32 @@
+import { useMemo } from 'react'
+import memoize from 'lodash/memoize'
+import {
+  PickerValue,
+  PickerValueContext,
+  PickerColumnItem,
+} from './picker-view'
+
+export function usePickerContext(columns: PickerColumnItem[][]) {
+  const generateItems = useMemo(() => {
+    return memoize(
+      (val: PickerValue[]) => {
+        return val.map((v, index) => {
+          const column = columns[index]
+          if (!column) return null
+          return column.find(item => item.value === v) ?? null
+        })
+      },
+      val => JSON.stringify(val)
+    )
+  }, [columns])
+
+  function generateContext(val: PickerValue[]): PickerValueContext {
+    return {
+      get items() {
+        return generateItems(val)
+      },
+    }
+  }
+
+  return generateContext
+}

--- a/src/components/picker-view/use-picker-value-extend.tsx
+++ b/src/components/picker-view/use-picker-value-extend.tsx
@@ -1,12 +1,8 @@
 import { useMemo } from 'react'
 import memoize from 'lodash/memoize'
-import {
-  PickerValue,
-  PickerValueContext,
-  PickerColumnItem,
-} from './picker-view'
+import { PickerValue, PickerValueExtend, PickerColumnItem } from './picker-view'
 
-export function usePickerContext(columns: PickerColumnItem[][]) {
+export function usePickerValueExtend(columns: PickerColumnItem[][]) {
   const generateItems = useMemo(() => {
     return memoize(
       (val: PickerValue[]) => {
@@ -20,7 +16,7 @@ export function usePickerContext(columns: PickerColumnItem[][]) {
     )
   }, [columns])
 
-  function generateContext(val: PickerValue[]): PickerValueContext {
+  function generateValueExtend(val: PickerValue[]): PickerValueExtend {
     return {
       get items() {
         return generateItems(val)
@@ -28,5 +24,5 @@ export function usePickerContext(columns: PickerColumnItem[][]) {
     }
   }
 
-  return generateContext
+  return generateValueExtend
 }

--- a/src/components/picker/demos/index.tsx
+++ b/src/components/picker/demos/index.tsx
@@ -26,7 +26,7 @@ function BasicDemo() {
           setVisible(false)
         }}
         value={value}
-        onConfirm={(v, c) => {
+        onConfirm={v => {
           setValue(v)
         }}
       />
@@ -54,8 +54,8 @@ function RenderChildrenDemo() {
         }}
         value={value}
         onConfirm={setValue}
-        onSelect={(val, context) => {
-          console.log('onSelect', val, context.items)
+        onSelect={(val, extend) => {
+          console.log('onSelect', val, extend.items)
         }}
       >
         {items => {

--- a/src/components/picker/index.en.md
+++ b/src/components/picker/index.en.md
@@ -18,7 +18,7 @@ type PickerColumn = (string | PickerColumnItem)[]
 
 type PickerValue = string | null
 
-type PickerValueContext = {
+type PickerValueExtend = {
   items: (PickerColumnItem | null)[]
 }
 ```
@@ -28,8 +28,8 @@ type PickerValueContext = {
 | columns      | Options to configure each column        | `PickerColumn[] \| ((value: PickerValue[]) => PickerColumn[])` | -        |
 | value        | Selected options                        | `PickerValue[]`                                                | -        |
 | defaultValue | Default selected options                | `PickerValue[]`                                                | -        |
-| onSelect     | Triggered when the options are changed  | `(value: PickerValue[], context: PickerValueContext) => void`  | -        |
-| onConfirm    | Triggered when confirming               | `(value: PickerValue[], context: PickerValueContext) => void`  | -        |
+| onSelect     | Triggered when the options are changed  | `(value: PickerValue[], extend: PickerValueExtend) => void`    | -        |
+| onConfirm    | Triggered when confirming               | `(value: PickerValue[], extend: PickerValueExtend) => void`    | -        |
 | onCancel     | Triggered when cancelling               | `() => void`                                                   | -        |
 | onClose      | Triggered when confirming or cancelling | `() => void`                                                   | -        |
 | visible      | Whether to show or hide the Picker      | `boolean`                                                      | `false`  |

--- a/src/components/picker/index.en.md
+++ b/src/components/picker/index.en.md
@@ -1,6 +1,6 @@
 # Picker
 
-The Picker series includes three components: `Picker`, `CascadePicker`, and `DatePicker`.
+The Picker series includes three components: [Picker](#picker), [CascadePicker](#cascadepicker) and [DatePicker](#datepicker).
 
 ## Picker
 

--- a/src/components/picker/index.ts
+++ b/src/components/picker/index.ts
@@ -9,7 +9,7 @@ export type {
   PickerValue,
   PickerColumnItem,
   PickerColumn,
-  PickerValueContext,
+  PickerValueExtend,
 } from '../picker-view'
 
 export default attachPropertiesToComponent(Picker, {

--- a/src/components/picker/index.ts
+++ b/src/components/picker/index.ts
@@ -9,6 +9,7 @@ export type {
   PickerValue,
   PickerColumnItem,
   PickerColumn,
+  PickerValueContext,
 } from '../picker-view'
 
 export default attachPropertiesToComponent(Picker, {

--- a/src/components/picker/index.zh.md
+++ b/src/components/picker/index.zh.md
@@ -18,7 +18,7 @@ type PickerColumn = (string | PickerColumnItem)[]
 
 type PickerValue = string | null
 
-type PickerValueContext = {
+type PickerValueExtend = {
   items: (PickerColumnItem | null)[]
 }
 ```
@@ -28,8 +28,8 @@ type PickerValueContext = {
 | columns      | 配置每一列的选项             | `PickerColumn[] \| ((value: PickerValue[]) => PickerColumn[])` | -        |
 | value        | 选中项                       | `PickerValue[]`                                                | -        |
 | defaultValue | 默认选中项                   | `PickerValue[]`                                                | -        |
-| onSelect     | 选项改变时触发               | `(value: PickerValue[], context: PickerValueContext) => void`  | -        |
-| onConfirm    | 确认时触发                   | `(value: PickerValue[], context: PickerValueContext) => void`  | -        |
+| onSelect     | 选项改变时触发               | `(value: PickerValue[], extend: PickerValueExtend) => void`    | -        |
+| onConfirm    | 确认时触发                   | `(value: PickerValue[], extend: PickerValueExtend) => void`    | -        |
 | onCancel     | 取消时触发                   | `() => void`                                                   | -        |
 | onClose      | 确认和取消时都会触发关闭事件 | `() => void`                                                   | -        |
 | visible      | 是否显示选择器               | `boolean`                                                      | `false`  |

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -7,12 +7,12 @@ import {
   PickerColumn,
   PickerColumnItem,
   PickerValue,
-  PickerValueContext,
+  PickerValueExtend,
 } from './index'
 import PickerView from '../picker-view'
 import { useColumns } from '../picker-view/use-columns'
 import { useConfig } from '../config-provider'
-import { usePickerContext } from '../picker-view/use-picker-context'
+import { usePickerValueExtend } from '../picker-view/use-picker-value-extend'
 
 const classPrefix = `adm-picker`
 
@@ -20,8 +20,8 @@ export type PickerProps = {
   columns: PickerColumn[] | ((value: PickerValue[]) => PickerColumn[])
   value?: PickerValue[]
   defaultValue?: PickerValue[]
-  onSelect?: (value: PickerValue[], context: PickerValueContext) => void
-  onConfirm?: (value: PickerValue[], context: PickerValueContext) => void
+  onSelect?: (value: PickerValue[], extend: PickerValueExtend) => void
+  onConfirm?: (value: PickerValue[], extend: PickerValueExtend) => void
   onCancel?: () => void
   onClose?: () => void
   visible?: boolean
@@ -53,12 +53,12 @@ export const Picker: FC<PickerProps> = p => {
   const [value, setValue] = usePropsValue({
     ...props,
     onChange: val => {
-      props.onConfirm?.(val, generateContext(val))
+      props.onConfirm?.(val, generateValueExtend(val))
     },
   })
 
   const columns = useColumns(props.columns, value)
-  const generateContext = usePickerContext(columns)
+  const generateValueExtend = usePickerValueExtend(columns)
 
   const [innerValue, setInnerValue] = useState<PickerValue[]>(value)
   useEffect(() => {
@@ -102,10 +102,10 @@ export const Picker: FC<PickerProps> = p => {
         <PickerView
           columns={innerColumns}
           value={innerValue}
-          onChange={(val, con) => {
+          onChange={(val, ext) => {
             setInnerValue(val)
             if (props.visible) {
-              props.onSelect?.(val, con)
+              props.onSelect?.(val, ext)
             }
           }}
         />
@@ -135,7 +135,7 @@ export const Picker: FC<PickerProps> = p => {
   return (
     <>
       {popupElement}
-      {props.children?.(generateContext(value).items)}
+      {props.children?.(generateValueExtend(value).items)}
     </>
   )
 }

--- a/src/components/selector/demos/demo1.tsx
+++ b/src/components/selector/demos/demo1.tsx
@@ -45,7 +45,7 @@ export default () => {
         <Selector
           options={ItemList}
           defaultValue={['1']}
-          onChange={(arr, context) => console.log(arr, context.items)}
+          onChange={(arr, extend) => console.log(arr, extend.items)}
         />
       </DemoBlock>
       <DemoBlock title='多选'>
@@ -53,7 +53,7 @@ export default () => {
           options={ItemList}
           defaultValue={['2', '3']}
           multiple={true}
-          onChange={(arr, context) => console.log(arr, context.items)}
+          onChange={(arr, extend) => console.log(arr, extend.items)}
         />
       </DemoBlock>
       <DemoBlock title='全局禁止'>

--- a/src/components/selector/index.en.md
+++ b/src/components/selector/index.en.md
@@ -10,15 +10,15 @@ type SelectorValue = string | number
 
 ## Selector
 
-| Name         | Description                            | Type                                                                     | Default |
-| ------------ | -------------------------------------- | ------------------------------------------------------------------------ | ------- |
-| value        | Selected value                         | `SelectorValue[]`                                                        | -       |
-| defaultValue | Selected value by default              | `SelectorValue[]`                                                        | `[]`    |
-| columns      | Number of the displayed columns        | `number`                                                                 | -       |
-| options      | Optional selector                      | `SelectorOption[]`                                                       | -       |
-| multiple     | Whether to allow multiple selections   | `boolean`                                                                | `false` |
-| disabled     | Whether to diabled selections globally | `boolean`                                                                | `false` |
-| onChange     | Triggered when the value is changed    | `(value: SelectorValue[], context: { items: SelectorOption[] }) => void` | -       |
+| Name         | Description                            | Type                                                                    | Default |
+| ------------ | -------------------------------------- | ----------------------------------------------------------------------- | ------- |
+| value        | Selected value                         | `SelectorValue[]`                                                       | -       |
+| defaultValue | Selected value by default              | `SelectorValue[]`                                                       | `[]`    |
+| columns      | Number of the displayed columns        | `number`                                                                | -       |
+| options      | Optional selector                      | `SelectorOption[]`                                                      | -       |
+| multiple     | Whether to allow multiple selections   | `boolean`                                                               | `false` |
+| disabled     | Whether to diabled selections globally | `boolean`                                                               | `false` |
+| onChange     | Triggered when the value is changed    | `(value: SelectorValue[], extend: { items: SelectorOption[] }) => void` | -       |
 
 ## SelectorOption
 

--- a/src/components/selector/index.zh.md
+++ b/src/components/selector/index.zh.md
@@ -10,15 +10,15 @@ type SelectorValue = string | number
 
 ## Selector
 
-| 属性         | 说明             | 类型                                                                     | 默认值  |
-| ------------ | ---------------- | ------------------------------------------------------------------------ | ------- |
-| value        | 选中项           | `SelectorValue[]`                                                        | -       |
-| defaultValue | 默认项           | `SelectorValue[]`                                                        | `[]`    |
-| columns      | 行展示数         | `number`                                                                 | -       |
-| options      | 可选项           | `SelectorOption[]`                                                       | -       |
-| multiple     | 是否允许多选     | `boolean`                                                                | `false` |
-| disabled     | 是否全局禁止选中 | `boolean`                                                                | `false` |
-| onChange     | 选项改变时触发   | `(value: SelectorValue[], context: { items: SelectorOption[] }) => void` | -       |
+| 属性         | 说明             | 类型                                                                    | 默认值  |
+| ------------ | ---------------- | ----------------------------------------------------------------------- | ------- |
+| value        | 选中项           | `SelectorValue[]`                                                       | -       |
+| defaultValue | 默认项           | `SelectorValue[]`                                                       | `[]`    |
+| columns      | 行展示数         | `number`                                                                | -       |
+| options      | 可选项           | `SelectorOption[]`                                                      | -       |
+| multiple     | 是否允许多选     | `boolean`                                                               | `false` |
+| disabled     | 是否全局禁止选中 | `boolean`                                                               | `false` |
+| onChange     | 选项改变时触发   | `(value: SelectorValue[], extend: { items: SelectorOption[] }) => void` | -       |
 
 ## SelectorOption
 

--- a/src/components/selector/selector.tsx
+++ b/src/components/selector/selector.tsx
@@ -25,7 +25,7 @@ export type SelectorProps<V> = {
   disabled?: boolean
   defaultValue?: V[]
   value?: V[]
-  onChange?: (v: V[], context: { items: SelectorOption<V>[] }) => void
+  onChange?: (v: V[], extend: { items: SelectorOption<V>[] }) => void
 } & NativeProps<'--checked-color'>
 
 const defaultProps = {
@@ -39,12 +39,12 @@ export const Selector = <V extends SelectorValue>(p: SelectorProps<V>) => {
     value: props.value,
     defaultValue: props.defaultValue,
     onChange: val => {
-      const context = {
+      const extend = {
         get items() {
           return props.options.filter(option => val.includes(option.value))
         },
       }
-      props.onChange?.(val, context)
+      props.onChange?.(val, extend)
     },
   })
 

--- a/src/components/tree-select/index.en.md
+++ b/src/components/tree-select/index.en.md
@@ -14,10 +14,10 @@ type TreeSelectOption = {
 }
 ```
 
-| Name         | Description                                                      | Type                                                                  | Default |
-| ------------ | ---------------------------------------------------------------- | --------------------------------------------------------------------- | ------- |
-| value        | Selected options                                                 | `string[]`                                                            | `[]`    |
-| defaultValue | Selected options by default                                      | `string[]`                                                            | `[]`    |
-| onChange     | Triggered when `value` is changed                                | `(value: string[], context: { options: TreeSelectOption[] }) => void` | -       |
-| options      | Cascaded data                                                    | `TreeSelectOption[]`                                                  | `[]`    |
-| fieldNames   | The customized fields of `label` `value` `children` in `options` | `{ label?: string; value?: string; children?: string }`               | `{}`    |
+| Name         | Description                                                      | Type                                                                 | Default |
+| ------------ | ---------------------------------------------------------------- | -------------------------------------------------------------------- | ------- |
+| value        | Selected options                                                 | `string[]`                                                           | `[]`    |
+| defaultValue | Selected options by default                                      | `string[]`                                                           | `[]`    |
+| onChange     | Triggered when `value` is changed                                | `(value: string[], extend: { options: TreeSelectOption[] }) => void` | -       |
+| options      | Cascaded data                                                    | `TreeSelectOption[]`                                                 | `[]`    |
+| fieldNames   | The customized fields of `label` `value` `children` in `options` | `{ label?: string; value?: string; children?: string }`              | `{}`    |

--- a/src/components/tree-select/index.zh.md
+++ b/src/components/tree-select/index.zh.md
@@ -14,10 +14,10 @@ type TreeSelectOption = {
 }
 ```
 
-| 参数         | 说明                                                  | 类型                                                                  | 默认值 |
-| ------------ | ----------------------------------------------------- | --------------------------------------------------------------------- | ------ |
-| value        | 选中项                                                | `string[]`                                                            | `[]`   |
-| defaultValue | 默认选中项                                            | `string[]`                                                            | `[]`   |
-| onChange     | `value` 变化时触发                                    | `(value: string[], context: { options: TreeSelectOption[] }) => void` | -      |
-| options      | 级联数据                                              | `TreeSelectOption[]`                                                  | `[]`   |
-| fieldNames   | 自定义 `options` 中 `label` `value` `children` 的字段 | `{ label?: string; value?: string; children?: string }`               | `{}`   |
+| 参数         | 说明                                                  | 类型                                                                 | 默认值 |
+| ------------ | ----------------------------------------------------- | -------------------------------------------------------------------- | ------ |
+| value        | 选中项                                                | `string[]`                                                           | `[]`   |
+| defaultValue | 默认选中项                                            | `string[]`                                                           | `[]`   |
+| onChange     | `value` 变化时触发                                    | `(value: string[], extend: { options: TreeSelectOption[] }) => void` | -      |
+| options      | 级联数据                                              | `TreeSelectOption[]`                                                 | `[]`   |
+| fieldNames   | 自定义 `options` 中 `label` `value` `children` 的字段 | `{ label?: string; value?: string; children?: string }`              | `{}`   |

--- a/src/components/tree-select/tree-select.tsx
+++ b/src/components/tree-select/tree-select.tsx
@@ -15,7 +15,7 @@ export type TreeSelectProps = {
   options: TreeSelectOption[]
   defaultValue?: string[]
   value?: string[]
-  onChange?: (value: string[], context: { options: TreeSelectOption[] }) => void
+  onChange?: (value: string[], extend: { options: TreeSelectOption[] }) => void
   fieldNames?: { label: string; value: string; children: string }
 } & NativeProps
 


### PR DESCRIPTION
为了代码复用（优雅），将之前获取 `context` 部分的逻辑整合成了 `usePickerContext` hook，在 Picker 和 PickerView 中都通过 `usePickerContext` 来获取 `context`