### PR TITLE
fix: (Switch) `checked` cannot be changed when `beforeChange` is not set

### DIFF
--- a/src/components/switch/switch.tsx
+++ b/src/components/switch/switch.tsx
@@ -37,10 +37,10 @@ export const Switch: FC<SwitchProps> = p => {
     if (disabled || props.loading || changing) {
       return
     }
-    setChanging(true)
+    const nextChecked = !checked
     if (props.beforeChange) {
+      setChanging(true)
       try {
-        const nextChecked = !checked
         await props.beforeChange(nextChecked)
         setChecked(nextChecked)
         setChanging(false)
@@ -48,6 +48,8 @@ export const Switch: FC<SwitchProps> = p => {
         setChanging(false)
         throw e
       }
+    } else {
+      setChecked(nextChecked)
     }
   }
 


### PR DESCRIPTION
修复在 Switch 中的 beforeChange 的判断范围影响 checked 值无法正确更新的问题
#4420