### PR TITLE
feat: (List) custom border style

### DIFF
--- a/src/components/list/demos/index.tsx
+++ b/src/components/list/demos/index.tsx
@@ -116,8 +116,8 @@ export default () => {
         <List
           style={{
             '--border-inner': 'none',
-            '--border-top': 'none',
-            '--border-bottom': 'none',
+            '--border-top': '1px solid red',
+            '--border-bottom': '1px solid blue',
           }}
         >
           <List.Item>1</List.Item>

--- a/src/components/list/demos/index.tsx
+++ b/src/components/list/demos/index.tsx
@@ -115,7 +115,7 @@ export default () => {
       <DemoBlock title='自定义边框' padding='0' border='none'>
         <List
           style={{
-            '--item-border-bottom': 'none',
+            '--border-inner': 'none',
             '--border-top': 'none',
             '--border-bottom': 'none',
           }}

--- a/src/components/list/demos/index.tsx
+++ b/src/components/list/demos/index.tsx
@@ -112,6 +112,19 @@ export default () => {
           </List>
         </div>
       </DemoBlock>
+      <DemoBlock title='自定义边框' padding='0' border='none'>
+        <List
+          style={{
+            '--item-border-bottom': 'none',
+            '--border-top': 'none',
+            '--border-bottom': 'none',
+          }}
+        >
+          <List.Item>1</List.Item>
+          <List.Item>2</List.Item>
+          <List.Item>3</List.Item>
+        </List>
+      </DemoBlock>
     </>
   )
 }

--- a/src/components/list/index.en.md
+++ b/src/components/list/index.en.md
@@ -28,7 +28,10 @@
 
 ### List & List.Item
 
-| Name                      | Description                        | Default                   |
-| ------------------------- | ---------------------------------- | ------------------------- |
-| --prefix-width            | Width of the prefix part.          | `auto`                    |
-| --active-background-color | The background color when clicked. | `var(--adm-border-color)` |
+| Name                      | Description                          | Default                             |
+| ------------------------- | ------------------------------------ | ----------------------------------- |
+| --prefix-width            | Width of the prefix part.            | `auto`                              |
+| --active-background-color | The background color when clicked.   | `var(--adm-border-color)`           |
+| --item-border-bottom      | Border style of the list item bottom | `solid 1px var(--adm-border-color)` |
+| --border-top              | Border style of the list top         | `solid 1px var(--adm-border-color)` |
+| --border-bottom           | Border style of the list bottom      | `solid 1px var(--adm-border-color)` |

--- a/src/components/list/index.en.md
+++ b/src/components/list/index.en.md
@@ -32,6 +32,6 @@
 | ------------------------- | ------------------------------------ | ----------------------------------- |
 | --prefix-width            | Width of the prefix part.            | `auto`                              |
 | --active-background-color | The background color when clicked.   | `var(--adm-border-color)`           |
-| --item-border-bottom      | Border style of the list item bottom | `solid 1px var(--adm-border-color)` |
+| --border-inner            | Border style of the list item bottom | `solid 1px var(--adm-border-color)` |
 | --border-top              | Border style of the list top         | `solid 1px var(--adm-border-color)` |
 | --border-bottom           | Border style of the list bottom      | `solid 1px var(--adm-border-color)` |

--- a/src/components/list/index.zh.md
+++ b/src/components/list/index.zh.md
@@ -32,6 +32,6 @@
 | ------------------------- | ---------------------- | ----------------------------------- |
 | --prefix-width            | prefix 部分的宽度      | `auto`                              |
 | --active-background-color | 点击时的背景颜色       | `var(--adm-border-color)`           |
-| --item-border-bottom      | 列表项底部的边框样式   | `solid 1px var(--adm-border-color)` |
+| --border-inner            | 列表项底部的边框样式   | `solid 1px var(--adm-border-color)` |
 | --border-top              | 列表容器顶部的边框样式 | `solid 1px var(--adm-border-color)` |
 | --border-bottom           | 列表容器底部的边框样式 | `solid 1px var(--adm-border-color)` |

--- a/src/components/list/index.zh.md
+++ b/src/components/list/index.zh.md
@@ -28,7 +28,10 @@
 
 ### List & List.Item
 
-| 属性                      | 说明              | 默认值                    |
-| ------------------------- | ----------------- | ------------------------- |
-| --prefix-width            | prefix 部分的宽度 | `auto`                    |
-| --active-background-color | 点击时的背景颜色  | `var(--adm-border-color)` |
+| 属性                      | 说明                   | 默认值                              |
+| ------------------------- | ---------------------- | ----------------------------------- |
+| --prefix-width            | prefix 部分的宽度      | `auto`                              |
+| --active-background-color | 点击时的背景颜色       | `var(--adm-border-color)`           |
+| --item-border-bottom      | 列表项底部的边框样式   | `solid 1px var(--adm-border-color)` |
+| --border-top              | 列表容器顶部的边框样式 | `solid 1px var(--adm-border-color)` |
+| --border-bottom           | 列表容器底部的边框样式 | `solid 1px var(--adm-border-color)` |

--- a/src/components/list/list-item.tsx
+++ b/src/components/list/list-item.tsx
@@ -16,12 +16,7 @@ export type ListItemProps = {
   disabled?: boolean
   onClick?: (e: React.MouseEvent) => void
 } & NativeProps<
-  | '--prefix-width'
-  | '--align-items'
-  | '--active-background-color'
-  | '--item-border-bottom'
-  | '--border-top'
-  | '--border-bottom'
+  '--prefix-width' | '--align-items' | '--active-background-color'
 >
 
 export const ListItem: FC<ListItemProps> = props => {

--- a/src/components/list/list-item.tsx
+++ b/src/components/list/list-item.tsx
@@ -16,7 +16,12 @@ export type ListItemProps = {
   disabled?: boolean
   onClick?: (e: React.MouseEvent) => void
 } & NativeProps<
-  '--prefix-width' | '--align-items' | '--active-background-color'
+  | '--prefix-width'
+  | '--align-items'
+  | '--active-background-color'
+  | '--item-border-bottom'
+  | '--border-top'
+  | '--border-bottom'
 >
 
 export const ListItem: FC<ListItemProps> = props => {

--- a/src/components/list/list.less
+++ b/src/components/list/list.less
@@ -2,7 +2,7 @@
   --prefix-width: 'auto';
   --align-items: center;
   --active-background-color: var(--adm-border-color);
-  --item-border-bottom: solid 1px var(--adm-border-color);
+  --border-inner: solid 1px var(--adm-border-color);
   --border-top: solid 1px var(--adm-border-color);
   --border-bottom: solid 1px var(--adm-border-color);
   background-color: #ffffff;
@@ -34,7 +34,7 @@
     align-items: var(--align-items);
     justify-content: flex-start;
     padding: 12px 12px 12px 0;
-    border-bottom: var(--item-border-bottom);
+    border-bottom: var(--border-inner);
     &-prefix {
       width: var(--prefix-width);
       flex: none;

--- a/src/components/list/list.less
+++ b/src/components/list/list.less
@@ -2,6 +2,9 @@
   --prefix-width: 'auto';
   --align-items: center;
   --active-background-color: var(--adm-border-color);
+  --item-border-bottom: solid 1px var(--adm-border-color);
+  --border-top: solid 1px var(--adm-border-color);
+  --border-bottom: solid 1px var(--adm-border-color);
   background-color: #ffffff;
   overflow: hidden;
   font-size: 17px;
@@ -9,9 +12,8 @@
     margin-bottom: -1px;
   }
   &-default {
-    border: solid 1px var(--adm-border-color);
-    border-right: none;
-    border-left: none;
+    border-top: var(--border-top);
+    border-bottom: var(--border-bottom);
   }
   &-card {
     margin: 12px;
@@ -32,7 +34,7 @@
     align-items: var(--align-items);
     justify-content: flex-start;
     padding: 12px 12px 12px 0;
-    border-bottom: solid 1px var(--adm-border-color);
+    border-bottom: var(--item-border-bottom);
     &-prefix {
       width: var(--prefix-width);
       flex: none;

--- a/src/components/list/list.tsx
+++ b/src/components/list/list.tsx
@@ -8,7 +8,12 @@ const classPrefix = `adm-list`
 export type ListProps = {
   mode?: 'default' | 'card' // 默认是整宽的列表，card 模式下展示为带 margin 和圆角的卡片
 } & NativeProps<
-  '--prefix-width' | '--align-items' | '--active-background-color'
+  | '--prefix-width'
+  | '--align-items'
+  | '--active-background-color'
+  | '--item-border-bottom'
+  | '--border-top'
+  | '--border-bottom'
 >
 
 const defaultProps = {

--- a/src/components/list/list.tsx
+++ b/src/components/list/list.tsx
@@ -11,7 +11,7 @@ export type ListProps = {
   | '--prefix-width'
   | '--align-items'
   | '--active-background-color'
-  | '--item-border-bottom'
+  | '--border-inner'
   | '--border-top'
   | '--border-bottom'
 >


### PR DESCRIPTION
Ability to custom the style of the List and List.Item border

Like this:

```js
style={{
  '--item-border-bottom': 'none',
  '--border-top': '1px solid red',
  '--border-bottom': '1px solid blue',
}}
```

<img src='https://user-images.githubusercontent.com/51314472/143664123-8e3a2418-7d42-4a31-9b5a-9f5dce47643d.png' width='50%'></img>