### PR TITLE
fix: (Tabs) tab line animation fail when resize

### DIFF
--- a/src/components/tabs/tabs.tsx
+++ b/src/components/tabs/tabs.tsx
@@ -44,7 +44,6 @@ const defaultProps = {
 export const Tabs: FC<TabsProps> = p => {
   const props = mergeProps(defaultProps, p)
   const tabListContainerRef = useRef<HTMLDivElement>(null)
-  const rootRef = useRef<HTMLDivElement>(null)
   const activeLineRef = useRef<HTMLDivElement>(null)
   const keyToIndexRecord: Record<string, number> = {}
   let firstActiveKey: string | null = null
@@ -166,7 +165,7 @@ export const Tabs: FC<TabsProps> = p => {
 
   useResizeEffect(() => {
     animate(true)
-  }, rootRef)
+  }, tabListContainerRef)
 
   useMutationEffect(
     () => {
@@ -209,7 +208,7 @@ export const Tabs: FC<TabsProps> = p => {
 
   return withNativeProps(
     props,
-    <div className={classPrefix} ref={rootRef}>
+    <div className={classPrefix}>
       <div className={`${classPrefix}-header`}>
         <animated.div
           className={classNames(


### PR DESCRIPTION
修复：https://github.com/ant-design/ant-design-mobile/issues/4448

这里不是很清楚为啥要监听根节点的resize，Tabs.Tab的children宽高变化应该不会影响上面的tab吧，所以这里我把监听根节点调整到`tabListContainerRef`。