### PR TITLE
fix: (ImageUploader) change the deleted logic to delete images by index

### DIFF
--- a/src/components/image-uploader/image-uploader.tsx
+++ b/src/components/image-uploader/image-uploader.tsx
@@ -180,7 +180,7 @@ export const ImageUploader: FC<ImageUploaderProps> = p => {
             onDelete={async () => {
               const canDelete = await props.onDelete?.(fileItem)
               if (canDelete === false) return
-              setValue(value.filter(x => x.url !== fileItem.url))
+              setValue(value.filter((x, i) => i !== index))
             }}
           />
         ))}


### PR DESCRIPTION
fix [#4328](https://github.com/ant-design/ant-design-mobile/issues/4328) 
我发现删除图片是通过url，相同url图片就会出现BUG。

现在通过index删除。
