### PR TITLE
feat(deps): update ahooks v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@react-spring/web": "^9.3.1",
     "@types/resize-observer-browser": "^0.1.6",
     "@use-gesture/react": "^10.2.4",
-    "ahooks": "^2.10.14",
+    "ahooks": "^3.0.0",
     "antd-mobile-icons": "^0.2.2",
     "antd-mobile-v5-count": "^1.0.1",
     "classnames": "^2.3.1",

--- a/src/components/date-picker/date-picker.tsx
+++ b/src/components/date-picker/date-picker.tsx
@@ -1,5 +1,5 @@
 import React, { FC, ReactNode, useCallback, useMemo } from 'react'
-import { usePersistFn } from 'ahooks'
+import { useMemoizedFn } from 'ahooks'
 import Picker, { PickerProps } from '../picker'
 import { NativeProps, withNativeProps } from '../../utils/native-props'
 import { mergeProps } from '../../utils/with-default-props'
@@ -68,7 +68,7 @@ export const DatePicker: FC<DatePickerProps> = p => {
     [setValue, props.precision]
   )
 
-  const onSelect = usePersistFn((val: string[]) => {
+  const onSelect = useMemoizedFn((val: string[]) => {
     const date = convertStringArrayToDate(val, props.precision)
     props.onSelect?.(date)
   })

--- a/src/components/image-uploader/image-uploader.tsx
+++ b/src/components/image-uploader/image-uploader.tsx
@@ -10,7 +10,7 @@ import { mergeProps } from '../../utils/with-default-props'
 import ImageViewer from '../image-viewer'
 import PreviewItem from './preview-item'
 import { usePropsValue } from '../../utils/use-props-value'
-import { usePersistFn } from 'ahooks'
+import { useMemoizedFn } from 'ahooks'
 import Space from '../space'
 import { NativeProps, withNativeProps } from '../../utils/native-props'
 
@@ -63,7 +63,7 @@ const defaultProps = {
 export const ImageUploader: FC<ImageUploaderProps> = p => {
   const props = mergeProps(defaultProps, p)
   const [value, setValue] = usePropsValue(props)
-  const updateValue = usePersistFn(
+  const updateValue = useMemoizedFn(
     (updater: (prev: ImageUploadItem[]) => ImageUploadItem[]) => {
       setValue(updater(value))
     }

--- a/src/components/infinite-scroll/infinite-scroll.tsx
+++ b/src/components/infinite-scroll/infinite-scroll.tsx
@@ -1,6 +1,6 @@
 import { mergeProps } from '../../utils/with-default-props'
 import React, { FC, useEffect, useRef } from 'react'
-import { useLockFn, usePersistFn } from 'ahooks'
+import { useLockFn, useMemoizedFn } from 'ahooks'
 import { NativeProps, withNativeProps } from '../../utils/native-props'
 import { getScrollParent } from '../../utils/get-scroll-parent'
 import Loading from '../loading'
@@ -39,7 +39,7 @@ export const InfiniteScroll: FC<InfiniteScrollProps> = p => {
   const elementRef = useRef<HTMLDivElement>(null)
 
   const checkTimeoutRef = useRef<number>()
-  const check = usePersistFn(() => {
+  const check = useMemoizedFn(() => {
     window.clearTimeout(checkTimeoutRef.current)
     checkTimeoutRef.current = window.setTimeout(() => {
       if (!props.hasMore) return

--- a/src/components/number-keyboard/number-keyboard.tsx
+++ b/src/components/number-keyboard/number-keyboard.tsx
@@ -7,7 +7,7 @@ import Popup, { PopupProps } from '../popup'
 import { GetContainer } from '../../utils/render-to-container'
 import { NativeProps, withNativeProps } from '../../utils/native-props'
 import SafeArea from '../safe-area'
-import { usePersistFn } from 'ahooks'
+import { useMemoizedFn } from 'ahooks'
 
 const classPrefix = 'adm-number-keyboard'
 
@@ -70,7 +70,7 @@ export const NumberKeyboard: React.FC<NumberKeyboardProps> = p => {
   const timeoutRef = useRef(-1)
   const intervalRef = useRef(-1)
 
-  const onDelete = usePersistFn(() => {
+  const onDelete = useMemoizedFn(() => {
     props.onDelete?.()
   })
 

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -13,7 +13,7 @@ import PickerView from '../picker-view'
 import { useColumns } from '../picker-view/use-columns'
 import { useConfig } from '../config-provider'
 import { usePickerValueExtend } from '../picker-view/use-picker-value-extend'
-import { usePersistFn } from 'ahooks'
+import { useMemoizedFn } from 'ahooks'
 
 const classPrefix = `adm-picker`
 
@@ -74,7 +74,7 @@ export const Picker = memo<PickerProps>(p => {
     }
   }, [value])
 
-  const onChange = usePersistFn((val, ext) => {
+  const onChange = useMemoizedFn((val, ext) => {
     setInnerValue(val)
     if (props.visible) {
       props.onSelect?.(val, ext)

--- a/src/components/switch/demos/demo1.tsx
+++ b/src/components/switch/demos/demo1.tsx
@@ -16,8 +16,8 @@ export default () => {
       <DemoBlock title='受控组件'>
         <Switch
           checked={checked}
-          onChange={checked => {
-            toggleChecked(checked)
+          onChange={() => {
+            toggleChecked()
           }}
         />
       </DemoBlock>

--- a/src/utils/use-mutation-effect.tsx
+++ b/src/utils/use-mutation-effect.tsx
@@ -1,12 +1,12 @@
 import { RefObject, useEffect } from 'react'
-import { usePersistFn } from 'ahooks'
+import { useMemoizedFn } from 'ahooks'
 
 export function useMutationEffect(
   effect: () => void,
   targetRef: RefObject<HTMLElement>,
   options: MutationObserverInit
 ) {
-  const fn = usePersistFn(effect)
+  const fn = useMemoizedFn(effect)
   useEffect(() => {
     const observer = new MutationObserver(() => {
       fn()

--- a/src/utils/use-props-value.ts
+++ b/src/utils/use-props-value.ts
@@ -1,5 +1,5 @@
 import { useRef } from 'react'
-import { usePersistFn, useUpdate } from 'ahooks'
+import { useMemoizedFn, useUpdate } from 'ahooks'
 
 type Options<T> = {
   value?: T
@@ -17,7 +17,7 @@ export function usePropsValue<T>(options: Options<T>) {
     stateRef.current = value
   }
 
-  const setState = usePersistFn((v: T) => {
+  const setState = useMemoizedFn((v: T) => {
     if (value === undefined) {
       stateRef.current = v
       update()

--- a/src/utils/use-resize-effect.tsx
+++ b/src/utils/use-resize-effect.tsx
@@ -1,11 +1,11 @@
 import { RefObject, useLayoutEffect } from 'react'
-import { usePersistFn } from 'ahooks'
+import { useMemoizedFn } from 'ahooks'
 
 export function useResizeEffect<T extends HTMLElement>(
   effect: (target: T) => void,
   targetRef: RefObject<T>
 ) {
-  const fn = usePersistFn(effect)
+  const fn = useMemoizedFn(effect)
   useLayoutEffect(() => {
     const target = targetRef.current
     if (!target) return


### PR DESCRIPTION
将ahooks 版本由v2 升级到 v3， 解决项目依赖ahooks 版本为v3时，checkbox 等组件抛出usePersistFn is not a function 错误。

antdm 使用以下两个hooks， 属于Breaking Changes
usePersistFn
useToggle