### PR TITLE
feat: (Input) add `inputMode` prop

### DIFF
--- a/src/components/input/index.en.md
+++ b/src/components/input/index.en.md
@@ -19,7 +19,7 @@ The `Input` component is layout-independent. It only includes the most basic inp
 | id           | The id of the input element, usually used with label                                          | `string`                                             | -       |
 | onEnterPress | The callback when Enter key is pressed                                                        | `(e: React.KeyboardEvent<HTMLInputElement>) => void` | -       |
 
-In addition, the following native attributes are supported: `maxLength` `minLength` `max` `min` `autoComplete` `enterKeyHint` `pattern` `type` `onFocus` `onBlur` `autoCapitalize` `autoCorrect` `onKeyDown` `onKeyUp`
+In addition, the following native attributes are supported: `maxLength` `minLength` `max` `min` `autoComplete` `enterKeyHint` `pattern` `inputMode` `type` `onFocus` `onBlur` `autoCapitalize` `autoCorrect` `onKeyDown` `onKeyUp`
 
 ### CSS Variables
 

--- a/src/components/input/index.zh.md
+++ b/src/components/input/index.zh.md
@@ -19,7 +19,7 @@
 | id           | input 元素的 id，常用来配合 label 使用       | `string`                                             | -       |
 | onEnterPress | 按下回车的回调                               | `(e: React.KeyboardEvent<HTMLInputElement>) => void` | -       |
 
-此外还支持以下原生属性：`maxLength` `minLength` `max` `min` `autoComplete` `enterKeyHint` `pattern` `type` `onFocus` `onBlur` `autoCapitalize` `autoCorrect` `onKeyDown` `onKeyUp`
+此外还支持以下原生属性：`maxLength` `minLength` `max` `min` `autoComplete` `enterKeyHint` `pattern` `inputMode` `type` `onFocus` `onBlur` `autoCapitalize` `autoCorrect` `onKeyDown` `onKeyUp`
 
 ### CSS 变量
 

--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -25,6 +25,7 @@ export type InputProps = Pick<
   | 'min'
   | 'autoComplete'
   | 'pattern'
+  | 'inputMode'
   | 'type'
   | 'onFocus'
   | 'onBlur'


### PR DESCRIPTION
用于指定输入框弹出键盘类型，MDN文档如下：

https://developer.mozilla.org/zh-CN/docs/Web/HTML/Global_attributes/inputmode