### PR TITLE
doc: (Modal) add primary for Action

### DIFF
--- a/src/components/modal/index.en.md
+++ b/src/components/modal/index.en.md
@@ -36,6 +36,7 @@
 | text      | The title                         | `string`                      | -       |
 | disabled  | Whether disabled state or not     | `boolean`                     | `false` |
 | danger    | Whether in dangerous state or not | `boolean`                     | `false` |
+| primary   | Whether in primary state or not   | `boolean`                     | `false` |
 | bold      | Whether the text is bold          | `boolean`                     | `false` |
 | className | Class name of the action button   | `string`                      | -       |
 | style     | Style of the action button        | `React.CSSProperties`         | -       |

--- a/src/components/modal/index.zh.md
+++ b/src/components/modal/index.zh.md
@@ -36,6 +36,7 @@
 | text      | 标题           | `string`                      | -       |
 | disabled  | 是否为禁用状态 | `boolean`                     | `false` |
 | danger    | 是否为危险状态 | `boolean`                     | `false` |
+| primary   | 是否为主要状态 | `boolean`                     | `false` |
 | bold      | 是否文字加粗   | `boolean`                     | `false` |
 | style     | `Action` 样式  | `React.CSSProperties`         | -       |
 | className | `Action` 类名  | `string`                      | -       |


### PR DESCRIPTION
the `Action` props of the `Modal `component supports the `primary` field, but the document is not displayed