### PR TITLE
fix: (ImageUploader) `ImageViewer` should be hidden when `ImageUploader` is unmounted

### DIFF
--- a/src/components/image-uploader/image-uploader.tsx
+++ b/src/components/image-uploader/image-uploader.tsx
@@ -158,10 +158,12 @@ export const ImageUploader: FC<ImageUploaderProps> = p => {
     e.target.value = '' // HACK: fix the same file doesn't trigger onChange
   }
 
+  const containerRef = useRef<HTMLDivElement>(null)
   function previewImage(index: number) {
     ImageViewer.Multi.show({
       images: value.map(fileItem => fileItem.url),
       defaultIndex: index,
+      getContainer: containerRef.current,
     })
   }
 
@@ -171,7 +173,7 @@ export const ImageUploader: FC<ImageUploaderProps> = p => {
 
   return withNativeProps(
     props,
-    <div className={classPrefix}>
+    <div ref={containerRef} className={classPrefix}>
       <Space className={`${classPrefix}-space`} wrap>
         {value.map((fileItem, index) => (
           <PreviewItem


### PR DESCRIPTION
close #4654

指定了`ImageViewer.Multi.show`的`getContainer`为当前组件内层级div。看这个方案是否合理