### PR TITLE
fix: (utils)  useTabListScroll not work when activeIndex value is  0

### DIFF
--- a/src/utils/use-tab-list-scroll.ts
+++ b/src/utils/use-tab-list-scroll.ts
@@ -6,7 +6,7 @@ import { useUpdateLayoutEffect } from 'ahooks'
 
 export const useTabListScroll = (
   targetRef: RefObject<HTMLElement>,
-  activeIndex: number
+  activeIndex: number | undefined
 ) => {
   const [{ scrollLeft }, api] = useSpring(() => ({
     scrollLeft: 0,
@@ -19,7 +19,7 @@ export const useTabListScroll = (
   function animate(immediate = false) {
     const container = targetRef.current
     if (!container) return
-    if (!activeIndex && activeIndex !== 0) return
+    if (activeIndex === undefined) return
 
     const activeTabWrapper = container.children.item(
       activeIndex

--- a/src/utils/use-tab-list-scroll.ts
+++ b/src/utils/use-tab-list-scroll.ts
@@ -19,7 +19,7 @@ export const useTabListScroll = (
   function animate(immediate = false) {
     const container = targetRef.current
     if (!container) return
-    if (!activeIndex) return
+    if (!activeIndex && activeIndex !== 0) return
 
     const activeTabWrapper = container.children.item(
       activeIndex


### PR DESCRIPTION
When manually setting activeKey to the first item, it cannot automatically scroll to the first item