### PR TITLE
fix: button click mask in the stepper component not position properly

### DIFF
--- a/src/components/stepper/stepper.less
+++ b/src/components/stepper/stepper.less
@@ -52,7 +52,7 @@
     color: var(--button-text-color);
     background-color: var(--button-background-color);
     font-size: var(--button-font-size);
-    --border-width: 0;
+    // --border-width: 0;
 
     &:disabled {
       color: var(--adm-color-weak);


### PR DESCRIPTION
fix: fix a bug when click plus and minus button in the stepper component,  the mask shadow display incorrectly.

Mask shadow are not covering the button properly.
<img width="175" alt="Screen Shot 2022-01-20 at 12 13 39 PM" src="https://user-images.githubusercontent.com/59941818/150272126-0e6cd082-b2ec-4c90-9afd-926e647a301a.png">
