### PR TITLE
fix: (FloatingBubble) `--edge-distance` not working properly

### DIFF
--- a/src/components/floating-bubble/floating-bubble.less
+++ b/src/components/floating-bubble/floating-bubble.less
@@ -17,6 +17,7 @@
     width: 100vw;
     height: 100vh;
     padding: var(--edge-distance);
+    box-sizing: border-box;
     pointer-events: none;
   }
   &-boundary {


### PR DESCRIPTION
修复floating-bubble的容器缺少css `box-sizing:border-box`导致无法控制浮动边界的问题。