### PR TITLE
doc: (Icon) selector of copy type must have state

### DIFF
--- a/docs/components/icon/demo-all.tsx
+++ b/docs/components/icon/demo-all.tsx
@@ -124,7 +124,7 @@ export default () => {
         <Selector
           options={copyTypes}
           value={[copyType]}
-          onChange={(val: string[]) => setCopyType(val[0])}
+          onChange={(val: string[]) => setCopyType(val[0] || copyType)}
           className={`${classPrefix}-copy-type-selector`}
         />
         <SearchBar


### PR DESCRIPTION
修复之前选择复制类型时可能出现的误导用户的情况：
<img width="783" alt="image" src="https://user-images.githubusercontent.com/51314472/154417356-4c94f992-c29b-476d-8162-62760226d04c.png">