### PR TITLE
refactor: (Form) move layout style to `Form.Item`

### DIFF
--- a/src/components/form/form-item.less
+++ b/src/components/form/form-item.less
@@ -30,6 +30,17 @@
   &&-hidden {
     display: none;
   }
+
+  &&-horizontal {
+    --align-items: stretch;
+    .adm-list-item-content-prefix {
+      padding-top: 12px;
+      padding-bottom: 12px;
+    }
+    .adm-list-item-content-extra {
+      align-self: center;
+    }
+  }
 }
 
 .adm-form-vertical {
@@ -38,13 +49,6 @@
       font-size: 15px;
       margin-bottom: 4px;
     }
-  }
-}
-
-.adm-form-horizontal {
-  .adm-list-item-content-prefix {
-    padding-top: 12px;
-    padding-bottom: 12px;
   }
 }
 

--- a/src/components/form/form-item.less
+++ b/src/components/form/form-item.less
@@ -11,6 +11,7 @@
     line-height: 1.5;
     box-sizing: border-box;
     position: relative;
+    color: #666666;
 
     &-required {
       position: absolute;
@@ -32,7 +33,10 @@
   }
 
   &&-horizontal {
-    --align-items: stretch;
+    &.adm-list-item {
+      --align-items: stretch;
+      --prefix-width: 6em;
+    }
     .adm-list-item-content-prefix {
       padding-top: 12px;
       padding-bottom: 12px;
@@ -41,19 +45,11 @@
       align-self: center;
     }
   }
-}
 
-.adm-form-vertical {
-  .@{class-prefix-form-item} {
-    &-label {
+  &&-vertical {
+    .adm-form-item-label {
       font-size: 15px;
       margin-bottom: 4px;
     }
-  }
-}
-
-.@{class-prefix-form-item} {
-  &-label {
-    color: #666666;
   }
 }

--- a/src/components/form/form-item.tsx
+++ b/src/components/form/form-item.tsx
@@ -129,9 +129,14 @@ const FormItemLayout: React.FC<FormItemLayoutProps> = props => {
       prefix={layout === 'horizontal' && labelElement}
       extra={extra}
       description={descriptionElement}
-      className={classNames(classPrefix, className, {
-        [`${classPrefix}-hidden`]: hidden,
-      })}
+      className={classNames(
+        classPrefix,
+        className,
+        `${classPrefix}-${layout}`,
+        {
+          [`${classPrefix}-hidden`]: hidden,
+        }
+      )}
       disabled={disabled}
       onClick={props.onClick}
       arrow={arrow}

--- a/src/components/form/form.less
+++ b/src/components/form/form.less
@@ -5,11 +5,6 @@
     --padding-left: 16px;
     --padding-right: 12px;
   }
-  &-horizontal {
-    .adm-list.adm-list {
-      --prefix-width: 6em;
-    }
-  }
   .@{class-prefix-form}-footer {
     padding: 20px 12px;
   }

--- a/src/components/form/form.less
+++ b/src/components/form/form.less
@@ -8,10 +8,6 @@
   &-horizontal {
     .adm-list.adm-list {
       --prefix-width: 6em;
-      --align-items: stretch;
-      .adm-list-item-content-extra {
-        align-self: center;
-      }
     }
   }
   .@{class-prefix-form}-footer {

--- a/src/components/form/form.tsx
+++ b/src/components/form/form.tsx
@@ -95,7 +95,7 @@ export const Form = forwardRef<FormInstance, FormProps>((p, ref) => {
 
   return (
     <RcForm
-      className={classNames(classPrefix, `${classPrefix}-${layout}`, className)}
+      className={classNames(classPrefix, className)}
       style={style}
       ref={ref as ForwardedRef<RCFormInstance>}
       {...formProps}


### PR DESCRIPTION
**问题：`Form` layout 为 vertical ，`Form.Item` layout 为 horizontal 时，label 的位置会发生变化**

<img width="383" alt="image" src="https://user-images.githubusercontent.com/22469543/154606490-723fa5ae-2ee2-4246-ba66-a9f174c1203a.png">

<img width="361" alt="form" src="https://user-images.githubusercontent.com/22469543/154606169-5f5bdb30-159c-4cb8-a7b8-94ee7d88133a.png">

**解决：这里给`Form.Item` 添加了 `${classPrefix}-${layout}`，同时将 layout 样式迁移到 `Form.Item`**

<img width="379" alt="form-2" src="https://user-images.githubusercontent.com/22469543/154607248-c43ae63c-9d1b-43ac-8b18-d6d79f41f9d4.png">


<hr />

另外有几个问题：
1. 目前 `help` 属性有点鸡肋，跟 `label` 展示效果一样，后续会加新的样式吗
2. 这些手动添加`className` `style` 的地方，是否可以用 `withNativeProps` 替代

![image](https://user-images.githubusercontent.com/22469543/154607452-038f1c90-b252-4942-8d1f-32746cb92147.png)
![image](https://user-images.githubusercontent.com/22469543/154607588-d7d56ca2-cef7-44e7-8f21-494e9af81280.png)

