### PR TITLE
refactor: (Image) adjust display

### DIFF
--- a/src/components/image/image.less
+++ b/src/components/image/image.less
@@ -25,4 +25,8 @@
       color: var(--adm-color-weak);
     }
   }
+
+  &.@{class-prefix-image}-inline {
+    display: inline-block;
+  }
 }

--- a/src/components/image/image.tsx
+++ b/src/components/image/image.tsx
@@ -6,6 +6,7 @@ import { staged } from 'staged-components'
 import { toCSSLength } from '../../utils/to-css-length'
 import { LazyDetector } from './lazy-detector'
 import { useIsomorphicUpdateLayoutEffect } from '../../utils/use-isomorphic-update-layout-effect'
+import classNames from 'classnames'
 
 const classPrefix = `adm-image`
 
@@ -18,6 +19,7 @@ export type ImageProps = {
   placeholder?: ReactNode
   fallback?: ReactNode
   lazy?: boolean
+  inline?: boolean
   onClick?: (event: React.MouseEvent<HTMLImageElement, Event>) => void
   onError?: (event: React.SyntheticEvent<HTMLImageElement, Event>) => void
   onLoad?: (event: React.SyntheticEvent<HTMLImageElement, Event>) => void
@@ -46,6 +48,7 @@ const defaultProps = {
     </div>
   ),
   lazy: false,
+  inline: false,
 }
 
 export const Image = staged<ImageProps>(p => {
@@ -117,7 +120,13 @@ export const Image = staged<ImageProps>(p => {
   }
   return withNativeProps(
     props,
-    <div ref={ref} className={classPrefix} style={style}>
+    <div
+      ref={ref}
+      className={classNames(classPrefix, {
+        [`${classPrefix}-inline`]: props.inline,
+      })}
+      style={style}
+    >
       {props.lazy && !initialized && (
         <LazyDetector
           onActive={() => {

--- a/src/components/image/index.en.md
+++ b/src/components/image/index.en.md
@@ -15,6 +15,7 @@
 | placeholder | Placeholder when loading                                            | `ReactNode`                                                      | default placeholder |
 | fallback    | Placeholder when failed to load                                     | `ReactNode`                                                      | default placeholder |
 | lazy        | Whether to load image lazily                                        | `boolean`                                                        | `false`             |
+| inline      | Should render as inline-block element                               | `boolean`                                                        | `false`             |
 | onError     | Callback when failed to load                                        | `(event: React.SyntheticEvent<HTMLImageElement, Event>) => void` | -                   |
 | onClick     | The click event                                                     | `(event: React.MouseEvent<HTMLImageElement, Event>) => void`     | -                   |
 | onLoad      | Triggered when image loaded                                         | `(event: React.SyntheticEvent<HTMLImageElement, Event>) => void` | -                   |

--- a/src/components/image/index.zh.md
+++ b/src/components/image/index.zh.md
@@ -15,6 +15,7 @@
 | placeholder | 加载时的占位                        | `ReactNode`                                                      | 默认占位 |
 | fallback    | 加载失败的占位                      | `ReactNode`                                                      | 默认占位 |
 | lazy        | 是否懒加载图片                      | `boolean`                                                        | `false`  |
+| inline      | 是否渲染为内联元素                  | `boolean`                                                        | `false`  |
 | onError     | 加载失败时触发                      | `(event: React.SyntheticEvent<HTMLImageElement, Event>) => void` | -        |
 | onClick     | 图片点击事件                        | `(event: React.MouseEvent<HTMLImageElement, Event>) => void`     | -        |
 | onLoad      | 图片加载完时触发                    | `(event: React.SyntheticEvent<HTMLImageElement, Event>) => void` | -        |


### PR DESCRIPTION
Image `display: block` 会有下面的问题（图片较小），用 `inline-block` 是不是更好一点

<img width="403" alt="antd1" src="https://user-images.githubusercontent.com/22469543/155465872-d9497bd1-d317-45c0-9051-6161a870662d.png">
