### PR TITLE
refactor: (PullToRefresh) replace `pageYOffset` with `scrollY`

### DIFF
--- a/src/components/pull-to-refresh/pull-to-refresh.tsx
+++ b/src/components/pull-to-refresh/pull-to-refresh.tsx
@@ -112,7 +112,7 @@ export const PullToRefresh: FC<PullToRefreshProps> = p => {
         const top =
           'scrollTop' in scrollParent
             ? scrollParent.scrollTop
-            : scrollParent.pageYOffset
+            : scrollParent.scrollY
         if (top <= 0 && y > 0) {
           pullingRef.current = true
         }


### PR DESCRIPTION
有个 deprecated 提示

![pull-1](https://user-images.githubusercontent.com/22469543/156140729-81077000-f092-402a-8d2a-613fbbb5ef20.png)
