### PR TITLE
feat: (Ellipsis) add `stopPropagationForActionButtons` props

### DIFF
--- a/src/components/ellipsis/ellipsis.tsx
+++ b/src/components/ellipsis/ellipsis.tsx
@@ -3,6 +3,10 @@ import { mergeProps } from '../../utils/with-default-props'
 import { NativeProps, withNativeProps } from '../../utils/native-props'
 import { useResizeEffect } from '../../utils/use-resize-effect'
 import { useIsomorphicLayoutEffect } from 'ahooks'
+import {
+  PropagationEvent,
+  withStopPropagation,
+} from 'antd-mobile/src/utils/with-stop-propagation'
 
 const classPrefix = `adm-ellipsis`
 
@@ -12,6 +16,7 @@ export type EllipsisProps = {
   rows?: number
   expandText?: string
   collapseText?: string
+  stopPropagation?: PropagationEvent[]
 } & NativeProps
 
 const defaultProps = {
@@ -19,6 +24,7 @@ const defaultProps = {
   rows: 1,
   expandText: '',
   collapseText: '',
+  stopPropagation: ['click'],
 }
 
 type EllipsisedValue = {
@@ -163,26 +169,32 @@ export const Ellipsis: FC<EllipsisProps> = p => {
   ])
 
   const expandActionElement =
-    exceeded && props.expandText ? (
-      <a
-        onClick={() => {
-          setExpanded(true)
-        }}
-      >
-        {props.expandText}
-      </a>
-    ) : null
+    exceeded && props.expandText
+      ? withStopPropagation(
+          props.stopPropagation,
+          <a
+            onClick={() => {
+              setExpanded(true)
+            }}
+          >
+            {props.expandText}
+          </a>
+        )
+      : null
 
   const collapseActionElement =
-    exceeded && props.expandText ? (
-      <a
-        onClick={() => {
-          setExpanded(false)
-        }}
-      >
-        {props.collapseText}
-      </a>
-    ) : null
+    exceeded && props.expandText
+      ? withStopPropagation(
+          props.stopPropagation,
+          <a
+            onClick={() => {
+              setExpanded(false)
+            }}
+          >
+            {props.collapseText}
+          </a>
+        )
+      : null
 
   const renderContent = () => {
     if (!exceeded) {

--- a/src/components/ellipsis/ellipsis.tsx
+++ b/src/components/ellipsis/ellipsis.tsx
@@ -16,7 +16,7 @@ export type EllipsisProps = {
   rows?: number
   expandText?: string
   collapseText?: string
-  stopPropagationForExpandButtons?: PropagationEvent[]
+  stopPropagationForActionButtons?: PropagationEvent[]
 } & NativeProps
 
 const defaultProps = {
@@ -24,7 +24,7 @@ const defaultProps = {
   rows: 1,
   expandText: '',
   collapseText: '',
-  stopPropagationForExpandButtons: [],
+  stopPropagationForActionButtons: [],
 }
 
 type EllipsisedValue = {
@@ -171,7 +171,7 @@ export const Ellipsis: FC<EllipsisProps> = p => {
   const expandActionElement =
     exceeded && props.expandText
       ? withStopPropagation(
-          props.stopPropagationForExpandButtons,
+          props.stopPropagationForActionButtons,
           <a
             onClick={() => {
               setExpanded(true)
@@ -185,7 +185,7 @@ export const Ellipsis: FC<EllipsisProps> = p => {
   const collapseActionElement =
     exceeded && props.expandText
       ? withStopPropagation(
-          props.stopPropagationForExpandButtons,
+          props.stopPropagationForActionButtons,
           <a
             onClick={() => {
               setExpanded(false)

--- a/src/components/ellipsis/ellipsis.tsx
+++ b/src/components/ellipsis/ellipsis.tsx
@@ -16,7 +16,7 @@ export type EllipsisProps = {
   rows?: number
   expandText?: string
   collapseText?: string
-  stopPropagation?: PropagationEvent[]
+  stopPropagationForExpandButtons?: PropagationEvent[]
 } & NativeProps
 
 const defaultProps = {
@@ -24,7 +24,7 @@ const defaultProps = {
   rows: 1,
   expandText: '',
   collapseText: '',
-  stopPropagation: ['click'],
+  stopPropagationForExpandButtons: [],
 }
 
 type EllipsisedValue = {
@@ -171,7 +171,7 @@ export const Ellipsis: FC<EllipsisProps> = p => {
   const expandActionElement =
     exceeded && props.expandText
       ? withStopPropagation(
-          props.stopPropagation,
+          props.stopPropagationForExpandButtons,
           <a
             onClick={() => {
               setExpanded(true)
@@ -185,7 +185,7 @@ export const Ellipsis: FC<EllipsisProps> = p => {
   const collapseActionElement =
     exceeded && props.expandText
       ? withStopPropagation(
-          props.stopPropagation,
+          props.stopPropagationForExpandButtons,
           <a
             onClick={() => {
               setExpanded(false)

--- a/src/components/ellipsis/index.en.md
+++ b/src/components/ellipsis/index.en.md
@@ -4,11 +4,11 @@
 
 ### Props
 
-| Name            | Description                                                                          | Type                           | Default     |
-| --------------- | ------------------------------------------------------------------------------------ | ------------------------------ | ----------- |
-| content         | The text content                                                                     | `string`                       | -           |
-| direction       | Position omitted                                                                     | `'start' \| 'end' \| 'middle'` | `'end'`     |
-| rows            | The number to display lines                                                          | `number`                       | `1`         |
-| expandText      | Expand operation text                                                                | `string`                       | `''`        |
-| collapseText    | Collapse operation text                                                              | `string`                       | `''`        |
-| stopPropagation | Prevent the event bubbling caused by the expand operation and the collapse operation | `PropagationEvent[]`           | `['click']` |
+| Name                            | Description                                                                          | Type                           | Default |
+| ------------------------------- | ------------------------------------------------------------------------------------ | ------------------------------ | ------- |
+| content                         | The text content                                                                     | `string`                       | -       |
+| direction                       | Position omitted                                                                     | `'start' \| 'end' \| 'middle'` | `'end'` |
+| rows                            | The number to display lines                                                          | `number`                       | `1`     |
+| expandText                      | Expand operation text                                                                | `string`                       | `''`    |
+| collapseText                    | Collapse operation text                                                              | `string`                       | `''`    |
+| stopPropagationForExpandButtons | Prevent the event bubbling caused by the expand operation and the collapse operation | `PropagationEvent[]`           | `[]`    |

--- a/src/components/ellipsis/index.en.md
+++ b/src/components/ellipsis/index.en.md
@@ -4,10 +4,11 @@
 
 ### Props
 
-| Name         | Description                 | Type                           | Default |
-| ------------ | --------------------------- | ------------------------------ | ------- |
-| content      | The text content            | `string`                       | -       |
-| direction    | Position omitted            | `'start' \| 'end' \| 'middle'` | `'end'` |
-| rows         | The number to display lines | `number`                       | `1`     |
-| expandText   | Expand operation text       | `string`                       | `''`    |
-| collapseText | Collapse operation text     | `string`                       | `''`    |
+| Name            | Description                                                                          | Type                           | Default     |
+| --------------- | ------------------------------------------------------------------------------------ | ------------------------------ | ----------- |
+| content         | The text content                                                                     | `string`                       | -           |
+| direction       | Position omitted                                                                     | `'start' \| 'end' \| 'middle'` | `'end'`     |
+| rows            | The number to display lines                                                          | `number`                       | `1`         |
+| expandText      | Expand operation text                                                                | `string`                       | `''`        |
+| collapseText    | Collapse operation text                                                              | `string`                       | `''`        |
+| stopPropagation | Prevent the event bubbling caused by the expand operation and the collapse operation | `PropagationEvent[]`           | `['click']` |

--- a/src/components/ellipsis/index.en.md
+++ b/src/components/ellipsis/index.en.md
@@ -11,4 +11,4 @@
 | rows                            | The number to display lines                                                          | `number`                       | `1`     |
 | expandText                      | Expand operation text                                                                | `string`                       | `''`    |
 | collapseText                    | Collapse operation text                                                              | `string`                       | `''`    |
-| stopPropagationForExpandButtons | Prevent the event bubbling caused by the expand operation and the collapse operation | `PropagationEvent[]`           | `[]`    |
+| stopPropagationForActionButtons | Prevent the event bubbling caused by the expand operation and the collapse operation | `PropagationEvent[]`           | `[]`    |

--- a/src/components/ellipsis/index.zh.md
+++ b/src/components/ellipsis/index.zh.md
@@ -4,10 +4,11 @@
 
 ### 属性
 
-| 属性         | 说明           | 类型                           | 默认值  |
-| ------------ | -------------- | ------------------------------ | ------- |
-| content      | 文本内容       | `string`                       | -       |
-| direction    | 省略位置       | `'start' \| 'end' \| 'middle'` | `'end'` |
-| rows         | 展示几行       | `number`                       | `1`     |
-| expandText   | 展开操作的文案 | `string`                       | `''`    |
-| collapseText | 收起操作的文案 | `string`                       | `''`    |
+| 属性            | 说明                                 | 类型                           | 默认值      |
+| --------------- | ------------------------------------ | ------------------------------ | ----------- |
+| content         | 文本内容                             | `string`                       | -           |
+| direction       | 省略位置                             | `'start' \| 'end' \| 'middle'` | `'end'`     |
+| rows            | 展示几行                             | `number`                       | `1`         |
+| expandText      | 展开操作的文案                       | `string`                       | `''`        |
+| collapseText    | 收起操作的文案                       | `string`                       | `''`        |
+| stopPropagation | 阻止展开操作，收起操作引发的事件冒泡 | `PropagationEvent[]`           | `['click']` |

--- a/src/components/ellipsis/index.zh.md
+++ b/src/components/ellipsis/index.zh.md
@@ -11,4 +11,4 @@
 | rows                            | 展示几行                             | `number`                       | `1`     |
 | expandText                      | 展开操作的文案                       | `string`                       | `''`    |
 | collapseText                    | 收起操作的文案                       | `string`                       | `''`    |
-| stopPropagationForExpandButtons | 阻止展开操作，收起操作引发的事件冒泡 | `PropagationEvent[]`           | `[]`    |
+| stopPropagationForActionButtons | 阻止展开操作，收起操作引发的事件冒泡 | `PropagationEvent[]`           | `[]`    |

--- a/src/components/ellipsis/index.zh.md
+++ b/src/components/ellipsis/index.zh.md
@@ -4,11 +4,11 @@
 
 ### 属性
 
-| 属性            | 说明                                 | 类型                           | 默认值      |
-| --------------- | ------------------------------------ | ------------------------------ | ----------- |
-| content         | 文本内容                             | `string`                       | -           |
-| direction       | 省略位置                             | `'start' \| 'end' \| 'middle'` | `'end'`     |
-| rows            | 展示几行                             | `number`                       | `1`         |
-| expandText      | 展开操作的文案                       | `string`                       | `''`        |
-| collapseText    | 收起操作的文案                       | `string`                       | `''`        |
-| stopPropagation | 阻止展开操作，收起操作引发的事件冒泡 | `PropagationEvent[]`           | `['click']` |
+| 属性                            | 说明                                 | 类型                           | 默认值  |
+| ------------------------------- | ------------------------------------ | ------------------------------ | ------- |
+| content                         | 文本内容                             | `string`                       | -       |
+| direction                       | 省略位置                             | `'start' \| 'end' \| 'middle'` | `'end'` |
+| rows                            | 展示几行                             | `number`                       | `1`     |
+| expandText                      | 展开操作的文案                       | `string`                       | `''`    |
+| collapseText                    | 收起操作的文案                       | `string`                       | `''`    |
+| stopPropagationForExpandButtons | 阻止展开操作，收起操作引发的事件冒泡 | `PropagationEvent[]`           | `[]`    |


### PR DESCRIPTION
展开和收起操作会触发冒泡事件