### PR TITLE
feat: (Form) supports `warningOnly` rule and add doc for rule definitions

### DIFF
--- a/src/components/form/demos/demo2.tsx
+++ b/src/components/form/demos/demo2.tsx
@@ -64,6 +64,7 @@ export default () => {
       </Form>
 
       <RefDemo />
+      <WarningOnlyDemo />
     </>
   )
 }
@@ -163,5 +164,31 @@ const DatePickerInputItem = () => {
         </Form.Item>
       )}
     </Form.Item>
+  )
+}
+
+const WarningOnlyDemo = () => {
+  const onFinish = (values: any) => {
+    console.log(values)
+  }
+
+  return (
+    <Form
+      onFinish={onFinish}
+      footer={
+        <Button block type='submit' color='primary' size='large'>
+          提交
+        </Button>
+      }
+    >
+      <Form.Header>非阻塞校验</Form.Header>
+      <Form.Item
+        name='email'
+        label='Email'
+        rules={[{ required: true }, { type: 'email', warningOnly: true }]}
+      >
+        <Input placeholder='请输入邮箱' />
+      </Form.Item>
+    </Form>
   )
 }

--- a/src/components/form/demos/demo2.tsx
+++ b/src/components/form/demos/demo2.tsx
@@ -184,8 +184,12 @@ const WarningOnlyDemo = () => {
       <Form.Header>非阻塞校验</Form.Header>
       <Form.Item
         name='email'
-        label='Email'
-        rules={[{ required: true }, { type: 'email', warningOnly: true }]}
+        label='邮箱'
+        rules={[
+          { required: true },
+          { type: 'string', min: 6 },
+          { type: 'email', warningOnly: true },
+        ]}
       >
         <Input placeholder='请输入邮箱' />
       </Form.Item>

--- a/src/components/form/form-item.less
+++ b/src/components/form/form-item.less
@@ -48,8 +48,12 @@
     }
   }
 
-  &-footer {
+  &-feedback-error {
     color: var(--adm-color-danger);
+    margin-top: 4px;
+  }
+  &-feedback-warning {
+    color: var(--adm-color-warning);
     margin-top: 4px;
   }
 

--- a/src/components/form/form-item.tsx
+++ b/src/components/form/form-item.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext, useCallback, useState, useMemo } from 'react'
+import React, { FC, useContext, useCallback, useState } from 'react'
 import classNames from 'classnames'
 import { NativeProps } from '../../utils/native-props'
 import { Field, FormInstance } from 'rc-field-form'
@@ -83,7 +83,8 @@ type FormItemLayoutProps = Pick<
   | 'childElementPosition'
 > & {
   htmlFor?: string
-  errors?: string[]
+  errors: string[]
+  warnings: string[]
 }
 
 const FormItemLayout: React.FC<FormItemLayoutProps> = props => {
@@ -98,9 +99,7 @@ const FormItemLayout: React.FC<FormItemLayoutProps> = props => {
     children,
     htmlFor,
     hidden,
-    errors,
     arrow,
-    description,
     childElementPosition = 'normal',
   } = props
 
@@ -111,8 +110,6 @@ const FormItemLayout: React.FC<FormItemLayoutProps> = props => {
   const hasFeedback =
     props.hasFeedback !== undefined ? props.hasFeedback : context.hasFeedback
   const layout = props.layout || context.layout
-
-  const feedback = hasFeedback && errors && errors.length > 0 ? errors[0] : null
 
   const requiredMark = (() => {
     const { requiredMarkStyle } = context
@@ -158,13 +155,31 @@ const FormItemLayout: React.FC<FormItemLayoutProps> = props => {
     </label>
   ) : null
 
-  const descriptionElement =
-    feedback || description ? (
-      <>
-        {description}
-        <div className={`${classPrefix}-footer`}>{feedback}</div>
-      </>
-    ) : null
+  const description = (
+    <>
+      {props.description}
+      {hasFeedback && (
+        <>
+          {props.errors.map((error, index) => (
+            <div
+              key={`error-${index}`}
+              className={`${classPrefix}-feedback-error`}
+            >
+              {error}
+            </div>
+          ))}
+          {props.warnings.map((warning, index) => (
+            <div
+              key={`warning-${index}`}
+              className={`${classPrefix}-feedback-warning`}
+            >
+              {warning}
+            </div>
+          ))}
+        </>
+      )}
+    </>
+  )
 
   return (
     <List.Item
@@ -172,7 +187,7 @@ const FormItemLayout: React.FC<FormItemLayoutProps> = props => {
       title={layout === 'vertical' && labelElement}
       prefix={layout === 'horizontal' && labelElement}
       extra={extra}
-      description={descriptionElement}
+      description={description}
       className={classNames(
         classPrefix,
         className,
@@ -276,6 +291,17 @@ export const FormItem: FC<FormItemProps> = props => {
       },
       curErrors
     )
+    const curWarnings = meta?.warnings ?? []
+    const warnings = Object.keys(subMetas).reduce(
+      (subWarnings: string[], key: string) => {
+        const warnings = subMetas[key]?.warnings ?? []
+        if (warnings.length) {
+          subWarnings = [...subWarnings, ...warnings]
+        }
+        return subWarnings
+      },
+      curWarnings
+    )
 
     return (
       <FormItemLayout
@@ -290,6 +316,7 @@ export const FormItem: FC<FormItemProps> = props => {
         hasFeedback={hasFeedback}
         htmlFor={fieldId}
         errors={errors}
+        warnings={warnings}
         onClick={onClick}
         hidden={hidden}
         layout={layout}

--- a/src/components/form/index.en.md
+++ b/src/components/form/index.en.md
@@ -243,3 +243,28 @@ You can modify the default verification information of Form.Item through `messag
 | touched    | Whether is operated      | `boolean`    |
 | validating | Whether is in validating | `boolean`    |
 | value      | Field value              | `any`        |
+
+### Rule
+
+Rule supports a config object, or a function returning config object:
+
+```tsx
+type Rule = RuleConfig | ((form: FormInstance) => RuleConfig);
+```
+
+| Name            | Description                                                                                                                            | Type                       |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
+| defaultField    | Validate rule for all array elements, valid when `type` is `array`                                                                     | `rule`                     |
+| enum            | Match enum value. You need to set `type` to `enum` to enable this                                                                      | `any[]`                    |
+| len             | Length of string, number, array                                                                                                        | `number`                   |
+| max             | `type` required: max length of `string`, `number`, `array`                                                                             | `number`                   |
+| message         | Error message. Will auto generate by [template](#validatemessages) if not provided                                                     | `string`                   |
+| min             | `type` required: min length of `string`, `number`, `array`                                                                             | `number`                   |
+| pattern         | Regex pattern                                                                                                                          | `RegExp`                   |
+| required        | Required field                                                                                                                         | `boolean`                  |
+| transform       | Transform value to the rule before validation                                                                                          | `(value) => any`           |
+| type            | Normally `string` \|`number` \|`boolean` \|`url` \| `email`. More type to ref [here](https://github.com/yiminghe/async-validator#type) | `string`                   |
+| validateTrigger | Set validate trigger event. Must be the sub set of `validateTrigger` in Form.Item                                                      | `string \| string[]`       |
+| validator       | Customize validation rule. Accept Promise as return. See [example](#custom-field)                                                      | `(rule, value) => Promise` |
+| warningOnly     | Warning only. Not block form submit                                                                                                    | `boolean`                  |
+| whitespace      | Failed if only has whitespace, only work with `type: 'string'` rule                                                                    | `boolean`                  |

--- a/src/components/form/index.zh.md
+++ b/src/components/form/index.zh.md
@@ -243,3 +243,28 @@ Form 通过增量更新方式，只更新被修改的字段相关组件以达到
 | touched    | 是否被用户操作过 | `boolean`    |
 | validating | 是否正在校验     | `boolean`    |
 | value      | 字段对应值       | `any`        |
+
+### Rule
+
+Rule 支持接收 object 进行配置，也支持 function 来动态获取 form 的数据：
+
+```tsx
+type Rule = RuleConfig | ((form: FormInstance) => RuleConfig);
+```
+
+| 属性            | 说明                                                                                                                                | 类型                       |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
+| defaultField    | 仅在 `type` 为 `array` 类型时有效，用于指定数组元素的校验规则                                                                       | `rule`                     |
+| enum            | 是否匹配枚举中的值（需要将 `type` 设置为 `enum`）                                                                                   | `any[]`                    |
+| len             | string 类型时为字符串长度；number 类型时为确定数字； array 类型时为数组长度                                                         | `number`                   |
+| max             | 必须设置 `type`：string 类型为字符串最大长度；number 类型时为最大值；array 类型时为数组最大长度                                     | `number`                   |
+| message         | 错误信息，不设置时会通过[模板](#validatemessages)自动生成                                                                           | `string`                   |
+| min             | 必须设置 `type`：string 类型为字符串最小长度；number 类型时为最小值；array 类型时为数组最小长度                                     | `number`                   |
+| pattern         | 正则表达式匹配                                                                                                                      | `RegExp`                   |
+| required        | 是否为必选字段                                                                                                                      | `boolean`                  |
+| transform       | 将字段值转换成目标值后进行校验                                                                                                      | `(value) => any`           |
+| type            | 类型，常见有 `string` \|`number` \|`boolean` \|`url` \| `email`。更多请参考[此处](https://github.com/yiminghe/async-validator#type) | `string`                   |
+| validateTrigger | 设置触发验证时机，必须是 Form.Item 的 `validateTrigger` 的子集                                                                      | `string \| string[] `      |
+| validator       | 自定义校验，接收 Promise 作为返回值。[示例](#自定义表单字段)参考                                                                    | `(rule, value) => Promise` |
+| warningOnly     | 仅警告，不阻塞表单提交                                                                                                              | `boolean`                  |
+| whitespace      | 如果字段仅包含空格则校验不通过，只在 `type: 'string'` 时生效                                                                        | `boolean`                  |

--- a/src/components/form/tests/form.test.tsx
+++ b/src/components/form/tests/form.test.tsx
@@ -235,6 +235,24 @@ describe('Form', () => {
     )
   })
 
+  test('warningOnly validate', async () => {
+    const fn = jest.fn()
+    const { getByTestId } = render(
+      <Form data-testid='form' onFinish={fn}>
+        <Form.Item name='test' rules={[{ required: true, warningOnly: true }]}>
+          <Input />
+        </Form.Item>
+      </Form>
+    )
+
+    await waitFor(() => {
+      fireEvent.submit(getByTestId('form'))
+    })
+
+    expect($$(`.${classPrefix}-item-footer`).length).not.toBeTruthy()
+    expect(fn).toBeCalledTimes(1)
+  })
+
   describe('Form.Item', () => {
     test('noStyle', async () => {
       const onChange = jest.fn()


### PR DESCRIPTION
这个issues #4838  rc-field-form 是支持的，所以在文档里加了 rule 属性 和 warningOnly demo

Rule 定义从 https://ant.design/components/form-cn/#Rule 搬运过来，做了略微修改

![image](https://user-images.githubusercontent.com/22469543/156987422-4ad36d9d-ed41-47bd-b62a-779b3a32a036.png)

其中的 `fileds` 字段试了下好像不能用？(或者是我用法问题)，就先删了

![form-1](https://user-images.githubusercontent.com/22469543/156987591-939ecf41-996c-49c7-b2b0-964661377d63.png)

