### PR TITLE
chore: update coverage config to exclude `.umi`

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -26,5 +26,6 @@ module.exports = {
     '<rootDir>/src/**/*.{js,jsx,ts,tsx}',
     '!**/demos/**',
     '!**/tests/**',
+    '!**/.umi/**',
   ],
 }


### PR DESCRIPTION
本地跑的时候会有一堆 .umi 里的文件
 
![image](https://user-images.githubusercontent.com/22469543/157631211-9e9976bc-6a9c-4be7-b345-ad313357449a.png)
