### PR TITLE
refactor: (Switch) remove error throw

### DIFF
--- a/src/components/switch/switch.tsx
+++ b/src/components/switch/switch.tsx
@@ -46,7 +46,6 @@ export const Switch: FC<SwitchProps> = p => {
         setChanging(false)
       } catch (e) {
         setChanging(false)
-        throw e
       }
     } else {
       setChecked(nextChecked)


### PR DESCRIPTION
起因是我在写 test 的时候发现 这个 error 没法捕获，思考了一下这个 error 似乎不需要 throw 出来

如果需要 error 可以在 beforeChange 中自行 try catch
 