### PR TITLE
fix: (Modal & Dialog & ImageViewer & ActionSheet) doesn't close when trigger too fast

### DIFF
--- a/src/components/action-sheet/action-sheet.tsx
+++ b/src/components/action-sheet/action-sheet.tsx
@@ -6,6 +6,7 @@ import React, {
   useImperativeHandle,
   useState,
   ReactNode,
+  useRef,
 } from 'react'
 import { NativeProps, withNativeProps } from '../../utils/native-props'
 import { mergeProps } from '../../utils/with-default-props'
@@ -142,10 +143,14 @@ export type ActionSheetRef = {
 export function showActionSheet(props: Omit<ActionSheetProps, 'visible'>) {
   const Wrapper = forwardRef<ActionSheetRef>((_, ref) => {
     const [visible, setVisible] = useState(false)
+    const closedRef = useRef(false)
     useEffect(() => {
-      setVisible(true)
+      if (!closedRef.current) {
+        setVisible(true)
+      }
     }, [])
     function handleClose() {
+      closedRef.current = true
       props.onClose?.()
       setVisible(false)
     }

--- a/src/components/action-sheet/action-sheet.tsx
+++ b/src/components/action-sheet/action-sheet.tsx
@@ -147,6 +147,8 @@ export function showActionSheet(props: Omit<ActionSheetProps, 'visible'>) {
     useEffect(() => {
       if (!closedRef.current) {
         setVisible(true)
+      } else {
+        handleAfterClose()
       }
     }, [])
     function handleClose() {
@@ -157,15 +159,16 @@ export function showActionSheet(props: Omit<ActionSheetProps, 'visible'>) {
     useImperativeHandle(ref, () => ({
       close: handleClose,
     }))
+    function handleAfterClose() {
+      props.afterClose?.()
+      unmount()
+    }
     return (
       <ActionSheet
         {...props}
         visible={visible}
         onClose={handleClose}
-        afterClose={() => {
-          props.afterClose?.()
-          unmount()
-        }}
+        afterClose={handleAfterClose}
       />
     )
   })

--- a/src/components/dialog/show.tsx
+++ b/src/components/dialog/show.tsx
@@ -24,6 +24,8 @@ export function show(props: DialogShowProps) {
     useEffect(() => {
       if (!closedRef.current) {
         setVisible(true)
+      } else {
+        handleAfterClose()
       }
     }, [])
     function handleClose() {

--- a/src/components/dialog/show.tsx
+++ b/src/components/dialog/show.tsx
@@ -3,6 +3,7 @@ import React, {
   forwardRef,
   useEffect,
   useImperativeHandle,
+  useRef,
   useState,
 } from 'react'
 import { renderToBody } from '../../utils/render-to-body'
@@ -19,10 +20,14 @@ export const closeFnSet = new Set<() => void>()
 export function show(props: DialogShowProps) {
   const Wrapper = forwardRef<DialogShowRef>((_, ref) => {
     const [visible, setVisible] = useState(false)
+    const closedRef = useRef(false)
     useEffect(() => {
-      setVisible(true)
+      if (!closedRef.current) {
+        setVisible(true)
+      }
     }, [])
     function handleClose() {
+      closedRef.current = true
       props.onClose?.()
       setVisible(false)
     }

--- a/src/components/image-viewer/methods.tsx
+++ b/src/components/image-viewer/methods.tsx
@@ -3,6 +3,7 @@ import React, {
   forwardRef,
   useEffect,
   useImperativeHandle,
+  useRef,
   useState,
 } from 'react'
 import { renderToBody } from '../../utils/render-to-body'
@@ -12,7 +13,6 @@ import {
   MultiImageViewerProps,
   MultiImageViewer,
 } from './image-viewer'
-import { useUnmountedRef } from 'ahooks'
 
 export type ImageViewerHandler = {
   close: () => void
@@ -24,28 +24,31 @@ export function showImageViewer(props: Omit<ImageViewerProps, 'visible'>) {
   clearImageViewer()
   const Wrapper = forwardRef<ImageViewerHandler>((_, ref) => {
     const [visible, setVisible] = useState(false)
+    const closedRef = useRef(false)
     useEffect(() => {
-      setVisible(true)
+      if (!closedRef.current) {
+        setVisible(true)
+      }
     }, [])
-    const isUnmountedRef = useUnmountedRef()
+    function handleClose() {
+      closedRef.current = true
+      props.onClose?.()
+      setVisible(false)
+    }
     useImperativeHandle(ref, () => ({
-      close: () => {
-        if (isUnmountedRef.current) return
-        setVisible(false)
-      },
+      close: handleClose,
     }))
+    function handleAfterClose() {
+      props.afterClose?.()
+      unmount()
+      handlerSet.delete(handler)
+    }
     return (
       <ImageViewer
         {...props}
         visible={visible}
-        onClose={() => {
-          props.onClose?.()
-          setVisible(false)
-        }}
-        afterClose={() => {
-          props.afterClose?.()
-          unmount()
-        }}
+        onClose={handleClose}
+        afterClose={handleAfterClose}
       />
     )
   })
@@ -66,28 +69,31 @@ export function showMultiImageViewer(
   clearImageViewer()
   const Wrapper = forwardRef<ImageViewerHandler>((_, ref) => {
     const [visible, setVisible] = useState(false)
+    const closedRef = useRef(false)
     useEffect(() => {
-      setVisible(true)
+      if (!closedRef.current) {
+        setVisible(true)
+      }
     }, [])
-    const isUnmountedRef = useUnmountedRef()
+    function handleClose() {
+      closedRef.current = true
+      props.onClose?.()
+      setVisible(false)
+    }
     useImperativeHandle(ref, () => ({
-      close: () => {
-        if (isUnmountedRef.current) return
-        setVisible(false)
-      },
+      close: handleClose,
     }))
+    function handleAfterClose() {
+      props.afterClose?.()
+      unmount()
+      handlerSet.delete(handler)
+    }
     return (
       <MultiImageViewer
         {...props}
         visible={visible}
-        onClose={() => {
-          props.onClose?.()
-          setVisible(false)
-        }}
-        afterClose={() => {
-          props.afterClose?.()
-          unmount()
-        }}
+        onClose={handleClose}
+        afterClose={handleAfterClose}
       />
     )
   })

--- a/src/components/image-viewer/methods.tsx
+++ b/src/components/image-viewer/methods.tsx
@@ -28,6 +28,8 @@ export function showImageViewer(props: Omit<ImageViewerProps, 'visible'>) {
     useEffect(() => {
       if (!closedRef.current) {
         setVisible(true)
+      } else {
+        handleAfterClose()
       }
     }, [])
     function handleClose() {
@@ -73,6 +75,8 @@ export function showMultiImageViewer(
     useEffect(() => {
       if (!closedRef.current) {
         setVisible(true)
+      } else {
+        handleAfterClose()
       }
     }, [])
     function handleClose() {
@@ -113,4 +117,8 @@ export function clearImageViewer() {
     handler.close()
   })
   handlerSet.clear()
+}
+
+export const getH = () => {
+  console.log(handlerSet)
 }

--- a/src/components/modal/show.tsx
+++ b/src/components/modal/show.tsx
@@ -3,6 +3,7 @@ import React, {
   forwardRef,
   useEffect,
   useImperativeHandle,
+  useRef,
   useState,
 } from 'react'
 import { renderToBody } from '../../utils/render-to-body'
@@ -19,17 +20,20 @@ export const closeFnSet = new Set<() => void>()
 export function show(props: ModalShowProps) {
   const Wrapper = forwardRef<ModalShowRef>((_, ref) => {
     const [visible, setVisible] = useState(false)
+    const closedRef = useRef(false)
     useEffect(() => {
-      setVisible(true)
+      if (!closedRef.current) {
+        setVisible(true)
+      }
     }, [])
     function handleClose() {
+      closedRef.current = true
       props.onClose?.()
       setVisible(false)
     }
     useImperativeHandle(ref, () => ({
       close: handleClose,
     }))
-
     function handleAfterClose() {
       props.afterClose?.()
       unmount()

--- a/src/components/modal/show.tsx
+++ b/src/components/modal/show.tsx
@@ -24,6 +24,8 @@ export function show(props: ModalShowProps) {
     useEffect(() => {
       if (!closedRef.current) {
         setVisible(true)
+      } else {
+        handleAfterClose()
       }
     }, [])
     function handleClose() {


### PR DESCRIPTION
- fix: 修复 `Modal`、`Dialog`、`ImageViewer`、`ActionSheet` 在显示时立即关闭无效。
- feat: 调整上述组件瞬间关闭时，也能触发`props.onClose`、`props.afterClose`与销毁
- feat: 调整 `ImageViewer`的关闭，与`Modal`、`Dialog`、`ActionSheet`的关闭行为保持一致。 

#4897 的方式采用定时器，有闪烁问题，我个人觉得两种方案都可。