### PR TITLE
refactor: (renderImperatively & ImageViewer) use a better way to get `close`, and refactor `showMultiImageViewer`

### DIFF
--- a/src/components/image-viewer/methods.tsx
+++ b/src/components/image-viewer/methods.tsx
@@ -40,45 +40,15 @@ export function showMultiImageViewer(
   props: Omit<MultiImageViewerProps, 'visible'>
 ) {
   clearImageViewer()
-  const Wrapper = forwardRef<ImageViewerShowHandler>((_, ref) => {
-    const [visible, setVisible] = useState(false)
-    const closedRef = useRef(false)
-    useEffect(() => {
-      if (!closedRef.current) {
-        setVisible(true)
-      } else {
-        handleAfterClose()
-      }
-    }, [])
-    function handleClose() {
-      closedRef.current = true
-      props.onClose?.()
-      setVisible(false)
-    }
-    useImperativeHandle(ref, () => ({
-      close: handleClose,
-    }))
-    function handleAfterClose() {
-      props.afterClose?.()
-      unmount()
-      handlerSet.delete(handler)
-    }
-    return (
-      <MultiImageViewer
-        {...props}
-        visible={visible}
-        onClose={handleClose}
-        afterClose={handleAfterClose}
-      />
-    )
-  })
-  const ref = createRef<ImageViewerShowHandler>()
-  const unmount = renderToBody(<Wrapper ref={ref} />)
-  const handler = {
-    close: () => {
-      ref.current?.close()
-    },
-  }
+  const handler: ImageViewerShowHandler = renderImperatively(
+    <MultiImageViewer
+      {...props}
+      afterClose={() => {
+        handlerSet.delete(handler)
+        props.afterClose?.()
+      }}
+    />
+  )
   handlerSet.add(handler)
   return handler
 }
@@ -88,8 +58,4 @@ export function clearImageViewer() {
     handler.close()
   })
   handlerSet.clear()
-}
-
-export const getH = () => {
-  console.log(handlerSet)
 }


### PR DESCRIPTION
#4914 的后续
组件外部使用ref来获取组件内部的函数onClose应该更好:smiley:
`showMultiImageViewer` 是不是改漏了:yum: