### PR TITLE
fix: (Picker) add innerExt to avoid that `extend` is not update when first trigger `onConfirm`

### DIFF
--- a/src/components/cascade-picker/demos/demo1.tsx
+++ b/src/components/cascade-picker/demos/demo1.tsx
@@ -53,8 +53,8 @@ function CascadePickerDemo() {
         onClose={() => {
           setVisible(false)
         }}
-        onConfirm={val => {
-          console.log('onConfirm', val)
+        onConfirm={(val, extend) => {
+          console.log('onConfirm', val, extend.items)
         }}
         onSelect={val => {
           console.log('onSelect', val)

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -62,7 +62,7 @@ export const Picker = memo<PickerProps>(p => {
   const [value, setValue] = usePropsValue({
     ...props,
     onChange: val => {
-      props.onConfirm?.(val, generateValueExtend(val))
+      props.onConfirm?.(val, innerExt)
     },
   })
 
@@ -82,8 +82,10 @@ export const Picker = memo<PickerProps>(p => {
     }
   }, [value])
 
+  const [innerExt, setInnerExt] = useState<PickerValueExtend>({ items: [] })
   const onChange = useMemoizedFn((val, ext) => {
     setInnerValue(val)
+    setInnerExt(ext)
     if (props.visible) {
       props.onSelect?.(val, ext)
     }


### PR DESCRIPTION
#4924 

Picker 里的 `columns`  依赖 `value` ，在 `value` 未改变前，`columns` 不全