### PR TITLE
fix: (Popover) does't show in label element

### DIFF
--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -180,8 +180,8 @@ export const Popover = forwardRef<PopoverRef, PopoverProps>((p, ref) => {
     if (!targetElement) return
     if (!props.trigger) return
 
-    function handleClick() {
-      console.log('handleClick')
+    function handleClick(e: Event) {
+      e.preventDefault()
       setVisible(v => !v)
     }
     targetElement.addEventListener('click', handleClick)


### PR DESCRIPTION
在 label 中点击 Popover 会触发 input 的点击事件，导致 useClickAway 里的回调生效