### PR TITLE
refactor: (NumberKeyboard) remove onMouseUp

### DIFF
--- a/src/components/number-keyboard/number-keyboard.tsx
+++ b/src/components/number-keyboard/number-keyboard.tsx
@@ -159,9 +159,6 @@ export const NumberKeyboard: React.FC<NumberKeyboardProps> = p => {
             onBackspacePressEnd()
           }
         }}
-        onMouseUp={e => {
-          onKeyPress(e, key)
-        }}
         title={key}
         role='button'
       >
@@ -209,7 +206,6 @@ export const NumberKeyboard: React.FC<NumberKeyboardProps> = p => {
                     onKeyPress(e, 'BACKSPACE')
                     onBackspacePressEnd()
                   }}
-                  onMouseUp={e => onKeyPress(e, 'BACKSPACE')}
                   title='BACKSPACE'
                   role='button'
                 >
@@ -218,7 +214,6 @@ export const NumberKeyboard: React.FC<NumberKeyboardProps> = p => {
                 <div
                   className={`${classPrefix}-key extra-key ok-key`}
                   onTouchEnd={e => onKeyPress(e, 'OK')}
-                  onMouseUp={e => onKeyPress(e, 'OK')}
                   role='button'
                 >
                   {confirmText}

--- a/src/components/number-keyboard/tests/numberic-keyboard.test.tsx
+++ b/src/components/number-keyboard/tests/numberic-keyboard.test.tsx
@@ -4,70 +4,72 @@ import NumberKeyboard from '..'
 
 const classPrefix = 'adm-number-keyboard'
 
-it('passes a11y test', async () => {
-  await testA11y(<NumberKeyboard visible />)
-})
-
-test('renders with title & close button', async () => {
-  let inputValue = ''
-  const onClose = jest.fn()
-  const onInput = jest.fn(value => {
-    inputValue = value
+describe('NumberKeyboard', () => {
+  test('a11y', async () => {
+    await testA11y(<NumberKeyboard visible />)
   })
 
-  const { getByTitle, getByText } = render(
-    <NumberKeyboard
-      visible
-      showCloseButton
-      onClose={onClose}
-      onInput={onInput}
-      title='title'
-    />
-  )
+  test('renders with title & close button', async () => {
+    let inputValue = ''
+    const onClose = jest.fn()
+    const onInput = jest.fn(value => {
+      inputValue = value
+    })
 
-  expect(getByText('title')).toHaveClass(`${classPrefix}-title`)
+    const { getByTitle, getByText } = render(
+      <NumberKeyboard
+        visible
+        showCloseButton
+        onClose={onClose}
+        onInput={onInput}
+        title='title'
+      />
+    )
 
-  // 点击关闭箭头
-  fireEvent.click(getByTitle('CLOSE'))
-  await waitFor(() => {
-    expect(onClose).toBeCalledTimes(1)
+    expect(getByText('title')).toHaveClass(`${classPrefix}-title`)
+
+    // 点击关闭箭头
+    fireEvent.click(getByTitle('CLOSE'))
+    await waitFor(() => {
+      expect(onClose).toBeCalledTimes(1)
+    })
+
+    // 点击数字
+    fireEvent.touchEnd(getByText('0'))
+    fireEvent.touchEnd(getByTitle(''))
+    await waitFor(() => {
+      expect(onInput).toBeCalledTimes(1)
+      expect(inputValue).toEqual('0')
+    })
   })
 
-  // 点击数字
-  fireEvent.touchEnd(getByText('0'))
-  fireEvent.touchEnd(getByTitle(''))
-  await waitFor(() => {
-    expect(onInput).toBeCalledTimes(1)
-    expect(inputValue).toEqual('0')
-  })
-})
+  test('renders with customKey', async () => {
+    let inputValue = ''
+    const onDelete = jest.fn()
+    const onInput = jest.fn(value => {
+      inputValue = value
+    })
 
-test('renders with customKey', async () => {
-  let inputValue = ''
-  const onDelete = jest.fn()
-  const onInput = jest.fn(value => {
-    inputValue = value
-  })
+    const { getByText, getByTitle } = render(
+      <NumberKeyboard
+        customKey='-'
+        visible
+        onInput={onInput}
+        onDelete={onDelete}
+      />
+    )
 
-  const { getByText, getByTitle } = render(
-    <NumberKeyboard
-      customKey='-'
-      visible
-      onInput={onInput}
-      onDelete={onDelete}
-    />
-  )
+    // 点击删除
+    fireEvent.touchEnd(getByTitle('BACKSPACE'))
+    await waitFor(() => {
+      expect(onDelete).toBeCalledTimes(1)
+    })
 
-  // 点击删除
-  fireEvent.touchEnd(getByTitle('BACKSPACE'))
-  await waitFor(() => {
-    expect(onDelete).toBeCalledTimes(1)
-  })
-
-  // 点击自定义按钮
-  fireEvent.touchEnd(getByText('-'))
-  await waitFor(() => {
-    expect(onInput).toBeCalledTimes(1)
-    expect(inputValue).toEqual('-')
+    // 点击自定义按钮
+    fireEvent.touchEnd(getByText('-'))
+    await waitFor(() => {
+      expect(onInput).toBeCalledTimes(1)
+      expect(inputValue).toEqual('-')
+    })
   })
 })


### PR DESCRIPTION
fix #4988 

在 iphone 上点击虚拟键盘时会触发 `onTouchEnd` 和 `onMouseUp`，导致两次 `onInput`

`onTouchEnd` 和 `onMouseUp` 的问题，见 #4995 
