### PR TITLE
enhance: (Modal) support disableBodyScroll prop for Mask

### DIFF
--- a/src/components/modal/index.en.md
+++ b/src/components/modal/index.en.md
@@ -10,27 +10,28 @@
 
 ### Props
 
-| Name             | Description                                                 | Type                                                       | Default     |
-| ---------------- | ----------------------------------------------------------- | ---------------------------------------------------------- | ----------- |
-| afterClose       | Callback after `Modal` is completely closed                 | `() => void`                                               | -           |
-| afterShow        | Triggered after fully displayed                             | `() => void`                                               | -           |
-| image            | The `url` of the picture                                    | `string`                                                   | -           |
-| header           | The top area                                                | `React.ReactNode`                                          | -           |
-| title            | The title of the Modal                                      | `React.ReactNode`                                          | -           |
-| content          | The content of the Modal                                    | `React.ReactNode`                                          | -           |
-| actions          | The list of the operation button                            | `Action[]`                                                 | `[]`        |
-| onAction         | Triggered when the action button is clicked                 | `(action: Action, index: number) => void \| Promise<void>` | -           |
-| closeOnAction    | Whether to close after clicking the operation button        | `boolean`                                                  | `false`     |
-| onClose          | Triggered when closed                                       | `() => void`                                               | -           |
-| closeOnMaskClick | Whether to support clicking the mask to close the modal box | `boolean`                                                  | `false`     |
-| visible          | To show or hide                                             | `boolean`                                                  | `false`     |
-| getContainer     | The parent container of the custom modal                    | `HTMLElement \| (() => HTMLElement) \| null`               | `null`      |
-| bodyStyle        | `Modal` content style                                       | `React.CSSProperties`                                      | -           |
-| bodyClassName    | `Modal` content class name                                  | `string`                                                   | -           |
-| maskStyle        | `Modal` mask style                                          | `React.CSSProperties`                                      | -           |
-| maskClassName    | `Modal` mask class name                                     | `string`                                                   | -           |
-| stopPropagation  | Stop the propagation of some events.                        | `PropagationEvent[]`                                       | `['click']` |
-| showCloseButton  | Whether to show a close button on the top right corner      | `boolean`                                                  | `false`     |
+| Name              | Description                                                 | Type                                                       | Default     |
+| ----------------- | ----------------------------------------------------------- | ---------------------------------------------------------- | ----------- |
+| afterClose        | Callback after `Modal` is completely closed                 | `() => void`                                               | -           |
+| afterShow         | Triggered after fully displayed                             | `() => void`                                               | -           |
+| image             | The `url` of the picture                                    | `string`                                                   | -           |
+| header            | The top area                                                | `React.ReactNode`                                          | -           |
+| title             | The title of the Modal                                      | `React.ReactNode`                                          | -           |
+| content           | The content of the Modal                                    | `React.ReactNode`                                          | -           |
+| actions           | The list of the operation button                            | `Action[]`                                                 | `[]`        |
+| onAction          | Triggered when the action button is clicked                 | `(action: Action, index: number) => void \| Promise<void>` | -           |
+| closeOnAction     | Whether to close after clicking the operation button        | `boolean`                                                  | `false`     |
+| onClose           | Triggered when closed                                       | `() => void`                                               | -           |
+| closeOnMaskClick  | Whether to support clicking the mask to close the modal box | `boolean`                                                  | `false`     |
+| visible           | To show or hide                                             | `boolean`                                                  | `false`     |
+| getContainer      | The parent container of the custom modal                    | `HTMLElement \| (() => HTMLElement) \| null`               | `null`      |
+| bodyStyle         | `Modal` content style                                       | `React.CSSProperties`                                      | -           |
+| bodyClassName     | `Modal` content class name                                  | `string`                                                   | -           |
+| maskStyle         | `Modal` mask style                                          | `React.CSSProperties`                                      | -           |
+| maskClassName     | `Modal` mask class name                                     | `string`                                                   | -           |
+| stopPropagation   | Stop the propagation of some events.                        | `PropagationEvent[]`                                       | `['click']` |
+| showCloseButton   | Whether to show a close button on the top right corner      | `boolean`                                                  | `false`     |
+| disableBodyScroll | Mask Whether to disable `body` scrolling                    | `boolean`                                                  | `true`      |
 
 ### Action
 

--- a/src/components/modal/index.zh.md
+++ b/src/components/modal/index.zh.md
@@ -10,27 +10,28 @@
 
 ### 属性
 
-| 属性             | 说明                         | 类型                                                       | 默认值      |
-| ---------------- | ---------------------------- | ---------------------------------------------------------- | ----------- |
-| afterClose       | `Modal` 完全关闭后的回调     | `() => void`                                               | -           |
-| afterShow        | 完全展示后触发               | `() => void`                                               | -           |
-| image            | 图片 `url`                   | `string`                                                   | -           |
-| header           | 顶部区域                     | `React.ReactNode`                                          | -           |
-| title            | 弹窗标题                     | `React.ReactNode`                                          | -           |
-| content          | 弹窗内容                     | `React.ReactNode`                                          | -           |
-| actions          | 操作按钮列表                 | `Action[]`                                                 | `[]`        |
-| onAction         | 点击操作按钮时触发           | `(action: Action, index: number) => void \| Promise<void>` | -           |
-| closeOnAction    | 点击操作按钮后后是否关闭     | `boolean`                                                  | `false`     |
-| onClose          | 关闭时触发                   | `() => void`                                               | -           |
-| closeOnMaskClick | 是否支持点击遮罩关闭弹窗     | `boolean`                                                  | `false`     |
-| visible          | 显示隐藏                     | `boolean`                                                  | `false`     |
-| getContainer     | 自定义弹窗的父容器           | `HTMLElement \| (() => HTMLElement) \| null`               | `null`      |
-| bodyStyle        | `Modal` 内容样式             | `React.CSSProperties`                                      | -           |
-| bodyClassName    | `Modal` 内容类名             | `string`                                                   | -           |
-| maskStyle        | `Modal` 遮罩样式             | `React.CSSProperties`                                      | -           |
-| maskClassName    | `Modal` 遮罩类名             | `string`                                                   | -           |
-| stopPropagation  | 阻止某些事件的冒泡           | `PropagationEvent[]`                                       | `['click']` |
-| showCloseButton  | 是否在右上角显示关闭图标按钮 | `boolean`                                                  | `false`     |
+| 属性              | 说明                         | 类型                                                       | 默认值      |
+| ----------------- | ---------------------------- | ---------------------------------------------------------- | ----------- |
+| afterClose        | `Modal` 完全关闭后的回调     | `() => void`                                               | -           |
+| afterShow         | 完全展示后触发               | `() => void`                                               | -           |
+| image             | 图片 `url`                   | `string`                                                   | -           |
+| header            | 顶部区域                     | `React.ReactNode`                                          | -           |
+| title             | 弹窗标题                     | `React.ReactNode`                                          | -           |
+| content           | 弹窗内容                     | `React.ReactNode`                                          | -           |
+| actions           | 操作按钮列表                 | `Action[]`                                                 | `[]`        |
+| onAction          | 点击操作按钮时触发           | `(action: Action, index: number) => void \| Promise<void>` | -           |
+| closeOnAction     | 点击操作按钮后后是否关闭     | `boolean`                                                  | `false`     |
+| onClose           | 关闭时触发                   | `() => void`                                               | -           |
+| closeOnMaskClick  | 是否支持点击遮罩关闭弹窗     | `boolean`                                                  | `false`     |
+| visible           | 显示隐藏                     | `boolean`                                                  | `false`     |
+| getContainer      | 自定义弹窗的父容器           | `HTMLElement \| (() => HTMLElement) \| null`               | `null`      |
+| bodyStyle         | `Modal` 内容样式             | `React.CSSProperties`                                      | -           |
+| bodyClassName     | `Modal` 内容类名             | `string`                                                   | -           |
+| maskStyle         | `Modal` 遮罩样式             | `React.CSSProperties`                                      | -           |
+| maskClassName     | `Modal` 遮罩类名             | `string`                                                   | -           |
+| stopPropagation   | 阻止某些事件的冒泡           | `PropagationEvent[]`                                       | `['click']` |
+| showCloseButton   | 是否在右上角显示关闭图标按钮 | `boolean`                                                  | `false`     |
+| disableBodyScroll | 遮罩层是否禁用 `body` 滚动   | `boolean`                                                  | `true`      |
 
 ### Action
 

--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -39,6 +39,7 @@ export type ModalProps = {
   maskClassName?: string
   stopPropagation?: PropagationEvent[]
   showCloseButton?: boolean
+  disableBodyScroll?: boolean
 } & NativeProps
 
 const defaultProps = {
@@ -159,6 +160,7 @@ export const Modal: FC<ModalProps> = p => {
           onMaskClick={props.closeOnMaskClick ? props.onClose : undefined}
           style={props.maskStyle}
           className={classNames(cls('mask'), props.maskClassName)}
+          disableBodyScroll={props.disableBodyScroll}
         />
         <div
           className={cls('wrap')}


### PR DESCRIPTION
Modal组件使用了Mask组件，里面useLockScroll有事件监听,qiankun子应用下，shadowDOM隔离，手机上内容不能滚动,我在Modal组件加了disableBodyScroll属性给里面的Mask组件，先保证能正常使用。