### PR TITLE
fix: (ImageUploader) fix the same file doesn't trigger onChange

### DIFF
--- a/src/components/image-uploader/image-uploader.tsx
+++ b/src/components/image-uploader/image-uploader.tsx
@@ -137,6 +137,7 @@ export const ImageUploader: FC<ImageUploaderProps> = p => {
 
     setTasks(prev => [...prev, ...newTasks])
 
+    e.target.value = '' // HACK: fix the same file doesn't trigger onChange
     await Promise.all(
       newTasks.map(async currentTask => {
         try {
@@ -172,8 +173,6 @@ export const ImageUploader: FC<ImageUploaderProps> = p => {
         }
       })
     ).catch(error => console.error(error))
-
-    e.target.value = '' // HACK: fix the same file doesn't trigger onChange
   }
 
   const imageViewerHandlerRef = useRef<ImageViewerShowHandler | null>(null)


### PR DESCRIPTION
#5055 

在处理任务队列之前，可以先将 e.target.file 删除