### PR TITLE
fix: 修复滑动 swiper 时点击屏幕任意区域会中断滑动的问题

### DIFF
--- a/src/components/swipe-action/swipe-action.tsx
+++ b/src/components/swipe-action/swipe-action.tsx
@@ -125,7 +125,6 @@ export const SwipeAction = forwardRef<SwipeActionRef, SwipeActionProps>(
         },
         // rubberband: true,
         axis: 'x',
-        preventScroll: true,
         pointer: { touch: true },
       }
     )

--- a/src/components/swiper/swiper.tsx
+++ b/src/components/swiper/swiper.tsx
@@ -195,7 +195,6 @@ export const Swiper = forwardRef(
           },
           rubberband: props.rubberband,
           axis: isVertical ? 'y' : 'x',
-          preventScroll: !isVertical,
           pointer: {
             touch: true,
           },


### PR DESCRIPTION
https://github.com/ant-design/ant-design-mobile/issues/5066

目前来看 `use-gesture` 库的 `preventScroll` 属性还没有实现的很好，或许可以将 `preventScroll` 暴露出来作为一个配置项？由用户自己配置