### PR TITLE
refactor: (Form) replace justify-content `right` with `flex-end`

### DIFF
--- a/src/components/form/form-item.less
+++ b/src/components/form/form-item.less
@@ -41,7 +41,7 @@
       }
     }
     &-position-right {
-      justify-content: right;
+      justify-content: flex-end;
       > * {
         flex: none;
       }


### PR DESCRIPTION
#5091 

<img width="798" alt="image" src="https://user-images.githubusercontent.com/22469543/164719627-126db27a-a93a-4db2-8683-4ea263f98076.png">

[兼容性](https://developer.mozilla.org/zh-CN/docs/Web/CSS/justify-content#browser_compatibility) 

`justify-content: right`, chrome 93 才支持... 