### PR TITLE
fix: (Tabs & JumboTabs & CapsuleTabs) auto scroll fail when the parent element is a flex layout

### DIFF
--- a/src/components/capsule-tabs/capsule-tabs.less
+++ b/src/components/capsule-tabs/capsule-tabs.less
@@ -2,6 +2,7 @@
 
 .@{class-prefix-tabs} {
   position: relative;
+  overflow: hidden;
 
   &-header {
     position: relative;

--- a/src/components/jumbo-tabs/jumbo-tabs.less
+++ b/src/components/jumbo-tabs/jumbo-tabs.less
@@ -3,6 +3,7 @@
 .@{class-prefix-tabs} {
   --gap: 8px;
   position: relative;
+  overflow: hidden;
 
   &-header {
     position: relative;

--- a/src/components/tabs/tabs.less
+++ b/src/components/tabs/tabs.less
@@ -6,6 +6,7 @@
   --active-line-height: 2px;
   --active-line-border-radius: var(--active-line-height);
   position: relative;
+  overflow: hidden;
 
   &-header {
     position: relative;


### PR DESCRIPTION
#5142 