### PR TITLE
fix: (Tabs & JumboTabs & CapsuleTabs) auto scroll fail when the parent element is a flex layout

### DIFF
--- a/src/components/capsule-tabs/capsule-tabs.less
+++ b/src/components/capsule-tabs/capsule-tabs.less
@@ -2,6 +2,8 @@
 
 .@{class-prefix-tabs} {
   position: relative;
+  // Hack for auto scroll fail when the parent element is a flex layout
+  min-width: 0;
 
   &-header {
     position: relative;

--- a/src/components/jumbo-tabs/jumbo-tabs.less
+++ b/src/components/jumbo-tabs/jumbo-tabs.less
@@ -3,6 +3,8 @@
 .@{class-prefix-tabs} {
   --gap: 8px;
   position: relative;
+  // Hack for auto scroll fail when the parent element is a flex layout
+  min-width: 0;
 
   &-header {
     position: relative;

--- a/src/components/tabs/tabs.less
+++ b/src/components/tabs/tabs.less
@@ -6,6 +6,8 @@
   --active-line-height: 2px;
   --active-line-border-radius: var(--active-line-height);
   position: relative;
+  // Hack for auto scroll fail when the parent element is a flex layout
+  min-width: 0;
 
   &-header {
     position: relative;


### PR DESCRIPTION
修改为 `min-width: 0`