### PR TITLE
fix: (Dropdown) icon display is not centered

### DIFF
--- a/src/components/dropdown/dropdown.less
+++ b/src/components/dropdown/dropdown.less
@@ -38,7 +38,7 @@
       &-arrow {
         color: var(--adm-color-light);
         font-size: 9px;
-        transform: rotate(0deg) translateY(-1px);
+        transform: rotate(0deg) translateY(1px);
         transition: all ease 0.2s;
         &-active {
           transform: rotate(-180deg) translateY(-1px);


### PR DESCRIPTION
icon 显示没有居中

![image](https://user-images.githubusercontent.com/42566669/168004841-b800c9d1-3d59-4ff7-9723-73e6a785827c.png)
