### PR TITLE
fix: modify scroll check

### DIFF
--- a/src/components/infinite-scroll/infinite-scroll.tsx
+++ b/src/components/infinite-scroll/infinite-scroll.tsx
@@ -54,9 +54,12 @@ export const InfiniteScroll: FC<InfiniteScrollProps> = p => {
     if (!parent) return
     const rect = element.getBoundingClientRect()
     const elementTop = rect.top
-    const current = isWindow(parent)
+    let current = isWindow(parent)
       ? window.innerHeight
       : parent.getBoundingClientRect().bottom
+    if (current > window.innerHeight) {
+      current = window.innerHeight
+    }
     if (current >= elementTop - props.threshold) {
       const nextFlag = {}
       nextFlagRef.current = nextFlag


### PR DESCRIPTION
问题触发场景：
在 InfiniteScroll 组件外使用带 overflow: auto 属性的容器包裹，组件的 loadMore 会持续触发

解决办法：
补充限制条件，当父容器的 rect bottom 属性大于视口容器高度时，使用视口容器高度做判断