### PR TITLE
doc: (NoticeBar) update props icon default

### DIFF
--- a/src/components/notice-bar/index.en.md
+++ b/src/components/notice-bar/index.en.md
@@ -13,7 +13,7 @@
 | closeable | Whether it can be closed                                             | `boolean`                                   | `false`             |
 | onClose   | Callback when closed                                                 | `() => void`                                | -                   |
 | extra     | Additional operating area, displayed to the left of the close button | `React.ReactNode`                           | -                   |
-| icon      | Radio icon on the left                                               | `React.ReactNode`                           | `<SoundOutlined />` |
+| icon      | Radio icon on the left                                               | `React.ReactNode`                           | `<SoundOutline />` |
 
 ### CSS Variables
 

--- a/src/components/notice-bar/index.zh.md
+++ b/src/components/notice-bar/index.zh.md
@@ -13,7 +13,7 @@
 | closeable | 是否可关闭                       | `boolean`                                   | `false`             |
 | onClose   | 关闭时的回调                     | `() => void`                                | -                   |
 | extra     | 额外操作区域，显示在关闭按钮左侧 | `React.ReactNode`                           | -                   |
-| icon      | 左侧广播图标                     | `React.ReactNode`                           | `<SoundOutlined />` |
+| icon      | 左侧广播图标                     | `React.ReactNode`                           | `<SoundOutline />` |
 
 ### CSS 变量
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20753923/168246896-9af0a3f9-d1ad-48ea-9492-ee9a67b07710.png)
默认shu'xing'zhi属性值单词拼写错误，应为SoundOutline