### PR TITLE
enhance: (Badge) adjust ts definition

### DIFF
--- a/src/components/badge/badge.tsx
+++ b/src/components/badge/badge.tsx
@@ -13,10 +13,6 @@ export type BadgeProps = {
   children?: React.ReactNode
 } & NativeProps<'--right' | '--top' | '--color'>
 
-type BadgeStyle = React.CSSProperties & {
-  '--color': BadgeProps['color']
-}
-
 export const Badge: FC<BadgeProps> = props => {
   const { content, color, children } = props
 
@@ -29,15 +25,18 @@ export const Badge: FC<BadgeProps> = props => {
     props.bordered && `${classPrefix}-bordered`
   )
 
-  const badgeStyle: BadgeStyle = {
-    '--color': color,
-  }
-
   const element =
     content || content === 0
       ? withNativeProps(
           props,
-          <div className={badgeCls} style={badgeStyle}>
+          <div
+            className={badgeCls}
+            style={
+              {
+                '--color': color,
+              } as BadgeProps['style']
+            }
+          >
             {!isDot && (
               <div className={`${classPrefix}-content`}>{content}</div>
             )}

--- a/src/components/badge/badge.tsx
+++ b/src/components/badge/badge.tsx
@@ -13,6 +13,10 @@ export type BadgeProps = {
   children?: React.ReactNode
 } & NativeProps<'--right' | '--top' | '--color'>
 
+type BadgeStyle = React.CSSProperties & {
+  '--color': BadgeProps['color']
+}
+
 export const Badge: FC<BadgeProps> = props => {
   const { content, color, children } = props
 
@@ -25,18 +29,15 @@ export const Badge: FC<BadgeProps> = props => {
     props.bordered && `${classPrefix}-bordered`
   )
 
+  const badgeStyle: BadgeStyle = {
+    '--color': color,
+  }
+
   const element =
     content || content === 0
       ? withNativeProps(
           props,
-          <div
-            className={badgeCls}
-            style={
-              {
-                '--color': color,
-              } as any
-            }
-          >
+          <div className={badgeCls} style={badgeStyle}>
             {!isDot && (
               <div className={`${classPrefix}-content`}>{content}</div>
             )}

--- a/src/components/badge/index.ts
+++ b/src/components/badge/index.ts
@@ -3,6 +3,8 @@ import { Badge, dot } from './badge'
 import { attachPropertiesToComponent } from '../../utils/attach-properties-to-component'
 export type { BadgeProps } from './badge'
 
-export default attachPropertiesToComponent(Badge, {
-  dot,
-})
+type Properties = {
+  dot: typeof dot
+}
+const properties: Properties = { dot }
+export default attachPropertiesToComponent(Badge, properties)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22469543/168535934-1e86e053-ad5c-4f3e-bffd-cd26521ba6e8.png)

- content 为 `Badge.dot` 的时，会有 ts 错误
- 优化了下 `as any` 的 ts