### PR TITLE
test: add setup and exclude warning

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,6 +10,7 @@ module.exports = {
       '<rootDir>/fileTransformer.js',
   },
   transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$'],
+  setupFiles: ['<rootDir>/src/tests/setup.ts'],
   setupFilesAfterEnv: ['@testing-library/jest-dom/extend-expect'],
   globals: {
     'ts-jest': {

--- a/src/tests/excludeWarning.ts
+++ b/src/tests/excludeWarning.ts
@@ -1,0 +1,21 @@
+const originError = console.error
+
+// remove px tester warning
+export function excludeWarning() {
+  const errorSpy = jest
+    .spyOn(console, 'error')
+    .mockImplementation((msg, ...rest) => {
+      if (
+        String(msg).includes(
+          'The px tester is not rendering properly. Please make sure you have imported `antd-mobile/es/global`.'
+        )
+      ) {
+        return
+      }
+      originError(msg, ...rest)
+    })
+
+  return () => {
+    errorSpy.mockRestore()
+  }
+}

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -1,0 +1,3 @@
+import { excludeWarning } from './excludeWarning'
+
+excludeWarning()


### PR DESCRIPTION
参考了下 ant-design 的 [excludeWarning.tsx](https://github.com/ant-design/ant-design/blob/master/tests/shared/excludeWarning.tsx)

实际用的时候发现 px tester 的 error 比 beforeAll 调用要早，所以加在了 setup 里

- - -
ps: 这个 exclude 只对当前项目有效