### PR TITLE
fix(Ellipsis): middle mode has more characters on right than on left

### DIFF
--- a/src/components/ellipsis/ellipsis.tsx
+++ b/src/components/ellipsis/ellipsis.tsx
@@ -129,7 +129,7 @@ export const Ellipsis: FC<EllipsisProps> = p => {
           }
         }
         const leftPartMiddle = Math.floor((leftPart[0] + leftPart[1]) / 2)
-        const rightPartMiddle = Math.floor((rightPart[0] + rightPart[1]) / 2)
+        const rightPartMiddle = Math.ceil((rightPart[0] + rightPart[1]) / 2)
         container.innerText =
           props.content.slice(0, leftPartMiddle) +
           '...' +


### PR DESCRIPTION
中间省略有时右边的字符比左边的多一到两个字符