### PR TITLE
refactor(Ellipsis): remove deprecated style property `webkitBoxOrient`

### DIFF
--- a/src/components/ellipsis/ellipsis.tsx
+++ b/src/components/ellipsis/ellipsis.tsx
@@ -61,7 +61,6 @@ export const Ellipsis: FC<EllipsisProps> = p => {
     container.style.textOverflow = 'clip'
     container.style.whiteSpace = 'normal'
     container.style.webkitLineClamp = 'unset'
-    container.style.webkitBoxOrient = 'unset'
     container.style.display = 'block'
     const lineHeight = pxToNumber(originStyle.lineHeight)
     const maxHeight = Math.floor(


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22469543/171548950-73746e8d-8ffb-4cf1-9b80-19eb686a3801.png)
