### PR TITLE
chore(eslint): update eslint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,16 @@ module.exports = {
     'project': 'tsconfig.json',
     'sourceType': 'module',
   },
+  'ignorePatterns': [
+    'config',
+    '.eslintrc.js',
+    'fileTransformer.js',
+    'gulpfile.js',
+    'jest.config.js',
+    'babel-transform-less-to-css.js',
+    'scripts/postcss-disable-css-vars.js',
+    'src/tests/mocks/style-mock.js',
+  ],
   'plugins': ['@typescript-eslint'],
   'rules': {
     '@typescript-eslint/explicit-function-return-type': 'off',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "outDir": "./",
     "rootDirs": ["src", "config"],
     "target": "ES6",
     "moduleResolution": "node",


### PR DESCRIPTION
# 更新 eslint rule 说明
## 当前遇到的问题
已使用与项目相同的 typescript 版本
![Pasted image 20220608171741](https://user-images.githubusercontent.com/12870715/172590287-10db6a33-a474-4de5-82b9-ec45340612ea.png)

打开一些文件，会有 `eslint` 的报错，这不会影响什么，但是看着恼人
报错信息如下：
```bash
Parsing error: "parserOptions.project" has been set for @typescript-eslint/parser.
The file does not match your project config: .eslintrc.js.
The file must be included in at least one of the projects provided.

```
截图如下：
![Pasted image 20220608172218](https://user-images.githubusercontent.com/12870715/172590328-5bdeb7d7-d682-4b84-9e9f-60d1742ca45d.png)

经查，以下文件打开时会有这种报错
config,
.eslintrc.js,
fileTransformer.js,
gulpfile.js,
jest.config.js,
babel-transform-less-to-css.js,
scripts/postcss-disable-css-vars.js,
src/tests/mocks/style-mock.js

于是加入到 .eslintrc.js 文件中
```typescript
ignorePatterns: [
'config',
'.eslintrc.js',
'fileTransformer.js',
'gulpfile.js',
'jest.config.js',
'babel-transform-less-to-css.js',
'scripts/postcss-disable-css-vars.js',
'src/tests/mocks/style-mock.js'
],
```
可解决这个恼人的消息。

其中有一文件 `src/tests/mocks/style-mock.js`报的是`'module' is not defined.`。

另有一文件 `.prettierrc.js` 形式与其他报错的文件类似，但并没有报错消息，我不知为何。但既然没有报错，就没有加入到 `ignorePatterns` 配置项中。

# 更新 tsconfig 说明

已使用与项目相同的 typescript 版本
![Pasted image 20220608171741](https://user-images.githubusercontent.com/12870715/172590362-38711010-2174-473f-b3ff-43ff22119d7b.png)

打开项目会有报错
![Pasted image 20220608180049](https://user-images.githubusercontent.com/12870715/172590385-b0a45a61-4b93-4d92-aef2-61c10c526742.png)

在 `tsconfig.json` 中加入
```typescript
"compilerOptions": {
	"outDir": "./",
}
```

可解决报错.

