### PR TITLE
chore(eslint): update eslint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,16 @@ module.exports = {
     'project': 'tsconfig.json',
     'sourceType': 'module',
   },
+  'ignorePatterns': [
+    'config',
+    '.eslintrc.js',
+    'fileTransformer.js',
+    'gulpfile.js',
+    'jest.config.js',
+    'babel-transform-less-to-css.js',
+    'scripts/postcss-disable-css-vars.js',
+    'src/tests/mocks/style-mock.js',
+  ],
   'plugins': ['@typescript-eslint'],
   'rules': {
     '@typescript-eslint/explicit-function-return-type': 'off',


### PR DESCRIPTION
# 更新 eslint rule 说明
## 当前遇到的问题
已使用与项目相同的 typescript 版本
![Pasted image 20220608171741](https://user-images.githubusercontent.com/12870715/172591959-5ed1febd-842d-4486-bae0-9b4c95f3ccb8.png)

打开一些 `module.exports` 开头的文件，会有 `eslint` 的报错，这不会影响什么，但是看着恼人
```typescript
module.exports = {
	...
}
```
报错信息如下：
```bash
Parsing error: "parserOptions.project" has been set for @typescript-eslint/parser.
The file does not match your project config: .eslintrc.js.
The file must be included in at least one of the projects provided.

```
截图如下：
![Pasted image 20220608172218](https://user-images.githubusercontent.com/12870715/172591978-2ccee53b-caf0-455f-a42e-c6e148d1bfef.png)

经查，以下文件打开时会有这种报错
config,
.eslintrc.js,
fileTransformer.js,
'gulpfile.js',
jest.config.js,
babel-transform-less-to-css.js,
scripts/postcss-disable-css-vars.js,
src/tests/mocks/style-mock.js

于是加入到 .eslintrc.js 文件中
```typescript
ignorePatterns: [
'config',
'.eslintrc.js',
'fileTransformer.js',
'gulpfile.js',
'jest.config.js',
'babel-transform-less-to-css.js',
'scripts/postcss-disable-css-vars.js',
'src/tests/mocks/style-mock.js'
],
```
可解决这个恼人的消息。

其中有一文件 `src/tests/mocks/style-mock.js`报的是
`'module' is not defined.`。

另有一文件 `.prettierrc.js` 没有报错消息，我不知为何，但既然没有报错，就没有加入到 `ignorePatterns` 配置项中。