### PR TITLE
feat(badge): add `wrapperClassName` and `wrapperStyle` props

### DIFF
--- a/src/components/badge/badge.tsx
+++ b/src/components/badge/badge.tsx
@@ -11,6 +11,8 @@ export type BadgeProps = {
   color?: string
   bordered?: boolean
   children?: React.ReactNode
+  wrapperClassName?: string
+  wrapperStyle?: React.CSSProperties
 } & NativeProps<'--right' | '--top' | '--color'>
 
 export const Badge: FC<BadgeProps> = props => {
@@ -45,7 +47,10 @@ export const Badge: FC<BadgeProps> = props => {
       : null
 
   return children ? (
-    <div className={`${classPrefix}-wrap`}>
+    <div
+      className={classNames(`${classPrefix}-wrap`, props.wrapperClassName)}
+      style={props.wrapperStyle}
+    >
       {children}
       {element}
     </div>

--- a/src/components/badge/index.en.md
+++ b/src/components/badge/index.en.md
@@ -14,11 +14,13 @@ It is suitable for reminders of productized new news, new functions, new service
 
 ### Props
 
-| Name     | Description                                                                                                                                                        | Type                                  | Default |
-| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------- | ------- |
-| bordered | Whether to have border.                                                                                                                                            | `boolean`                             | `false` |
-| color    | The background color of the Badge. Equivalent to setting the `--color` CSS variable.                                                                               | `string`                              | -       |
-| content  | The content of the Badge: if `null` `undefined` `''` or nothing is passed, it would not be displayed; if `Badge.dot` is passed, a small red dot would be displayed | `React.ReactNode \| typeof Badge.dot` | -       |
+| Name             | Description                                                                                                                                                        | Type                                  | Default |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------- | ------- |
+| bordered         | Whether to have border.                                                                                                                                            | `boolean`                             | `false` |
+| color            | The background color of the Badge. Equivalent to setting the `--color` CSS variable.                                                                               | `string`                              | -       |
+| content          | The content of the Badge: if `null` `undefined` `''` or nothing is passed, it would not be displayed; if `Badge.dot` is passed, a small red dot would be displayed | `React.ReactNode \| typeof Badge.dot` | -       |
+| wrapperClassName | `Badge` wrap class name                                                                                                                                            | `string`                              | -       |
+| wrapperStyle     | `Badge` wrap style                                                                                                                                                 | `React.CSSProperties`                 | -       |
 
 ### CSS Variables
 

--- a/src/components/badge/index.zh.md
+++ b/src/components/badge/index.zh.md
@@ -14,11 +14,13 @@
 
 ### 属性
 
-| 属性     | 说明                                                                                            | 类型                                  | 默认值  |
-| -------- | ----------------------------------------------------------------------------------------------- | ------------------------------------- | ------- |
-| bordered | 是否增加描边                                                                                    | `boolean`                             | `false` |
-| color    | 徽标背景色，等效于设置 `--color` CSS 变量                                                       | `string`                              | -       |
-| content  | 徽标内容：如果传 `null` `undefined` `''` 或不传，则不显示徽标；如果传 `Badge.dot`，会显示小红点 | `React.ReactNode \| typeof Badge.dot` | -       |
+| 属性             | 说明                                                                                            | 类型                                  | 默认值  |
+| ---------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------- | ------- |
+| bordered         | 是否增加描边                                                                                    | `boolean`                             | `false` |
+| color            | 徽标背景色，等效于设置 `--color` CSS 变量                                                       | `string`                              | -       |
+| content          | 徽标内容：如果传 `null` `undefined` `''` 或不传，则不显示徽标；如果传 `Badge.dot`，会显示小红点 | `React.ReactNode \| typeof Badge.dot` | -       |
+| wrapperClassName | `Badge` wrap 自定义类名                                                                         | `string`                              | -       |
+| wrapperStyle     | `Badge` wrap 自定义样式                                                                         | `React.CSSProperties`                 | -       |
 
 ### CSS 变量
 

--- a/src/components/badge/tests/badge.test.tsx
+++ b/src/components/badge/tests/badge.test.tsx
@@ -27,4 +27,21 @@ describe('Badge', () => {
     )
     expect(container).toMatchSnapshot()
   })
+
+  test('test wrapperClassName & wrapperStyle', () => {
+    const { getByTestId } = render(
+      <Badge
+        color='#108ee9'
+        content='新'
+        wrapperClassName='test'
+        data-testid='test-badge-wrap'
+        wrapperStyle={{ color: 'red' }}
+      >
+        text
+      </Badge>
+    )
+    const element = getByTestId('test-badge-wrap')
+    expect(element.parentNode).toHaveClass('test')
+    expect(element.parentNode).toHaveStyle('color: red')
+  })
 })


### PR DESCRIPTION
#5290 

调整了下结构、即使没有children、多一层 wrap 应该也没啥关系！这样className & style 可以放在外层！