### PR TITLE
chore(github workflows): codeql-action v1 to v2

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,7 +31,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v2
         with:
           config-file: ./.github/codeql/codeql-config.yml
           languages: ${{ matrix.language }}
@@ -43,7 +43,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v1
+        uses: github/codeql-action/autobuild@v2
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -57,4 +57,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
发现提示 `CodeQL Action v1 will be deprecated on December 7th, 2022. Please upgrade to v2. `
![image](https://user-images.githubusercontent.com/12870715/173741292-fda5f2c8-efdb-4fbc-acec-936000a29f77.png)

根据文档说明
https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/

![image](https://user-images.githubusercontent.com/12870715/173741432-d5868e4a-7c4d-4379-9093-3693ee7d4fe5.png)

项目中在使用的有
`github/codeql-action/init`
`github/codeql-action/autobuild`
`github/codeql-action/analyze`

更改版本到 v2