### PR TITLE
fix(Picker): picker component accessibility issues on android

### DIFF
--- a/src/components/cascade-picker-view/tests/cascade-picker-view.test.tsx
+++ b/src/components/cascade-picker-view/tests/cascade-picker-view.test.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { render, testA11y, fireEvent, waitFor } from 'testing'
+import { render, testA11y, fireEvent, waitFor, actSleep } from 'testing'
 import CascadePickerView from '..'
 import { options } from '../demos/options-data'
 
@@ -7,7 +7,7 @@ const classPrefix = `adm-picker-view`
 
 const mockStyleHtml = `
 <style>
-  .adm-picker-view-column {
+  .adm-picker-view-column-wheel {
     --item-height: 34px;
   }
 </style>
@@ -41,7 +41,9 @@ describe('CascadePickerView', () => {
 
     const { getByTestId } = render(<App />)
 
-    const wheelEl = document.body.querySelectorAll(`.${classPrefix}-column`)[0]
+    const wheelEl = document.body.querySelectorAll(
+      `.${classPrefix}-column-wheel`
+    )[0]
     fireEvent.mouseDown(wheelEl, {
       buttons: 1,
     })
@@ -50,11 +52,9 @@ describe('CascadePickerView', () => {
       buttons: 1,
     })
     fireEvent.mouseUp(wheelEl)
-
-    await waitFor(() => {
-      expect(getByTestId('res')).toHaveTextContent(
-        JSON.stringify(['江苏', '南京'])
-      )
-    })
+    await actSleep(100)
+    expect(getByTestId('res')).toHaveTextContent(
+      JSON.stringify(['江苏', '南京'])
+    )
   })
 })

--- a/src/components/config-provider/tests/__snapshots__/config-provider.test.tsx.snap
+++ b/src/components/config-provider/tests/__snapshots__/config-provider.test.tsx.snap
@@ -1148,6 +1148,7 @@ exports[`ConfigProvider should display the text as en 1`] = `
         >
           <a
             class="adm-picker-header-button"
+            role="button"
           >
             Cancel
           </a>
@@ -1156,6 +1157,7 @@ exports[`ConfigProvider should display the text as en 1`] = `
           />
           <a
             class="adm-picker-header-button"
+            role="button"
           >
             Confirm
           </a>
@@ -2539,6 +2541,7 @@ exports[`ConfigProvider should display the text as es 1`] = `
         >
           <a
             class="adm-picker-header-button"
+            role="button"
           >
             Cancelar
           </a>
@@ -2547,6 +2550,7 @@ exports[`ConfigProvider should display the text as es 1`] = `
           />
           <a
             class="adm-picker-header-button"
+            role="button"
           >
             Confirmar
           </a>
@@ -3930,6 +3934,7 @@ exports[`ConfigProvider should display the text as fa-IR 1`] = `
         >
           <a
             class="adm-picker-header-button"
+            role="button"
           >
             لغو
           </a>
@@ -3938,6 +3943,7 @@ exports[`ConfigProvider should display the text as fa-IR 1`] = `
           />
           <a
             class="adm-picker-header-button"
+            role="button"
           >
             تایید
           </a>
@@ -5321,6 +5327,7 @@ exports[`ConfigProvider should display the text as fr-FR 1`] = `
         >
           <a
             class="adm-picker-header-button"
+            role="button"
           >
             Annuler
           </a>
@@ -5329,6 +5336,7 @@ exports[`ConfigProvider should display the text as fr-FR 1`] = `
           />
           <a
             class="adm-picker-header-button"
+            role="button"
           >
             Valider
           </a>
@@ -6712,6 +6720,7 @@ exports[`ConfigProvider should display the text as id-ID 1`] = `
         >
           <a
             class="adm-picker-header-button"
+            role="button"
           >
             Batal 
           </a>
@@ -6720,6 +6729,7 @@ exports[`ConfigProvider should display the text as id-ID 1`] = `
           />
           <a
             class="adm-picker-header-button"
+            role="button"
           >
             Yakin
           </a>
@@ -8103,6 +8113,7 @@ exports[`ConfigProvider should display the text as kk-KZ 1`] = `
         >
           <a
             class="adm-picker-header-button"
+            role="button"
           >
             Бастарту
           </a>
@@ -8111,6 +8122,7 @@ exports[`ConfigProvider should display the text as kk-KZ 1`] = `
           />
           <a
             class="adm-picker-header-button"
+            role="button"
           >
             OK
           </a>
@@ -9494,6 +9506,7 @@ exports[`ConfigProvider should display the text as ko-KR 1`] = `
         >
           <a
             class="adm-picker-header-button"
+            role="button"
           >
             취소
           </a>
@@ -9502,6 +9515,7 @@ exports[`ConfigProvider should display the text as ko-KR 1`] = `
           />
           <a
             class="adm-picker-header-button"
+            role="button"
           >
             확인
           </a>
@@ -10885,6 +10899,7 @@ exports[`ConfigProvider should display the text as zh-CH 1`] = `
         >
           <a
             class="adm-picker-header-button"
+            role="button"
           >
             取消
           </a>
@@ -10893,6 +10908,7 @@ exports[`ConfigProvider should display the text as zh-CH 1`] = `
           />
           <a
             class="adm-picker-header-button"
+            role="button"
           >
             确定
           </a>
@@ -12276,6 +12292,7 @@ exports[`ConfigProvider should display the text as zh-HK 1`] = `
         >
           <a
             class="adm-picker-header-button"
+            role="button"
           >
             取消
           </a>
@@ -12284,6 +12301,7 @@ exports[`ConfigProvider should display the text as zh-HK 1`] = `
           />
           <a
             class="adm-picker-header-button"
+            role="button"
           >
             確定
           </a>
@@ -13667,6 +13685,7 @@ exports[`ConfigProvider should display the text as zh-TW 1`] = `
         >
           <a
             class="adm-picker-header-button"
+            role="button"
           >
             取消
           </a>
@@ -13675,6 +13694,7 @@ exports[`ConfigProvider should display the text as zh-TW 1`] = `
           />
           <a
             class="adm-picker-header-button"
+            role="button"
           >
             確定
           </a>

--- a/src/components/picker-view/picker-view.less
+++ b/src/components/picker-view/picker-view.less
@@ -66,6 +66,7 @@
   flex-direction: column;
   position: relative;
   z-index: 0;
+  padding-bottom: 1px;
   > * {
     flex: 1;
     text-overflow: ellipsis;

--- a/src/components/picker-view/tests/picker-view.test.tsx
+++ b/src/components/picker-view/tests/picker-view.test.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { render, testA11y, fireEvent, waitFor } from 'testing'
+import { render, testA11y, fireEvent, waitFor, actSleep } from 'testing'
 import PickerView from '../'
 import { basicColumns } from '../demos/columns-data'
 
@@ -7,7 +7,7 @@ const classPrefix = `adm-picker-view`
 
 const mockStyleHtml = `
 <style>
-  .adm-picker-view-column {
+  .adm-picker-view-column-wheel {
     --item-height: 34px;
   }
 </style>
@@ -40,8 +40,9 @@ describe('PickerView', () => {
     }
 
     const { getByTestId } = render(<App />)
-
-    const wheelEl = document.body.querySelectorAll(`.${classPrefix}-column`)[0]
+    const wheelEl = document.body.querySelectorAll(
+      `.${classPrefix}-column-wheel`
+    )[0]
     fireEvent.mouseDown(wheelEl, {
       buttons: 1,
     })
@@ -50,11 +51,7 @@ describe('PickerView', () => {
       buttons: 1,
     })
     fireEvent.mouseUp(wheelEl)
-
-    await waitFor(() => {
-      expect(getByTestId('res')).toHaveTextContent(
-        JSON.stringify(['Thur', 'am'])
-      )
-    })
+    await actSleep(100)
+    expect(getByTestId('res')).toHaveTextContent(JSON.stringify(['Thur', 'am']))
   })
 })

--- a/src/components/picker-view/wheel.tsx
+++ b/src/components/picker-view/wheel.tsx
@@ -163,41 +163,38 @@ export const Wheel = memo<Props>(
           >
             -
           </div>
-          <div>
-            {previous && (
-              <div
-                className='adm-picker-view-column-accessible-button'
-                onClick={() => {
-                  scrollSelect(previousIndex)
-                }}
-                role='button'
-                aria-label={`选择上一项：${previous.label}`}
-              >
-                -
-              </div>
-            )}
+          <div
+            className='adm-picker-view-column-accessible-button'
+            onClick={() => {
+              if (!previous) return
+              scrollSelect(previousIndex)
+            }}
+            role={previous ? 'button' : 'text'}
+            aria-label={
+              !previous ? '没有上一项' : `选择上一项：${previous.label}`
+            }
+          >
+            -
           </div>
-          <div>
-            {next && (
-              <div
-                className='adm-picker-view-column-accessible-button'
-                onClick={() => {
-                  scrollSelect(nextIndex)
-                }}
-                role='button'
-                aria-label={`选择下一项：${next.label}`}
-              >
-                -
-              </div>
-            )}
+          <div
+            className='adm-picker-view-column-accessible-button'
+            onClick={() => {
+              if (!next) return
+              scrollSelect(nextIndex)
+            }}
+            role={next ? 'button' : 'text'}
+            aria-label={!next ? '没有下一项' : `选择下一项：${next.label}`}
+          >
+            -
           </div>
         </div>
       )
     }
 
     return (
-      <div ref={rootRef} className={`${classPrefix}-column`}>
+      <div className={`${classPrefix}-column`}>
         <animated.div
+          ref={rootRef}
           style={{ translateY: y }}
           className={`${classPrefix}-column-wheel`}
           aria-hidden

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -152,6 +152,7 @@ export const Picker = memo(
       <div className={classPrefix}>
         <div className={`${classPrefix}-header`}>
           <a
+            role='button'
             className={`${classPrefix}-header-button`}
             onClick={() => {
               props.onCancel?.()
@@ -162,6 +163,7 @@ export const Picker = memo(
           </a>
           <div className={`${classPrefix}-header-title`}>{props.title}</div>
           <a
+            role='button'
             className={`${classPrefix}-header-button`}
             onClick={() => {
               setValue(innerValue)


### PR DESCRIPTION
无障碍
1. Picker弹窗上的确定/取消按钮在Android和ios上的无障碍焦点定位问题
2. android上选择器选中某个项时跳动问题
3. android无法选中项问题
4. 当选中某一项后，该项后面没有可选了，导致焦点不在弹窗上