### PR TITLE
fix(Steps): icon background should be black in dark mode

### DIFF
--- a/src/components/steps/steps.less
+++ b/src/components/steps/steps.less
@@ -16,7 +16,7 @@
     .@{class-prefix-step}-icon-container {
       position: absolute;
       z-index: 1;
-      background: var(--adm-color-white);
+      background: var(--adm-color-background);
       color: var(--icon-color);
       > .antd-mobile-icon {
         display: block;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/37403253/174932172-a8bba4f2-967b-4811-bfad-042044a66087.png)
steps 在暗黑模式下 .adm-step-icon-container 类中  background 为白色
```css
.adm-step .adm-step-indicator .adm-step-icon-container {
    position: absolute;
    z-index: 1;
    background: var(--adm-color-white);
    color: var(--icon-color);
}
```