### PR TITLE
feat(Cascader): add a new actions param to children render function

### DIFF
--- a/src/components/cascader/cascader.tsx
+++ b/src/components/cascader/cascader.tsx
@@ -1,4 +1,10 @@
-import React, { useState, useEffect, ReactNode, FC } from 'react'
+import React, {
+  useState,
+  useEffect,
+  ReactNode,
+  forwardRef,
+  useImperativeHandle,
+} from 'react'
 import Popup, { PopupProps } from '../popup'
 import {
   CascaderValue,
@@ -14,6 +20,13 @@ import { useCascaderValueExtend } from '../cascader-view/use-cascader-value-exte
 
 const classPrefix = `adm-cascader`
 
+export type CascaderActions = {
+  open: () => void
+  close: () => void
+  toggle: () => void
+}
+export type CascaderRef = CascaderActions
+
 export type CascaderProps = {
   options: CascaderOption[]
   value?: CascaderValue[]
@@ -27,7 +40,10 @@ export type CascaderProps = {
   title?: ReactNode
   confirmText?: ReactNode
   cancelText?: ReactNode
-  children?: (items: (CascaderOption | null)[]) => ReactNode
+  children?: (
+    items: (CascaderOption | null)[],
+    actions: CascaderActions
+  ) => ReactNode
   onTabsChange?: (index: number) => void
 } & Pick<
   PopupProps,
@@ -47,7 +63,7 @@ const defaultProps = {
   forceRender: false,
 }
 
-export const Cascader: FC<CascaderProps> = p => {
+export const Cascader = forwardRef<CascaderRef, CascaderProps>((p, ref) => {
   const { locale } = useConfig()
   const props = mergeProps(
     defaultProps,
@@ -58,6 +74,30 @@ export const Cascader: FC<CascaderProps> = p => {
     },
     p
   )
+
+  const [visible, setVisible] = usePropsValue({
+    value: props.visible,
+    defaultValue: false,
+    onChange: v => {
+      if (v === false) {
+        props.onClose?.()
+      }
+    },
+  })
+
+  const actions: CascaderActions = {
+    toggle: () => {
+      setVisible(v => !v)
+    },
+    open: () => {
+      setVisible(true)
+    },
+    close: () => {
+      setVisible(false)
+    },
+  }
+
+  useImperativeHandle(ref, () => actions)
 
   const [value, setValue] = usePropsValue({
     ...props,
@@ -70,12 +110,12 @@ export const Cascader: FC<CascaderProps> = p => {
 
   const [innerValue, setInnerValue] = useState<CascaderValue[]>(value)
   useEffect(() => {
-    if (!props.visible) {
+    if (!visible) {
       setInnerValue(value)
     }
-  }, [props.visible])
+  }, [visible])
   useEffect(() => {
-    if (!props.visible) {
+    if (!visible) {
       setInnerValue(value)
     }
   }, [value])
@@ -88,7 +128,7 @@ export const Cascader: FC<CascaderProps> = p => {
           className={`${classPrefix}-header-button`}
           onClick={() => {
             props.onCancel?.()
-            props.onClose?.()
+            setVisible(false)
           }}
         >
           {props.cancelText}
@@ -98,7 +138,7 @@ export const Cascader: FC<CascaderProps> = p => {
           className={`${classPrefix}-header-button`}
           onClick={() => {
             setValue(innerValue)
-            props.onClose?.()
+            setVisible(false)
           }}
         >
           {props.confirmText}
@@ -110,7 +150,7 @@ export const Cascader: FC<CascaderProps> = p => {
           value={innerValue}
           onChange={(val, ext) => {
             setInnerValue(val)
-            if (props.visible) {
+            if (visible) {
               props.onSelect?.(val, ext)
             }
           }}
@@ -121,11 +161,11 @@ export const Cascader: FC<CascaderProps> = p => {
 
   const popupElement = (
     <Popup
-      visible={props.visible}
+      visible={visible}
       position='bottom'
       onMaskClick={() => {
         props.onCancel?.()
-        props.onClose?.()
+        setVisible(false)
       }}
       getContainer={props.getContainer}
       destroyOnClose={props.destroyOnClose}
@@ -142,7 +182,7 @@ export const Cascader: FC<CascaderProps> = p => {
   return (
     <>
       {popupElement}
-      {props.children?.(generateValueExtend(value).items)}
+      {props.children?.(generateValueExtend(value).items, actions)}
     </>
   )
-}
+})

--- a/src/components/cascader/demos/demo1.tsx
+++ b/src/components/cascader/demos/demo1.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { Cascader, Button, Space, Toast } from 'antd-mobile'
-import { DemoBlock } from 'demos'
+import { DemoBlock, DemoDescription } from 'demos'
 
 import { options, longOptions } from './data'
 
@@ -69,6 +69,21 @@ function RenderChildrenDemo() {
   )
 }
 
+function ActionsDemo() {
+  const [value, setValue] = useState<string[]>([])
+  return (
+    <Cascader
+      options={options}
+      value={value}
+      onConfirm={v => {
+        setValue(v)
+      }}
+    >
+      {(_, actions) => <Button onClick={actions.open}>选择</Button>}
+    </Cascader>
+  )
+}
+
 export default () => {
   return (
     <>
@@ -108,6 +123,16 @@ export default () => {
         >
           选择
         </Button>
+      </DemoBlock>
+
+      <DemoBlock title='使用 actions 来控制显示/隐藏'>
+        <Space direction='vertical' block>
+          <ActionsDemo />
+          <DemoDescription>
+            在 children 渲染函数中，你可以使用第二个参数 actions
+            来非常方便的控制 Picker 的显示或隐藏
+          </DemoDescription>
+        </Space>
       </DemoBlock>
     </>
   )

--- a/src/components/cascader/index.en.md
+++ b/src/components/cascader/index.en.md
@@ -32,26 +32,38 @@ type CascaderValueExtend = {
 }
 ```
 
-| Name           | Description                                     | Type                                                            | Default    |
-| -------------- | ----------------------------------------------- | --------------------------------------------------------------- | ---------- |
-| cancelText     | Text of the cancel button                       | `ReactNode`                                                     | `'取消'`   |
-| children       | Render function of the selected options         | `(items: CascaderOption[]) => ReactNode`                        | -          |
-| confirmText    | Text of the ok button                           | `ReactNode`                                                     | `'确定'`   |
-| defaultValue   | Default selected options                        | `CascaderValue[]`                                               | `[]`       |
-| destroyOnClose | Unmount content when not visible                | `boolean`                                                       | `true`     |
-| forceRender    | Render content forcely                          | `boolean`                                                       | `false`    |
-| onCancel       | Triggered when cancelling                       | `() => void`                                                    | -          |
-| onClose        | Triggered when confirming or cancelling         | `() => void`                                                    | -          |
-| onConfirm      | Triggered when confirming                       | `(value: CascaderValue[], extend: CascaderValueExtend) => void` | -          |
-| onSelect       | Triggered when the selected options are changed | `(value: CascaderValue[], extend: CascaderValueExtend) => void` | -          |
-| onTabsChange   | Callback when switching panel                   | `(index: number) => void`                                       | -          |
-| options        | Data of the cascade options                     | `CascaderOption[]`                                              | -          |
-| placeholder    | Hint text                                       | `string`                                                        | `'请选择'` |
-| title          | Title                                           | `ReactNode`                                                     | -          |
-| value          | Selected options                                | `CascaderValue[]`                                               | -          |
-| visible        | Whether to show or hide the Picker              | `boolean`                                                       | `false`    |
+| Name           | Description                                     | Type                                                               | Default    |
+| -------------- | ----------------------------------------------- | ------------------------------------------------------------------ | ---------- |
+| cancelText     | Text of the cancel button                       | `ReactNode`                                                        | `'取消'`   |
+| children       | Render function of the selected options         | `(items: CascaderOption[], actions: CascaderActions) => ReactNode` | -          |
+| confirmText    | Text of the ok button                           | `ReactNode`                                                        | `'确定'`   |
+| defaultValue   | Default selected options                        | `CascaderValue[]`                                                  | `[]`       |
+| destroyOnClose | Unmount content when not visible                | `boolean`                                                          | `true`     |
+| forceRender    | Render content forcely                          | `boolean`                                                          | `false`    |
+| onCancel       | Triggered when cancelling                       | `() => void`                                                       | -          |
+| onClose        | Triggered when confirming or cancelling         | `() => void`                                                       | -          |
+| onConfirm      | Triggered when confirming                       | `(value: CascaderValue[], extend: CascaderValueExtend) => void`    | -          |
+| onSelect       | Triggered when the selected options are changed | `(value: CascaderValue[], extend: CascaderValueExtend) => void`    | -          |
+| onTabsChange   | Callback when switching panel                   | `(index: number) => void`                                          | -          |
+| options        | Data of the cascade options                     | `CascaderOption[]`                                                 | -          |
+| placeholder    | Hint text                                       | `string`                                                           | `'请选择'` |
+| title          | Title                                           | `ReactNode`                                                        | -          |
+| value          | Selected options                                | `CascaderValue[]`                                                  | -          |
+| visible        | Whether to show or hide the Picker              | `boolean`                                                          | `false`    |
 
 Please pay attention to the `children` property of `CascaderOption`. If the `children` of an `option` is `[]`, then when the user selects this `option`, the Cascader component will automatically jump to the next level, even if There are currently no options at this level (because Cascader has no way to determine whether this empty array will become an array with content in subsequent updates). Therefore, please make sure that the `children` property of the last level option (aka "leaf node") does not exist or has the value `undefined`, so that the Cascader component can correctly recognize it.
+
+### CascaderActions
+
+| Name   | Description                           | Type         |
+| ------ | ------------------------------------- | ------------ |
+| close  | Close Cascader.                       | `() => void` |
+| open   | Open Cascader.                        | `() => void` |
+| toggle | Toggle the visible state of Cascader. | `() => void` |
+
+### Ref
+
+Same as CascaderActions.
 
 ### Loading <Experimental></Experimental>
 

--- a/src/components/cascader/index.ts
+++ b/src/components/cascader/index.ts
@@ -4,7 +4,7 @@ import { attachPropertiesToComponent } from '../../utils/attach-properties-to-co
 import './cascader.less'
 import { optionSkeleton } from '../cascader-view/option-skeleton'
 
-export type { CascaderProps } from './cascader'
+export type { CascaderProps, CascaderRef, CascaderActions } from './cascader'
 
 export type {
   CascaderValue,

--- a/src/components/cascader/index.zh.md
+++ b/src/components/cascader/index.zh.md
@@ -32,26 +32,38 @@ type CascaderValueExtend = {
 }
 ```
 
-| 属性           | 说明                         | 类型                                                            | 默认值     |
-| -------------- | ---------------------------- | --------------------------------------------------------------- | ---------- |
-| cancelText     | 取消按钮的文字               | `ReactNode`                                                     | `'取消'`   |
-| children       | 所选项的渲染函数             | `(items: CascaderOption[]) => ReactNode`                        | -          |
-| confirmText    | 确定按钮的文字               | `ReactNode`                                                     | `'确定'`   |
-| defaultValue   | 默认选中项                   | `CascaderValue[]`                                               | `[]`       |
-| destroyOnClose | 不可见时卸载内容             | `boolean`                                                       | `true`     |
-| forceRender    | 强制渲染内容                 | `boolean`                                                       | `false`    |
-| onCancel       | 取消时触发                   | `() => void`                                                    | -          |
-| onClose        | 确认和取消时都会触发关闭事件 | `() => void`                                                    | -          |
-| onConfirm      | 确认时触发                   | `(value: CascaderValue[], extend: CascaderValueExtend) => void` | -          |
-| onSelect       | 选项改变时触发               | `(value: CascaderValue[], extend: CascaderValueExtend) => void` | -          |
-| onTabsChange   | 切换面板的回调               | `(index: number) => void`                                       | -          |
-| options        | 级联数据                     | `CascaderOption[]`                                              | -          |
-| placeholder    | 未选中时的提示文案           | `string`                                                        | `'请选择'` |
-| title          | 标题                         | `ReactNode`                                                     | -          |
-| value          | 选中项                       | `CascaderValue[]`                                               | -          |
-| visible        | 是否显示级联选择             | `boolean`                                                       | `false`    |
+| 属性           | 说明                         | 类型                                                               | 默认值     |
+| -------------- | ---------------------------- | ------------------------------------------------------------------ | ---------- |
+| cancelText     | 取消按钮的文字               | `ReactNode`                                                        | `'取消'`   |
+| children       | 所选项的渲染函数             | `(items: CascaderOption[], actions: CascaderActions) => ReactNode` | -          |
+| confirmText    | 确定按钮的文字               | `ReactNode`                                                        | `'确定'`   |
+| defaultValue   | 默认选中项                   | `CascaderValue[]`                                                  | `[]`       |
+| destroyOnClose | 不可见时卸载内容             | `boolean`                                                          | `true`     |
+| forceRender    | 强制渲染内容                 | `boolean`                                                          | `false`    |
+| onCancel       | 取消时触发                   | `() => void`                                                       | -          |
+| onClose        | 确认和取消时都会触发关闭事件 | `() => void`                                                       | -          |
+| onConfirm      | 确认时触发                   | `(value: CascaderValue[], extend: CascaderValueExtend) => void`    | -          |
+| onSelect       | 选项改变时触发               | `(value: CascaderValue[], extend: CascaderValueExtend) => void`    | -          |
+| onTabsChange   | 切换面板的回调               | `(index: number) => void`                                          | -          |
+| options        | 级联数据                     | `CascaderOption[]`                                                 | -          |
+| placeholder    | 未选中时的提示文案           | `string`                                                           | `'请选择'` |
+| title          | 标题                         | `ReactNode`                                                        | -          |
+| value          | 选中项                       | `CascaderValue[]`                                                  | -          |
+| visible        | 是否显示级联选择             | `boolean`                                                          | `false`    |
 
 请留意 `CascaderOption` 的 `children` 属性，如果某个 `option` 的 `children` 为 `[]`，那当用户选择了这个 `option` 时，Cascader 组件会自动跳转到下一级，即便这一级当前是没有任何选项的（因为 Cascader 没有办法判断，在后续的更新中，这个空数组会不会变为一个有内容的数组）。因此，请确保最末一级的 option（也就是"叶子节点"）的 `children` 属性不存在或者值为 `undefined`，这样 Cascader 组件才能将其正确地识别。
+
+### CascaderActions
+
+| 属性   | 说明                           | 类型         |
+| ------ | ------------------------------ | ------------ |
+| close  | 关闭 Cascader                  | `() => void` |
+| open   | 显示 Cascader                  | `() => void` |
+| toggle | 切换 Cascader 的显示和隐藏状态 | `() => void` |
+
+### Ref
+
+同 CascaderActions。
 
 ### 加载中 <Experimental></Experimental>
 


### PR DESCRIPTION
与 picker 相同，增加 `children render actions` 和 `ref`