### PR TITLE
enhance(CascaderView): avoid render empty children

### DIFF
--- a/src/components/cascader-view/cascader-view.tsx
+++ b/src/components/cascader-view/cascader-view.tsx
@@ -71,7 +71,7 @@ export const CascaderView: FC<CascaderViewProps> = p => {
         selected: target,
         options: currentOptions,
       })
-      if (!target || !target.children) {
+      if (!target || !target.children || target.children.length === 0) {
         reachedEnd = true
         break
       }

--- a/src/components/cascader-view/tests/cascader-view.test.tsx
+++ b/src/components/cascader-view/tests/cascader-view.test.tsx
@@ -62,4 +62,19 @@ describe('CascaderView', () => {
     click(2, 0)
     expect(container).toMatchSnapshot()
   })
+
+  test('avoid render empty children', async () => {
+    const onChange = jest.fn()
+    const options = [{ label: '第一层', value: '1', children: [] }]
+    const { container } = render(
+      <CascaderView options={options} onChange={onChange} />
+    )
+
+    click(0, 0)
+    expect(onChange).toBeCalledTimes(1)
+    expect(onChange.mock.calls[0][0]).toStrictEqual(['1'])
+    expect(
+      container.querySelectorAll(`.${classPrefix}-header-title`).length
+    ).toBe(1)
+  })
 })


### PR DESCRIPTION
```ts
const options = [{ label: '第一层', value: '1', children: [] }]
```

避免渲染出空的 `children`，省得用户自己洗一遍数据