### PR TITLE
fix(Picker): display incorrect style in dark mode

### DIFF
--- a/src/components/picker-view/picker-view.less
+++ b/src/components/picker-view/picker-view.less
@@ -9,7 +9,7 @@
   display: flex;
   position: relative;
   overflow: hidden;
-  background: var(--adm-color-white);
+  background: var(--adm-color-background);
 }
 
 .@{class-prefix-picker-view}-column {
@@ -104,19 +104,21 @@
     border-bottom: solid 1px var(--adm-color-border);
   }
   &-top {
-    background: linear-gradient(
+    background: var(--adm-color-background);
+    mask: linear-gradient(
       0deg,
-      rgba(255, 255, 255, 0.6) 0%,
-      rgba(255, 255, 255, 0.8) 50%,
-      rgba(255, 255, 255, 1)
+      rgba(0, 0, 0, 0.6) 0%,
+      rgba(0, 0, 0, 0.8) 50%,
+      rgba(0, 0, 0, 1) 100%
     );
   }
   &-bottom {
-    background: linear-gradient(
+    background: var(--adm-color-background);
+    mask: linear-gradient(
       180deg,
-      rgba(255, 255, 255, 0.6) 0%,
-      rgba(255, 255, 255, 0.8) 50%,
-      rgba(255, 255, 255, 1)
+      rgba(0, 0, 0, 0.6) 0%,
+      rgba(0, 0, 0, 0.8) 50%,
+      rgba(0, 0, 0, 1) 100%
     );
   }
 }


### PR DESCRIPTION
fix #5374 

使用 mask 实现遮罩，兼容性参照 [caniuse](https://caniuse.com/?search=mask-image)，覆盖移动端主流版本