### PR TITLE
fix(Calendar): replace renderLabel type string to ReactNode

### DIFF
--- a/src/components/calendar/calendar.tsx
+++ b/src/components/calendar/calendar.tsx
@@ -35,7 +35,7 @@ export type CalendarProps = {
   nextYearButton?: React.ReactNode
   onPageChange?: (year: number, month: number) => void
   weekStartsOn?: 'Monday' | 'Sunday'
-  renderLabel?: (date: Date) => string | null | undefined
+  renderLabel?: (date: Date) => React.ReactNode
   allowClear?: boolean
   max?: Date
   min?: Date


### PR DESCRIPTION
`renderLabel` function can accept `ReactNode` now but the type is defined as `string`. 