### PR TITLE
feat(Modal & Dialog & ActionSheet): omit `destroyOnClose` and `forceRender` types in imperatively show mode

### DIFF
--- a/src/components/action-sheet/action-sheet.tsx
+++ b/src/components/action-sheet/action-sheet.tsx
@@ -139,7 +139,9 @@ export type ActionSheetShowHandler = {
   close: () => void
 }
 
-export function showActionSheet(props: Omit<ActionSheetProps, 'visible'>) {
+export function showActionSheet(
+  props: Omit<ActionSheetProps, 'visible' | 'destroyOnClose' | 'forceRender'>
+) {
   return renderImperatively(
     <ActionSheet {...props} />
   ) as ActionSheetShowHandler

--- a/src/components/dialog/show.tsx
+++ b/src/components/dialog/show.tsx
@@ -2,7 +2,10 @@ import React from 'react'
 import { Dialog, DialogProps } from './dialog'
 import { renderImperatively } from '../../utils/render-imperatively'
 
-export type DialogShowProps = Omit<DialogProps, 'visible'>
+export type DialogShowProps = Omit<
+  DialogProps,
+  'visible' | 'destroyOnClose' | 'forceRender'
+>
 
 export type DialogShowHandler = {
   close: () => void

--- a/src/components/modal/show.tsx
+++ b/src/components/modal/show.tsx
@@ -2,7 +2,10 @@ import React from 'react'
 import { Modal, ModalProps } from './modal'
 import { renderImperatively } from '../../utils/render-imperatively'
 
-export type ModalShowProps = Omit<ModalProps, 'visible'>
+export type ModalShowProps = Omit<
+  ModalProps,
+  'visible' | 'destroyOnClose' | 'forceRender'
+>
 
 export type ModalShowHandler = {
   close: () => void


### PR DESCRIPTION
在以下指令式打开对话框时`Modal.show()`、`Dialog.show()`、`ActionSheet.show()`，

排除掉 `destroyOnClose` 、`forceRender` 两个类型。因为，指令式模式下，对话框关闭时总是卸载组件