### PR TITLE
doc: Grammar fixes to make it make sense in English

### DIFF
--- a/docs/guide/migration.en.md
+++ b/docs/guide/migration.en.md
@@ -82,4 +82,4 @@ import { Button } from 'antd-mobile' // v2
 import { Button } from 'antd-mobile-v5' // v5
 ```
 
-Need to be noted, not every package manager has a well support for npm alias.
+Please note that npm aliases are not well supported by all package managers


### PR DESCRIPTION
Added a grammar correction to make the "not all package managers support npm aliases" make sense in English