### PR TITLE
fix(SwipeAction): fix close on touch outside and interaction between SwipeActions

### DIFF
--- a/src/components/swipe-action/swipe-action.tsx
+++ b/src/components/swipe-action/swipe-action.tsx
@@ -92,10 +92,17 @@ export const SwipeAction = forwardRef<SwipeActionRef, SwipeActionProps>(
     function forceCancelDrag() {
       dragCancelRef.current?.()
       draggingRef.current = false
+      dragDownRef.current = false
     }
+    const dragDownRef = useRef(false)
 
     const bind = useDrag(
       state => {
+        if (state.down) {
+          dragDownRef.current = state.down
+        }
+        if (!dragDownRef.current) return
+
         dragCancelRef.current = state.cancel
         if (!state.intentional) return
         draggingRef.current = true

--- a/src/components/swipe-action/swipe-action.tsx
+++ b/src/components/swipe-action/swipe-action.tsx
@@ -92,20 +92,16 @@ export const SwipeAction = forwardRef<SwipeActionRef, SwipeActionProps>(
     function forceCancelDrag() {
       dragCancelRef.current?.()
       draggingRef.current = false
-      dragDownRef.current = false
     }
-    const dragDownRef = useRef(false)
 
     const bind = useDrag(
       state => {
-        if (state.down) {
-          dragDownRef.current = state.down
-        }
-        if (!dragDownRef.current) return
-
         dragCancelRef.current = state.cancel
         if (!state.intentional) return
-        draggingRef.current = true
+        if (state.down) {
+          draggingRef.current = true
+        }
+        if (!draggingRef.current) return
         const [offsetX] = state.offset
         if (state.last) {
           const leftWidth = getLeftWidth()


### PR DESCRIPTION
1. fix #5490

2. 解决bug（1），可以通过 SwipeAction 组件 demo 复现，步骤如下：
  2.1 右滑列表项C，展示”置顶“按钮
  2.2 点击列表项B，来恢复列表项C的默认效果，点击一次无法关闭，再次点击时才关闭（不符合预期）

3. 解决bug（2），可以通过 SwipeAction 组件 demo 复现，步骤如下：
  3.1 右滑列表项C，展示”置顶“按钮
  3.2 点击列表项B，来恢复列表项C的默认效果
  3.3 再次左滑列表项C，列表项B也会出现滑动（不符合预期）