### PR TITLE
fix(Rate): rate value will reset when drag stop on PC

### DIFF
--- a/src/components/rate/rate.less
+++ b/src/components/rate/rate.less
@@ -6,6 +6,7 @@
   --inactive-color: var(--adm-color-border);
   display: inline-flex;
   touch-action: pan-y;
+  user-select: none;
   &-box {
     position: relative;
   }

--- a/src/components/rate/rate.less
+++ b/src/components/rate/rate.less
@@ -20,6 +20,7 @@
     overflow: hidden;
     cursor: pointer;
     box-sizing: border-box;
+    transition: all 0.3s;
     &-half {
       padding-right: 0;
       width: 50%;

--- a/src/components/rate/rate.tsx
+++ b/src/components/rate/rate.tsx
@@ -44,14 +44,6 @@ export const Rate: FC<RateProps> = p => {
           [`${classPrefix}-star-half`]: half,
           [`${classPrefix}-star-readonly`]: props.readOnly,
         })}
-        // onMouseUp={() => {
-        //   if (props.readOnly) return
-        //   if (props.allowClear && value === v) {
-        //     setValue(0)
-        //   } else {
-        //     setValue(v)
-        //   }
-        // }}
         role='radio'
         aria-checked={value >= v}
         aria-label={'' + v}
@@ -71,14 +63,13 @@ export const Rate: FC<RateProps> = p => {
       const container = containerRef.current
       if (!container) return
       const rect = container.getBoundingClientRect()
-
       const rawValue = ((clientX - rect.left) / rect.width) * props.count
 
-      const roundedValue = props.allowHalf
+      const ceiledValue = props.allowHalf
         ? Math.ceil(rawValue * 2) / 2
         : Math.ceil(rawValue)
 
-      const boundValue = bound(roundedValue, 0, props.count)
+      const boundValue = bound(ceiledValue, 0, props.count)
 
       if (tap) {
         if (props.allowClear && boundValue === value) {
@@ -87,7 +78,7 @@ export const Rate: FC<RateProps> = p => {
         }
       }
 
-      setValue(bound(roundedValue, 0, props.count))
+      setValue(boundValue)
     },
     {
       axis: 'x',

--- a/src/components/rate/rate.tsx
+++ b/src/components/rate/rate.tsx
@@ -44,14 +44,14 @@ export const Rate: FC<RateProps> = p => {
           [`${classPrefix}-star-half`]: half,
           [`${classPrefix}-star-readonly`]: props.readOnly,
         })}
-        onClick={() => {
-          if (props.readOnly) return
-          if (props.allowClear && value === v) {
-            setValue(0)
-          } else {
-            setValue(v)
-          }
-        }}
+        // onMouseUp={() => {
+        //   if (props.readOnly) return
+        //   if (props.allowClear && value === v) {
+        //     setValue(0)
+        //   } else {
+        //     setValue(v)
+        //   }
+        // }}
         role='radio'
         aria-checked={value >= v}
         aria-label={'' + v}
@@ -66,6 +66,7 @@ export const Rate: FC<RateProps> = p => {
       if (props.readOnly) return
       const {
         xy: [clientX],
+        tap,
       } = state
       const container = containerRef.current
       if (!container) return
@@ -74,20 +75,28 @@ export const Rate: FC<RateProps> = p => {
       const rawValue = ((clientX - rect.left) / rect.width) * props.count
 
       const roundedValue = props.allowHalf
-        ? Math.round(rawValue * 2) / 2
-        : Math.round(rawValue)
+        ? Math.ceil(rawValue * 2) / 2
+        : Math.ceil(rawValue)
+
+      const boundValue = bound(roundedValue, 0, props.count)
+
+      if (tap) {
+        if (props.allowClear && boundValue === value) {
+          setValue(0)
+          return
+        }
+      }
 
       setValue(bound(roundedValue, 0, props.count))
     },
     {
       axis: 'x',
-      preventScroll: true,
       pointer: {
         touch: true,
       },
+      filterTaps: true,
     }
   )
-
   return withNativeProps(
     props,
     <div

--- a/src/components/rate/tests/rate.test.tsx
+++ b/src/components/rate/tests/rate.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, testA11y, fireEvent, screen } from 'testing'
+import { render, testA11y, fireEvent, screen, mockDrag } from 'testing'
 import Rate from '..'
 
 const classPrefix = `adm-rate`
@@ -12,8 +12,29 @@ describe('Rate', () => {
   test('readOnly should be work', () => {
     const onChange = jest.fn()
     render(<Rate value={4} readOnly onChange={onChange} />)
+    const radioGroup = screen.getByRole('radiogroup')
+    radioGroup.getBoundingClientRect = jest.fn(
+      () =>
+        ({
+          bottom: 82,
+          height: 30,
+          left: 12,
+          right: 167.9375,
+          top: 52,
+          width: 155.9375,
+          x: 12,
+          y: 52,
+        } as DOMRect)
+    )
     const radio = screen.getByRole('radio', { name: '1' })
-    fireEvent.click(radio)
+    mockDrag(radioGroup, [
+      {
+        clientX: 0,
+      },
+      {
+        clientX: 100,
+      },
+    ])
     expect(radio).toHaveClass(`${classPrefix}-star-readonly`)
     expect(onChange).not.toBeCalled()
   })
@@ -21,21 +42,89 @@ describe('Rate', () => {
   test('allowHalf should be work', () => {
     render(<Rate allowHalf />)
     const radio = screen.getByRole('radio', { name: '1.5' })
-    fireEvent.click(radio)
+    const shouldNotActiveRadio = screen.getByRole('radio', { name: '2' })
+    const radioGroup = screen.getByRole('radiogroup')
+    radioGroup.getBoundingClientRect = jest.fn(
+      () =>
+        ({
+          bottom: 82,
+          height: 30,
+          left: 12,
+          right: 167.9375,
+          top: 52,
+          width: 155.9375,
+          x: 12,
+          y: 52,
+        } as DOMRect)
+    )
+
+    mockDrag(radioGroup, [
+      {
+        clientX: 54,
+      },
+      {
+        clientX: 54,
+      },
+    ])
+
     expect(radio).toHaveClass(`${classPrefix}-star-half`)
     expect(radio).toHaveClass(`${classPrefix}-star-active`)
-
-    fireEvent.click(radio)
+    expect(shouldNotActiveRadio).not.toHaveClass(`${classPrefix}-star-active`)
+    mockDrag(radioGroup, [
+      {
+        clientX: 54,
+      },
+      {
+        clientX: 54,
+      },
+    ])
     expect(
       document.querySelectorAll(`.${classPrefix}-star-active`)
     ).toHaveLength(0)
   })
 
+  test('can clear', () => {
+    render(<Rate defaultValue={1} />)
+    const radio = screen.getByRole('radio', { name: '1' })
+    const radioGroup = screen.getByRole('radiogroup')
+    radioGroup.getBoundingClientRect = jest.fn(
+      () =>
+        ({
+          bottom: 82,
+          height: 30,
+          left: 12,
+          right: 167.9375,
+          top: 52,
+          width: 155.9375,
+          x: 12,
+          y: 52,
+        } as DOMRect)
+    )
+    expect(radio).toHaveClass(`${classPrefix}-star-active`)
+    // fireEvent.click(radio)
+    mockDrag(radioGroup, [{ clientX: 40 }, { clientX: 40 }])
+    expect(radio).not.toHaveClass(`${classPrefix}-star-active`)
+  })
+
   test('can not clear', () => {
     render(<Rate allowClear={false} defaultValue={1} />)
     const radio = screen.getByRole('radio', { name: '1' })
+    const radioGroup = screen.getByRole('radiogroup')
+    radioGroup.getBoundingClientRect = jest.fn(
+      () =>
+        ({
+          bottom: 82,
+          height: 30,
+          left: 12,
+          right: 167.9375,
+          top: 52,
+          width: 155.9375,
+          x: 12,
+          y: 52,
+        } as DOMRect)
+    )
     expect(radio).toHaveClass(`${classPrefix}-star-active`)
-    fireEvent.click(radio)
+    mockDrag(radioGroup, [{ clientX: 40 }, { clientX: 40 }])
     expect(radio).toHaveClass(`${classPrefix}-star-active`)
   })
 })

--- a/src/components/rate/tests/rate.test.tsx
+++ b/src/components/rate/tests/rate.test.tsx
@@ -5,6 +5,18 @@ import Rate from '..'
 const classPrefix = `adm-rate`
 
 describe('Rate', () => {
+  const getBoundingClientRectMock = jest.spyOn(
+    HTMLElement.prototype,
+    'getBoundingClientRect'
+  )
+
+  beforeAll(() => {
+    getBoundingClientRectMock.mockReturnValue({
+      left: 12,
+      width: 155.9375,
+    } as DOMRect)
+  })
+
   test('a11y', async () => {
     await testA11y(<Rate />)
   })
@@ -13,19 +25,6 @@ describe('Rate', () => {
     const onChange = jest.fn()
     render(<Rate value={4} readOnly onChange={onChange} />)
     const radioGroup = screen.getByRole('radiogroup')
-    radioGroup.getBoundingClientRect = jest.fn(
-      () =>
-        ({
-          bottom: 82,
-          height: 30,
-          left: 12,
-          right: 167.9375,
-          top: 52,
-          width: 155.9375,
-          x: 12,
-          y: 52,
-        } as DOMRect)
-    )
     const radio = screen.getByRole('radio', { name: '1' })
     mockDrag(radioGroup, [
       {
@@ -44,19 +43,6 @@ describe('Rate', () => {
     const radio = screen.getByRole('radio', { name: '1.5' })
     const shouldNotActiveRadio = screen.getByRole('radio', { name: '2' })
     const radioGroup = screen.getByRole('radiogroup')
-    radioGroup.getBoundingClientRect = jest.fn(
-      () =>
-        ({
-          bottom: 82,
-          height: 30,
-          left: 12,
-          right: 167.9375,
-          top: 52,
-          width: 155.9375,
-          x: 12,
-          y: 52,
-        } as DOMRect)
-    )
 
     mockDrag(radioGroup, [
       {
@@ -83,46 +69,10 @@ describe('Rate', () => {
     ).toHaveLength(0)
   })
 
-  test('can clear', () => {
-    render(<Rate defaultValue={1} />)
-    const radio = screen.getByRole('radio', { name: '1' })
-    const radioGroup = screen.getByRole('radiogroup')
-    radioGroup.getBoundingClientRect = jest.fn(
-      () =>
-        ({
-          bottom: 82,
-          height: 30,
-          left: 12,
-          right: 167.9375,
-          top: 52,
-          width: 155.9375,
-          x: 12,
-          y: 52,
-        } as DOMRect)
-    )
-    expect(radio).toHaveClass(`${classPrefix}-star-active`)
-    // fireEvent.click(radio)
-    mockDrag(radioGroup, [{ clientX: 40 }, { clientX: 40 }])
-    expect(radio).not.toHaveClass(`${classPrefix}-star-active`)
-  })
-
   test('can not clear', () => {
     render(<Rate allowClear={false} defaultValue={1} />)
     const radio = screen.getByRole('radio', { name: '1' })
     const radioGroup = screen.getByRole('radiogroup')
-    radioGroup.getBoundingClientRect = jest.fn(
-      () =>
-        ({
-          bottom: 82,
-          height: 30,
-          left: 12,
-          right: 167.9375,
-          top: 52,
-          width: 155.9375,
-          x: 12,
-          y: 52,
-        } as DOMRect)
-    )
     expect(radio).toHaveClass(`${classPrefix}-star-active`)
     mockDrag(radioGroup, [{ clientX: 40 }, { clientX: 40 }])
     expect(radio).toHaveClass(`${classPrefix}-star-active`)


### PR DESCRIPTION
在PC上拖动的时候有个不太符合预期的行为= =，单个Star的`onClick`会后于`drag`事件执行，导致value在拖动结束时会变成开始点击时对应的value，这里全部改到`drag`事件中用拖动的逻辑计算了= =。

用`Math.round`点击触发的体验不是很棒= =，点左半边的话会被省略= =。改成`Math.ceil`的话拖动的时候就又有点灵敏= =。

加了一个test，把对应test中的click改成了`mockDrag`的原地拖动。