### PR TITLE
fix(Slider): crash when using `range` property

### DIFF
--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -161,6 +161,7 @@ export const Slider: FC<SliderProps> = p => {
           const val = getValueByPosition(position)
           const valueBeforeDrag = valueBeforeDragRef.current
           if (!valueBeforeDrag) return
+          if (typeof valueBeforeDrag === 'number') return
           const next = [...valueBeforeDrag] as [number, number]
           next[index] = val
           setSliderValue(next)

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -43,6 +43,7 @@ export const Slider: FC<SliderProps> = p => {
   const { min, max, disabled, marks, ticks, step, icon } = props
 
   function sortValue(val: [number, number]): [number, number] {
+    if (typeof val === 'number') return val
     return val.sort((a, b) => a - b)
   }
   function convertValue(value: SliderValue): [number, number] {


### PR DESCRIPTION
以下使用方式，会直接导致组件报错：

```tsx
<Slider marks={marks} ticks value={40} range />
```
