### PR TITLE
fix(Slider): fix crash when `range` and `value` don't match

### DIFF
--- a/src/components/slider/demos/demo2.tsx
+++ b/src/components/slider/demos/demo2.tsx
@@ -15,9 +15,7 @@ const marks = {
 }
 
 export default () => {
-  const [onAfterChangeValue, setAfterValue] = useState<
-    number | [number, number]
-  >(10)
+  const [afterValue, setAfterValue] = useState<number | [number, number]>(10)
 
   const toastValue = (value: number | number[]) => {
     let text = ''
@@ -32,7 +30,7 @@ export default () => {
 
   return (
     <>
-      <DemoBlock title={`拖拽结束监听 (最终拖拽值${onAfterChangeValue})`}>
+      <DemoBlock title={`拖拽结束监听 (最终拖拽值${afterValue})`}>
         <Slider step={20} onAfterChange={value => setAfterValue(value)} />
       </DemoBlock>
 

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -7,6 +7,7 @@ import Thumb from './thumb'
 import { mergeProps } from '../../utils/with-default-props'
 import { nearest } from '../../utils/nearest'
 import { usePropsValue } from '../../utils/use-props-value'
+import { devWarning } from 'antd-mobile/src/utils/dev-log'
 
 const classPrefix = `adm-slider`
 
@@ -56,8 +57,16 @@ export const Slider: FC<SliderProps> = p => {
     props.onAfterChange?.(reverseValue(value))
   }
 
+  let propsValue: SliderValue | undefined = props.value
+  if (props.range && typeof props.value === 'number') {
+    devWarning(
+      'Slider',
+      'When `range` prop is enabled, the `value` prop should be an array, like: [0, 0]'
+    )
+    propsValue = [0, props.value]
+  }
   const [rawValue, setRawValue] = usePropsValue<SliderValue>({
-    value: props.value,
+    value: propsValue,
     defaultValue: props.defaultValue ?? (props.range ? [min, min] : min),
     onChange: props.onChange,
   })

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -7,7 +7,7 @@ import Thumb from './thumb'
 import { mergeProps } from '../../utils/with-default-props'
 import { nearest } from '../../utils/nearest'
 import { usePropsValue } from '../../utils/use-props-value'
-import { devWarning } from 'antd-mobile/src/utils/dev-log'
+import { devWarning } from '../../utils/dev-log'
 
 const classPrefix = `adm-slider`
 


### PR DESCRIPTION
修复 `Slider` 组件使用时 `range` 属性时，崩溃的问题。复现如下：

```tsx
<Slider value={40} range />
```