### PR TITLE
enhance(Stepper): default `decimal` input mode

### DIFF
--- a/src/components/stepper/stepper.tsx
+++ b/src/components/stepper/stepper.tsx
@@ -176,6 +176,7 @@ export const Stepper: FC<StepperProps> = p => {
           aria-valuenow={Number(inputValue)}
           aria-valuemax={max}
           aria-valuemin={min}
+          inputMode='decimal'
         />
       </div>
       <Button


### PR DESCRIPTION
Close #5675