### PR TITLE
chore: Update test related config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
+  maxConcurrency: 1,
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   modulePathIgnorePatterns: ['<rootDir>/lib/', '<rootDir>/dist/'],
   moduleDirectories: ['node_modules', 'src/tests'],

--- a/src/components/swipe-action/tests/swipe-action.test.tsx
+++ b/src/components/swipe-action/tests/swipe-action.test.tsx
@@ -60,39 +60,7 @@ describe('SwipeAction', () => {
     await testA11y(<App />)
   })
 
-  test('swipe from left to right', async () => {
-    const { getByTestId, getByText } = render(<App />)
-
-    swipe(getByTestId('swipe'), [
-      {
-        clientX: 150,
-      },
-    ])
-
-    const track = document.querySelectorAll(`.${classPrefix}-track`)[0]
-    await waitFor(() =>
-      expect(track).toHaveStyle(`transform: translate3d(${width}px,0,0)`)
-    )
-
-    await userEvent.click(getByText('pin'))
-    await waitFor(() => expect(track).toHaveStyle(`transform: none`))
-  })
-
-  test('swipe from right to left', async () => {
-    const { getByTestId } = render(<App />)
-
-    swipe(getByTestId('swipe'), [
-      {
-        clientX: 50,
-      },
-    ])
-
-    const track = document.querySelectorAll(`.${classPrefix}-track`)[0]
-    await waitFor(() =>
-      expect(track).toHaveStyle(`transform: translate3d(-${width}px,0,0);`)
-    )
-  })
-
+  // Seems `react-spring` will block event handler. Just move this test case to the top
   test('manual return to the position', async () => {
     const App = () => {
       const ref = useRef<SwipeActionRef>(null)
@@ -136,6 +104,39 @@ describe('SwipeAction', () => {
     fireEvent.click(getByText('delete'))
     fireEvent.click(getByText('确定'))
     await waitFor(() => expect(track).toHaveStyle(`transform: none`))
+  })
+
+  test('swipe from left to right', async () => {
+    const { getByTestId, getByText } = render(<App />)
+
+    swipe(getByTestId('swipe'), [
+      {
+        clientX: 150,
+      },
+    ])
+
+    const track = document.querySelectorAll(`.${classPrefix}-track`)[0]
+    await waitFor(() =>
+      expect(track).toHaveStyle(`transform: translate3d(${width}px,0,0)`)
+    )
+
+    await userEvent.click(getByText('pin'))
+    await waitFor(() => expect(track).toHaveStyle(`transform: none`))
+  })
+
+  test('swipe from right to left', async () => {
+    const { getByTestId } = render(<App />)
+
+    swipe(getByTestId('swipe'), [
+      {
+        clientX: 50,
+      },
+    ])
+
+    const track = document.querySelectorAll(`.${classPrefix}-track`)[0]
+    await waitFor(() =>
+      expect(track).toHaveStyle(`transform: translate3d(-${width}px,0,0);`)
+    )
   })
 
   test('ref.show', async () => {


### PR DESCRIPTION
看了一下主要挂在几个测试用例，剩下的偶偶发：
```
src/components/swipe-action/tests/swipe-action.test.tsx
SwipeAction › manual return to the position
  TestingLibraryElementError: Unable to find an element with the text: 确定. This could be because the text is broken up by multiple elements. In this case, you can provide a function for your text matcher to make your matcher more flexible.

src/components/dialog/tests/dialog.test.tsx
Dialog › wait for confirm to complete
  Timed out in waitForElementToBeRemoved.

src/components/passcode-input/tests/passcode-input.test.tsx
PasscodeInput › native keyboard should be work
  TypeError: _a.scrollIntoView is not a function
PasscodeInput › event callbacks should be called
  TypeError: _a.scrollIntoView is not a function
```

动画相关由于 `react-spring` 是通过 `applyAnimatedValues` 方法在 React 生命周期之外直接操作 dom，所以尝试了 fakeTimer 仍然会被 block 住。`src/components/swipe-action/tests/swipe-action.test.tsx` 测试通过调整顺序暂时好了。剩下的通过 `maxConcurrency` 降低并发兜底（虽然卡的时候仍然会挂）。