### PR TITLE
fix(NumberKeyboard): customKey background-color when dark

### DIFF
--- a/src/components/number-keyboard/number-keyboard.less
+++ b/src/components/number-keyboard/number-keyboard.less
@@ -6,7 +6,7 @@
     flex-wrap: wrap;
     flex: 1;
     &&-confirmed-style .@{class-prefix-number-keyboard}-key-sign {
-      background-color: var(--adm-color-white);
+      background-color: var(--adm-color-background);
     }
   }
 


### PR DESCRIPTION
Fix NumberKeyboard customKey `background-color` when dark mode,

Before:
![20220923170449](https://user-images.githubusercontent.com/25154432/191928511-c796b515-44cb-44b0-be63-bb3e24b6efdd.jpg)

After:
![after](https://user-images.githubusercontent.com/25154432/191928527-ecb35894-776f-4d0e-b067-b1e28a4d9b91.jpg)
