### PR TITLE
chore: use webpack build compatible umd

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -160,31 +160,6 @@ async function buildBundles(cb) {
   cb && cb()
 }
 
-function buildCompatibleUMD() {
-  return gulp
-    .src('lib/bundle/antd-mobile.umd.js')
-    .pipe(
-      babel({
-        presets: [
-          [
-            '@babel/env',
-            {
-              targets: {
-                'chrome': '49',
-                'ios': '9',
-              },
-            },
-          ],
-        ],
-      })
-    )
-    .pipe(rename('antd-mobile.compatible.umd.js'))
-    .pipe(gulp.dest('lib/bundle/'))
-    .pipe(rename('antd-mobile.js'))
-    .pipe(gulp.dest('lib/umd/'))
-}
-
-// Deprecated
 function umdWebpack() {
   return gulp
     .src('lib/es/index.js')
@@ -223,7 +198,7 @@ function umdWebpack() {
           module: {
             rules: [
               {
-                test: /\.js$/,
+                test: /\.m?js$/,
                 use: {
                   loader: 'babel-loader',
                   options: {
@@ -235,7 +210,7 @@ function umdWebpack() {
                           'modules': false,
                           'targets': {
                             'chrome': '49',
-                            'ios': '10',
+                            'ios': '9',
                           },
                         },
                       ],
@@ -276,6 +251,13 @@ function umdWebpack() {
       )
     )
     .pipe(gulp.dest('lib/umd/'))
+}
+
+function copyUmd() {
+  return gulp
+    .src(['lib/umd/antd-mobile.js'])
+    .pipe(rename('antd-mobile.compatible.umd.js'))
+    .pipe(gulp.dest('lib/bundle/'))
 }
 
 function copyMetaFiles() {
@@ -352,7 +334,7 @@ exports.default = gulp.series(
   copyMetaFiles,
   generatePackageJSON,
   buildBundles,
-  buildCompatibleUMD,
   gulp.series(init2xFolder, build2xCSS),
-  umdWebpack
+  umdWebpack,
+  copyUmd
 )


### PR DESCRIPTION
ref: https://github.com/ant-design/ant-design-mobile/issues/5571

试了一下不支持 `globalThis` 的浏览器(如，IOS 9)
- `globalThis` 报错
- `typeof globalThis` 返回 undefined

然后看下用 vite/webpack 打包出来的产物

- vite
```js
// development
var __read$7 = globalThis && globalThis.__read || ... 
var __spread$2 = globalThis && globalThis.__spread || ... 
```
-  webpack
```js
// development
/******/ 	/* webpack/runtime/global */
/******/ 	(() => {
/******/ 		__webpack_require__.g = (function() {
/******/ 			if (typeof globalThis === 'object') return globalThis;
/******/ 			try {
/******/ 				return this || new Function('return this')();
/******/ 			} catch (e) {
/******/ 				if (typeof window === 'object') return window;
/******/ 			}
/******/ 		})();
/******/ 	})();
```

所以这里将 compatible umd 改成用 webpack 构建

---

另外发现有些三方包的产物是 `.mjs` (如 `@floating-ui/dom`)，babel-loader 里也要匹配进来