### PR TITLE
fix: popup strict prevent default to fix with IOS12

### DIFF
--- a/src/components/popup/popup.tsx
+++ b/src/components/popup/popup.tsx
@@ -43,7 +43,7 @@ export const Popup: FC<PopupProps> = p => {
   }, [props.visible])
 
   const ref = useRef<HTMLDivElement>(null)
-  useLockScroll(ref, props.disableBodyScroll && active)
+  useLockScroll(ref, props.disableBodyScroll && active ? 'strict' : false)
 
   const unmountedRef = useUnmountedRef()
   const { percent } = useSpring({

--- a/src/utils/dev-log.ts
+++ b/src/utils/dev-log.ts
@@ -11,3 +11,28 @@ export function devError(component: string, message: string) {
     console.error(`[antd-mobile: ${component}] ${message}`)
   }
 }
+
+let infoBox: HTMLTextAreaElement
+export function devPrint(...message: any[]) {
+  if (isDev) {
+    if (!infoBox) {
+      infoBox = document.createElement('textarea')
+      document.body.append(infoBox)
+      infoBox.style.position = 'fixed'
+      infoBox.style.top = '0'
+      infoBox.style.left = '0'
+      infoBox.style.width = '100vw'
+      infoBox.style.height = '100vh'
+      infoBox.style.zIndex = '999999'
+      infoBox.style.fontSize = '12px'
+      // infoBox.style.opacity = '0.85'
+      infoBox.style.pointerEvents = 'none'
+      infoBox.style.background = 'transparent'
+      infoBox.style.textShadow =
+        '-1px -1px 0 #FFF, -1px 1px 0 #FFF, 1px -1px 0 #FFF, 1px 1px 0 #FFF'
+    }
+
+    infoBox.value = `${infoBox.value}\n${message.join(' ')}`.trim()
+    infoBox.scrollTop = infoBox.scrollHeight
+  }
+}

--- a/src/utils/use-lock-scroll.ts
+++ b/src/utils/use-lock-scroll.ts
@@ -2,6 +2,7 @@ import { useTouch } from './use-touch'
 import { useEffect, RefObject } from 'react'
 import { getScrollParent } from './get-scroll-parent'
 import { supportsPassive } from './supports-passive'
+import { devPrint } from './dev-log'
 
 let totalLockCount = 0
 
@@ -10,12 +11,20 @@ const BODY_LOCK_CLASS = 'adm-overflow-hidden'
 // 移植自vant：https://github.com/youzan/vant/blob/HEAD/src/composables/use-lock-scroll.ts
 export function useLockScroll(
   rootRef: RefObject<HTMLElement>,
-  shouldLock: boolean
+  shouldLock: boolean | 'strict'
 ) {
   const touch = useTouch()
 
   const onTouchMove = (event: TouchEvent) => {
     touch.move(event)
+
+    // Strict will ignore direction
+    if (shouldLock === 'strict') {
+      if (event.cancelable) {
+        event.preventDefault()
+      }
+      return
+    }
 
     const direction = touch.deltaY.current > 0 ? '10' : '01'
     const el = getScrollParent(
@@ -23,6 +32,7 @@ export function useLockScroll(
       rootRef.current
     ) as HTMLElement
     if (!el) return
+
     const { scrollHeight, offsetHeight, scrollTop } = el
     let status = '11'
 

--- a/src/utils/use-lock-scroll.ts
+++ b/src/utils/use-lock-scroll.ts
@@ -2,7 +2,6 @@ import { useTouch } from './use-touch'
 import { useEffect, RefObject } from 'react'
 import { getScrollParent } from './get-scroll-parent'
 import { supportsPassive } from './supports-passive'
-import { devPrint } from './dev-log'
 
 let totalLockCount = 0
 


### PR DESCRIPTION
IOS 12 下横向滚动后再垂直滚动会被认为是合理的滚动方向（标准为初次滚动一个方向后就会被锁定，而非可以混合滚动），导致在开始 `touchmove` 没有调用 `preventDefault` 就会出现后期无法阻止滚动导致 Popup 锁不住屏幕滚动的问题。
添加一个 `strict` 模式，使用后直接锁定而不关心方向性。

不确定是否保险，请多关注一下。