### PR TITLE
chore: prevent transform `rgba()` to `#RGBA`

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -124,6 +124,7 @@ function getViteConfigForPackage({ env, formats, external }) {
     define: { 'process.env.NODE_ENV': `"${env}"` },
 
     build: {
+      cssTarget: 'chrome61',
       lib: {
         name: 'antdMobile',
         entry: './lib/es/index.js',


### PR DESCRIPTION
fix: #5731

![image](https://user-images.githubusercontent.com/29533304/195820217-7aaa1924-a84c-458f-9ad6-a83904f10415.png)
