### PR TITLE
fix(Picker): position offset in a11y

### DIFF
--- a/src/components/picker-view/picker-view.less
+++ b/src/components/picker-view/picker-view.less
@@ -65,6 +65,7 @@
   display: flex;
   flex-direction: column;
   position: relative;
+  top: calc(var(--item-height) * -1);
   z-index: 0;
   padding-bottom: 1px;
   > * {


### PR DESCRIPTION
Wheel 加了 `item-height-measure` 元素后，无障碍模式下的布局位置发生了偏移

<img width="1193" alt="WX20221018-112640@2x" src="https://user-images.githubusercontent.com/22469543/196329791-51a15263-4b8c-4419-8cf9-c764ab904d6e.png">
