### PR TITLE
feat(ImageViewer): 底层图片渲染使用 Image

### DIFF
--- a/src/components/image-viewer/demos/demo1.less
+++ b/src/components/image-viewer/demos/demo1.less
@@ -1,3 +1,7 @@
+.imageWidth {
+  --adm-image-height: 100px;
+}
+
 .footer {
   padding: 16px;
   text-align: center;

--- a/src/components/image-viewer/demos/demo1.tsx
+++ b/src/components/image-viewer/demos/demo1.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { ImageViewer, Button } from 'antd-mobile'
+import { ImageViewer, Button, DotLoading, ErrorBlock } from 'antd-mobile'
 import { DemoBlock } from 'demos'
 import { demoImage, demoImages } from './images'
 import styles from './demo1.less'
@@ -19,6 +19,32 @@ const Single = () => {
       <ImageViewer
         image={demoImage}
         visible={visible}
+        onClose={() => {
+          setVisible(false)
+        }}
+      />
+    </>
+  )
+}
+
+// 图片能力展示
+const MultiImage = () => {
+  const [visible, setVisible] = useState(false)
+  return (
+    <>
+      <Button
+        onClick={() => {
+          setVisible(true)
+        }}
+      >
+        显示图片
+      </Button>
+      <ImageViewer.Multi
+        images={demoImages}
+        visible={visible}
+        placeholder={<DotLoading color='primary' />}
+        fallback={<ErrorBlock status='default' />}
+        defaultIndex={1}
         onClose={() => {
           setVisible(false)
         }}
@@ -100,6 +126,10 @@ export default () => {
 
       <DemoBlock title='多张图片预览'>
         <Multi />
+      </DemoBlock>
+
+      <DemoBlock title='Image 属性展示'>
+        <MultiImage />
       </DemoBlock>
 
       <DemoBlock title='指令式调用'>

--- a/src/components/image-viewer/image-viewer.less
+++ b/src/components/image-viewer/image-viewer.less
@@ -51,8 +51,8 @@
     align-items: center;
     img {
       display: block;
-      max-width: 100%;
-      max-height: 100%;
+      max-width: 100vw;
+      max-height: 100vh;
     }
   }
   &-indicator {

--- a/src/components/image-viewer/image-viewer.tsx
+++ b/src/components/image-viewer/image-viewer.tsx
@@ -16,6 +16,7 @@ import Mask from '../mask'
 import SafeArea from '../safe-area'
 import { Slide } from './slide'
 import { Slides, SlidesRef } from './slides'
+import { ImageProps } from '../image'
 
 const classPrefix = `adm-image-viewer`
 
@@ -27,7 +28,14 @@ export type ImageViewerProps = {
   onClose?: () => void
   afterClose?: () => void
   renderFooter?: (image: string) => React.ReactNode
-}
+  onLoad?: (
+    event: React.SyntheticEvent<HTMLImageElement, Event>,
+    index: number
+  ) => void
+} & Pick<
+  ImageProps,
+  'fit' | 'placeholder' | 'fallback' | 'lazy' | 'crossOrigin'
+>
 
 const defaultProps = {
   maxZoom: 3,
@@ -49,7 +57,14 @@ export const ImageViewer: FC<ImageViewerProps> = p => {
       <div className={`${classPrefix}-content`}>
         {props.image && (
           <Slide
+            index={0}
             image={props.image}
+            fit={props.fit}
+            placeholder={props.placeholder}
+            fallback={props.fallback}
+            lazy={props.lazy}
+            crossOrigin={props.crossOrigin}
+            onLoad={props.onLoad}
             onTap={() => {
               props.onClose?.()
             }}
@@ -122,6 +137,12 @@ export const MultiImageViewer = forwardRef<
             defaultIndex={index}
             onIndexChange={onSlideChange}
             images={props.images}
+            fit={props.fit}
+            placeholder={props.placeholder}
+            fallback={props.fallback}
+            lazy={props.lazy}
+            crossOrigin={props.crossOrigin}
+            onLoad={props.onLoad}
             onTap={() => {
               props.onClose?.()
             }}

--- a/src/components/image-viewer/index.en.md
+++ b/src/components/image-viewer/index.en.md
@@ -12,15 +12,20 @@ You need to click on the picture to view the details and use it with the thumbna
 
 ## ImageViewer
 
-| Name         | Description                                                                                                                 | Type                                       | Default         |
-| ------------ | --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ | --------------- |
-| afterClose   | Triggered when it is completely closed                                                                                      | `() => void`                               | -               |
-| getContainer | To get the specified mounted HTML node, the default is `body`, if `null` returned, it would be rendered to the current node | `HTMLElement \| () => HTMLElement \| null` | `document.body` |
-| image        | The `url` of the image resource                                                                                             | `string`                                   | -               |
-| maxZoom      | The maximum zoom ratio                                                                                                      | `number \| 'auto'`                         | `3`             |
-| onClose      | Triggered when it is closed                                                                                                 | `boolean`                                  | -               |
-| renderFooter | Render extra content on footer                                                                                              | `(image: string) => ReactNode`             | -               |
-| visible      | Whether to show or hide                                                                                                     | `boolean`                                  | `false`         |
+| Name         | Description                                                                                                                 | Type                                                                            | Default             |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | ------------------- | --- | --- |
+| afterClose   | Triggered when it is completely closed                                                                                      | `() => void`                                                                    | -                   |
+| getContainer | To get the specified mounted HTML node, the default is `body`, if `null` returned, it would be rendered to the current node | `HTMLElement \| () => HTMLElement \| null`                                      | `document.body`     |
+| image        | The `url` of the image resource                                                                                             | `string`                                                                        | -                   |
+| maxZoom      | The maximum zoom ratio                                                                                                      | `number \| 'auto'`                                                              | `3`                 |
+| onClose      | Triggered when it is closed                                                                                                 | `boolean`                                                                       | -                   |
+| renderFooter | Render extra content on footer                                                                                              | `(image: string) => ReactNode`                                                  | -                   |
+| visible      | Whether to show or hide                                                                                                     | `boolean`                                                                       | `false`             |
+| fallback     | Placeholder when failed to load                                                                                             | `ReactNode`                                                                     | default placeholder |
+| fit          | The fill mode of the image                                                                                                  | `'contain' \| 'cover' \| 'fill' \| 'none' \| 'scale-down'`                      | `'fill'`            |     | -   |
+| lazy         | Whether to load image lazily                                                                                                | `boolean`                                                                       | `false`             |
+| onLoad       | Triggered when image loaded                                                                                                 | `(event: React.SyntheticEvent<HTMLImageElement, Event>, index: number) => void` | -                   |
+| placeholder  | Placeholder when loading                                                                                                    | `ReactNode`                                                                     |
 
 ## ImageViewer.Multi
 

--- a/src/components/image-viewer/index.zh.md
+++ b/src/components/image-viewer/index.zh.md
@@ -12,15 +12,20 @@
 
 ## ImageViewer
 
-| 属性         | 说明                                                                      | 类型                                       | 默认值          |
-| ------------ | ------------------------------------------------------------------------- | ------------------------------------------ | --------------- |
-| afterClose   | 完全关闭后触发                                                            | `() => void`                               | -               |
-| getContainer | 指定挂载的 HTML 节点，默认为 `body`，如果为 `null` 的话，会渲染到当前节点 | `HTMLElement \| () => HTMLElement \| null` | `document.body` |
-| image        | 图片资源的 `url`                                                          | `string`                                   | -               |
-| maxZoom      | 最大缩放比例                                                              | `number \| 'auto'`                         | `3`             |
-| onClose      | 关闭时触发                                                                | `boolean`                                  | -               |
-| renderFooter | 渲染底部额外内容                                                          | `(image: string) => ReactNode`             | -               |
-| visible      | 是否显示                                                                  | `boolean`                                  | `false`         |
+| 属性         | 说明                                                                      | 类型                                                                            | 默认值          |
+| ------------ | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | --------------- |
+| afterClose   | 完全关闭后触发                                                            | `() => void`                                                                    | -               |
+| getContainer | 指定挂载的 HTML 节点，默认为 `body`，如果为 `null` 的话，会渲染到当前节点 | `HTMLElement \| () => HTMLElement \| null`                                      | `document.body` |
+| image        | 图片资源的 `url`                                                          | `string`                                                                        | -               |
+| maxZoom      | 最大缩放比例                                                              | `number \| 'auto'`                                                              | `3`             |
+| onClose      | 关闭时触发                                                                | `boolean`                                                                       | -               |
+| renderFooter | 渲染底部额外内容                                                          | `(image: string) => ReactNode`                                                  | -               |
+| visible      | 是否显示                                                                  | `boolean`                                                                       | `false`         |
+| fallback     | 加载失败的占位                                                            | `ReactNode`                                                                     | 默认占位        |
+| fit          | 图片填充模式                                                              | `'contain' \| 'cover' \| 'fill' \| 'none' \| 'scale-down'`                      | `'fill'`        |
+| lazy         | 是否懒加载图片                                                            | `boolean`                                                                       | `false`         |
+| onLoad       | 图片加载完时触发                                                          | `(event: React.SyntheticEvent<HTMLImageElement, Event>, index: number) => void` | -               |
+| placeholder  | 加载时的占位                                                              | `ReactNode`                                                                     | 默认占位        |
 
 ## ImageViewer.Multi
 

--- a/src/components/image-viewer/slide.tsx
+++ b/src/components/image-viewer/slide.tsx
@@ -1,6 +1,7 @@
 import React, { FC, MutableRefObject, useRef } from 'react'
 import { useSpring, animated } from '@react-spring/web'
 import { useSize } from 'ahooks'
+import Image, { ImageProps } from '../image'
 import { rubberbandIfOutOfBounds } from '../../utils/rubberband'
 import { useDragAndPinch } from '../../utils/use-drag-and-pinch'
 import { bound } from '../../utils/bound'
@@ -15,12 +16,20 @@ type Props = {
   onTap: () => void
   onZoomChange?: (zoom: number) => void
   dragLockRef?: MutableRefObject<boolean>
-}
+  index: number
+  onLoad?: (
+    event: React.SyntheticEvent<HTMLImageElement, Event>,
+    index: number
+  ) => void
+} & Pick<
+  ImageProps,
+  'fit' | 'placeholder' | 'fallback' | 'lazy' | 'crossOrigin'
+>
 
 export const Slide: FC<Props> = props => {
   const { dragLockRef, maxZoom } = props
   const controlRef = useRef<HTMLDivElement>(null)
-  const imgRef = useRef<HTMLImageElement>(null)
+  const imgRef = useRef<HTMLDivElement>(null)
   const [{ matrix }, api] = useSpring(() => ({
     matrix: mat.create(),
     config: { tension: 200 },
@@ -226,11 +235,17 @@ export const Slide: FC<Props> = props => {
             matrix,
           }}
         >
-          <img
+          <Image
             ref={imgRef}
             src={props.image}
             draggable={false}
             alt={props.image}
+            fit={props.fit}
+            placeholder={props.placeholder}
+            fallback={props.fallback}
+            lazy={props.lazy}
+            crossOrigin={props.crossOrigin}
+            onLoad={evt => props.onLoad?.(evt, props.index)}
           />
         </animated.div>
       </div>

--- a/src/components/image-viewer/slides.tsx
+++ b/src/components/image-viewer/slides.tsx
@@ -4,6 +4,7 @@ import { useSpring, animated } from '@react-spring/web'
 import { Slide } from './slide'
 import { convertPx } from '../../utils/convert-px'
 import { bound } from '../../utils/bound'
+import { ImageProps } from '../image'
 
 const classPrefix = `adm-image-viewer`
 
@@ -13,7 +14,14 @@ export type SlidesType = {
   maxZoom: number
   defaultIndex: number
   onIndexChange?: (index: number) => void
-}
+  onLoad?: (
+    event: React.SyntheticEvent<HTMLImageElement, Event>,
+    index: number
+  ) => void
+} & Pick<
+  ImageProps,
+  'fit' | 'placeholder' | 'fallback' | 'lazy' | 'crossOrigin'
+>
 export type SlidesRef = {
   swipeTo: (index: number, immediate?: boolean) => void
 }
@@ -94,7 +102,14 @@ export const Slides = forwardRef<SlidesRef, SlidesType>((props, ref) => {
         {props.images.map((image, index) => (
           <Slide
             key={index}
+            index={index}
             image={image}
+            fit={props.fit}
+            placeholder={props.placeholder}
+            fallback={props.fallback}
+            lazy={props.lazy}
+            crossOrigin={props.crossOrigin}
+            onLoad={evt => props.onLoad?.(evt, index)}
             onTap={props.onTap}
             maxZoom={props.maxZoom}
             onZoomChange={zoom => {

--- a/src/components/image/image.tsx
+++ b/src/components/image/image.tsx
@@ -1,5 +1,5 @@
 import { mergeProps } from '../../utils/with-default-props'
-import React, { ReactNode, useState, useRef } from 'react'
+import React, { ReactNode, useState, forwardRef, Ref } from 'react'
 import { NativeProps, withNativeProps } from '../../utils/native-props'
 import { staged } from 'staged-components'
 import { toCSSLength } from '../../utils/to-css-length'
@@ -52,92 +52,92 @@ const defaultProps = {
   draggable: false,
 }
 
-export const Image = staged<ImageProps>(p => {
-  const props = mergeProps(defaultProps, p)
+export const Image = forwardRef<HTMLDivElement, ImageProps>(
+  staged((p: ImageProps, ref: Ref<HTMLDivElement>) => {
+    const props = mergeProps(defaultProps, p)
 
-  const [loaded, setLoaded] = useState(false)
-  const [failed, setFailed] = useState(false)
+    const [loaded, setLoaded] = useState(false)
+    const [failed, setFailed] = useState(false)
 
-  const ref = useRef<HTMLDivElement>(null)
+    let src: string | undefined = props.src
+    let srcSet: string | undefined = props.srcSet
 
-  let src: string | undefined = props.src
-  let srcSet: string | undefined = props.srcSet
+    const [initialized, setInitialized] = useState(!props.lazy)
 
-  const [initialized, setInitialized] = useState(!props.lazy)
+    src = initialized ? props.src : undefined
+    srcSet = initialized ? props.srcSet : undefined
 
-  src = initialized ? props.src : undefined
-  srcSet = initialized ? props.srcSet : undefined
+    useIsomorphicUpdateLayoutEffect(() => {
+      setLoaded(false)
+      setFailed(false)
+    }, [src])
 
-  useIsomorphicUpdateLayoutEffect(() => {
-    setLoaded(false)
-    setFailed(false)
-  }, [src])
-
-  function renderInner() {
-    if (failed) {
-      return <>{props.fallback}</>
-    }
-    const img = (
-      <img
-        className={`${classPrefix}-img`}
-        src={src}
-        alt={props.alt}
-        onClick={props.onClick}
-        onLoad={e => {
-          setLoaded(true)
-          props.onLoad?.(e)
-        }}
-        onError={e => {
-          setFailed(true)
-          props.onError?.(e)
-        }}
-        style={{
-          objectFit: props.fit,
-          display: loaded ? 'block' : 'none',
-        }}
-        crossOrigin={props.crossOrigin}
-        decoding={props.decoding}
-        loading={props.loading}
-        referrerPolicy={props.referrerPolicy}
-        sizes={props.sizes}
-        srcSet={srcSet}
-        useMap={props.useMap}
-        draggable={props.draggable}
-      />
-    )
-    return (
-      <>
-        {!loaded && props.placeholder}
-        {img}
-      </>
-    )
-  }
-
-  const style: ImageProps['style'] = {}
-  if (props.width) {
-    style['--width'] = toCSSLength(props.width)
-    style['width'] = toCSSLength(props.width)
-  }
-  if (props.height) {
-    style['--height'] = toCSSLength(props.height)
-    style['height'] = toCSSLength(props.height)
-  }
-  return withNativeProps(
-    props,
-    <div
-      ref={ref}
-      className={classPrefix}
-      style={style}
-      onClick={props.onContainerClick}
-    >
-      {props.lazy && !initialized && (
-        <LazyDetector
-          onActive={() => {
-            setInitialized(true)
+    function renderInner() {
+      if (failed) {
+        return <>{props.fallback}</>
+      }
+      const img = (
+        <img
+          className={`${classPrefix}-img`}
+          src={src}
+          alt={props.alt}
+          onClick={props.onClick}
+          onLoad={e => {
+            setLoaded(true)
+            props.onLoad?.(e)
           }}
+          onError={e => {
+            setFailed(true)
+            props.onError?.(e)
+          }}
+          style={{
+            objectFit: props.fit,
+            display: loaded ? 'block' : 'none',
+          }}
+          crossOrigin={props.crossOrigin}
+          decoding={props.decoding}
+          loading={props.loading}
+          referrerPolicy={props.referrerPolicy}
+          sizes={props.sizes}
+          srcSet={srcSet}
+          useMap={props.useMap}
+          draggable={props.draggable}
         />
-      )}
-      {renderInner()}
-    </div>
-  )
-})
+      )
+      return (
+        <>
+          {!loaded && props.placeholder}
+          {img}
+        </>
+      )
+    }
+
+    const style: ImageProps['style'] = {}
+    if (props.width) {
+      style['--width'] = toCSSLength(props.width)
+      style['width'] = toCSSLength(props.width)
+    }
+    if (props.height) {
+      style['--height'] = toCSSLength(props.height)
+      style['height'] = toCSSLength(props.height)
+    }
+    return withNativeProps(
+      props,
+      <div
+        ref={ref}
+        className={classPrefix}
+        style={style}
+        onClick={props.onContainerClick}
+      >
+        {props.lazy && !initialized && (
+          <LazyDetector
+            onActive={() => {
+              setInitialized(true)
+            }}
+          />
+        )}
+        {renderInner()}
+      </div>
+    )
+  })
+)


### PR DESCRIPTION
#5765 
@miracles1919 有几个不确定的点，麻烦神迹大佬看一下：
1. `placeholder` 要不要默认为空？（图片加载完成后会闪一下）
2. Image 的 `max-width` `max-height` 使用了 `vw` `vh` 单位，否则[图片无法自适应](https://stackoverflow.com/questions/3751565/css-100-width-or-height-while-keeping-aspect-ratio)
3. Image 组件内使用 forwardRef 后， props和ref的类型写了两遍，没找到别的办法