### PR TITLE
feat(NoticeBar): add `wrap` props

### DIFF
--- a/src/components/notice-bar/demos/demo1.tsx
+++ b/src/components/notice-bar/demos/demo1.tsx
@@ -25,6 +25,10 @@ export default () => {
         <NoticeBar content={demoLongText} color='alert' />
       </DemoBlock>
 
+      <DemoBlock title='超长换行' padding='0'>
+        <NoticeBar content={demoLongText} speed={0} color='alert' />
+      </DemoBlock>
+
       <DemoBlock title='自定义' padding='0' background='transparent'>
         <Space block direction='vertical'>
           <NoticeBar

--- a/src/components/notice-bar/demos/demo1.tsx
+++ b/src/components/notice-bar/demos/demo1.tsx
@@ -30,7 +30,7 @@ export default () => {
           content={demoLongText}
           wrap
           color='alert'
-          style={{ '--height': '80px' }}
+          // style={{ '--height': '80px' }}
         />
       </DemoBlock>
 

--- a/src/components/notice-bar/demos/demo1.tsx
+++ b/src/components/notice-bar/demos/demo1.tsx
@@ -25,8 +25,8 @@ export default () => {
         <NoticeBar content={demoLongText} color='alert' />
       </DemoBlock>
 
-      <DemoBlock title='自动换行' padding='0'>
-        <NoticeBar content={demoLongText} wrap={true} color='alert' />
+      <DemoBlock title='多行展示' padding='0'>
+        <NoticeBar content={demoLongText} wrap color='alert' />
       </DemoBlock>
 
       <DemoBlock title='自定义' padding='0' background='transparent'>

--- a/src/components/notice-bar/demos/demo1.tsx
+++ b/src/components/notice-bar/demos/demo1.tsx
@@ -26,7 +26,12 @@ export default () => {
       </DemoBlock>
 
       <DemoBlock title='多行展示' padding='0'>
-        <NoticeBar content={demoLongText} wrap color='alert' />
+        <NoticeBar
+          content={demoLongText}
+          wrap
+          color='alert'
+          style={{ '--height': '80px' }}
+        />
       </DemoBlock>
 
       <DemoBlock title='自定义' padding='0' background='transparent'>

--- a/src/components/notice-bar/demos/demo1.tsx
+++ b/src/components/notice-bar/demos/demo1.tsx
@@ -26,12 +26,7 @@ export default () => {
       </DemoBlock>
 
       <DemoBlock title='多行展示' padding='0'>
-        <NoticeBar
-          content={demoLongText}
-          wrap
-          color='alert'
-          // style={{ '--height': '80px' }}
-        />
+        <NoticeBar content={demoLongText} wrap color='alert' />
       </DemoBlock>
 
       <DemoBlock title='自定义' padding='0' background='transparent'>

--- a/src/components/notice-bar/demos/demo1.tsx
+++ b/src/components/notice-bar/demos/demo1.tsx
@@ -25,8 +25,8 @@ export default () => {
         <NoticeBar content={demoLongText} color='alert' />
       </DemoBlock>
 
-      <DemoBlock title='超长换行' padding='0'>
-        <NoticeBar content={demoLongText} speed={0} color='alert' />
+      <DemoBlock title='自动换行' padding='0'>
+        <NoticeBar content={demoLongText} wrap={true} color='alert' />
       </DemoBlock>
 
       <DemoBlock title='自定义' padding='0' background='transparent'>

--- a/src/components/notice-bar/demos/demo1.tsx
+++ b/src/components/notice-bar/demos/demo1.tsx
@@ -26,7 +26,11 @@ export default () => {
       </DemoBlock>
 
       <DemoBlock title='多行展示' padding='0'>
-        <NoticeBar content={demoLongText} wrap color='alert' />
+        <NoticeBar
+          content='适用于当前页面内信息的通知，是一种较醒目的页面内通知方式'
+          wrap
+          color='alert'
+        />
       </DemoBlock>
 
       <DemoBlock title='自定义' padding='0' background='transparent'>

--- a/src/components/notice-bar/index.en.md
+++ b/src/components/notice-bar/index.en.md
@@ -33,6 +33,6 @@ It is applicable to the notification of information in the current page, which i
 | --background-color | background color                  | `#b2b2b2` |
 | --border-color     | border color                      | `#a0a0a0` |
 | --font-size        | Font size of notice text content. | `15px`    |
-| --height           | Height of the whole element.      | `38px`    |
+| --height           | Height of the whole element.      | `40px`    |
 | --icon-font-size   | Font size of left icon.           | `18px`    |
 | --text-color       | text color                        | `#ffffff` |

--- a/src/components/notice-bar/index.en.md
+++ b/src/components/notice-bar/index.en.md
@@ -14,16 +14,17 @@ It is applicable to the notification of information in the current page, which i
 
 ### Props
 
-| Name      | Description                                                                                                    | Type                                        | Default            |
-| --------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------- | ------------------ |
-| closeable | Whether it can be closed                                                                                       | `boolean`                                   | `false`            |
-| color     | The type of the NoticeBar                                                                                      | `'default' \| 'alert' \| 'error' \| 'info'` | `'default'`        |
-| content   | The content of the NoticeBar                                                                                   | `React.ReactNode`                           | -                  |
-| delay     | Delay to start scrolling, unit `ms`                                                                            | `number`                                    | `2000`             |
-| extra     | Additional operating area, displayed to the left of the close button                                           | `React.ReactNode`                           | -                  |
-| icon      | Radio icon on the left                                                                                         | `React.ReactNode`                           | `<SoundOutline />` |
-| onClose   | Callback when closed                                                                                           | `() => void`                                | -                  |
-| speed     | Scroll speed, unit `px/s`（In particular, word wrap when `speed` is `0` and the text is extraordinarily long） | `number`                                    | `50`               |
+| Name      | Description                                                          | Type                                        | Default            |
+| --------- | -------------------------------------------------------------------- | ------------------------------------------- | ------------------ |
+| closeable | Whether it can be closed                                             | `boolean`                                   | `false`            |
+| color     | The type of the NoticeBar                                            | `'default' \| 'alert' \| 'error' \| 'info'` | `'default'`        |
+| content   | The content of the NoticeBar                                         | `React.ReactNode`                           | -                  |
+| delay     | Delay to start scrolling, unit `ms`                                  | `number`                                    | `2000`             |
+| extra     | Additional operating area, displayed to the left of the close button | `React.ReactNode`                           | -                  |
+| icon      | Radio icon on the left                                               | `React.ReactNode`                           | `<SoundOutline />` |
+| onClose   | Callback when closed                                                 | `() => void`                                | -                  |
+| speed     | Scroll speed, unit `px/s`                                            | `number`                                    | `50`               |
+| wrap      | Should line break automatically                                      | `boolean`                                   | `false`            |
 
 ### CSS Variables
 

--- a/src/components/notice-bar/index.en.md
+++ b/src/components/notice-bar/index.en.md
@@ -24,7 +24,7 @@ It is applicable to the notification of information in the current page, which i
 | icon      | Radio icon on the left                                               | `React.ReactNode`                           | `<SoundOutline />` |
 | onClose   | Callback when closed                                                 | `() => void`                                | -                  |
 | speed     | Scroll speed, unit `px/s`                                            | `number`                                    | `50`               |
-| wrap      | Should line break automatically                                      | `boolean`                                   | `false`            |
+| wrap      | Whether to display multiple lines                                    | `boolean`                                   | `false`            |
 
 ### CSS Variables
 

--- a/src/components/notice-bar/index.en.md
+++ b/src/components/notice-bar/index.en.md
@@ -14,16 +14,16 @@ It is applicable to the notification of information in the current page, which i
 
 ### Props
 
-| Name      | Description                                                          | Type                                        | Default            |
-| --------- | -------------------------------------------------------------------- | ------------------------------------------- | ------------------ |
-| closeable | Whether it can be closed                                             | `boolean`                                   | `false`            |
-| color     | The type of the NoticeBar                                            | `'default' \| 'alert' \| 'error' \| 'info'` | `'default'`        |
-| content   | The content of the NoticeBar                                         | `React.ReactNode`                           | -                  |
-| delay     | Delay to start scrolling, unit `ms`                                  | `number`                                    | `2000`             |
-| extra     | Additional operating area, displayed to the left of the close button | `React.ReactNode`                           | -                  |
-| icon      | Radio icon on the left                                               | `React.ReactNode`                           | `<SoundOutline />` |
-| onClose   | Callback when closed                                                 | `() => void`                                | -                  |
-| speed     | Scroll speed, unit `px/s`                                            | `number`                                    | `50`               |
+| Name      | Description                                                                                                    | Type                                        | Default            |
+| --------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------- | ------------------ |
+| closeable | Whether it can be closed                                                                                       | `boolean`                                   | `false`            |
+| color     | The type of the NoticeBar                                                                                      | `'default' \| 'alert' \| 'error' \| 'info'` | `'default'`        |
+| content   | The content of the NoticeBar                                                                                   | `React.ReactNode`                           | -                  |
+| delay     | Delay to start scrolling, unit `ms`                                                                            | `number`                                    | `2000`             |
+| extra     | Additional operating area, displayed to the left of the close button                                           | `React.ReactNode`                           | -                  |
+| icon      | Radio icon on the left                                                                                         | `React.ReactNode`                           | `<SoundOutline />` |
+| onClose   | Callback when closed                                                                                           | `() => void`                                | -                  |
+| speed     | Scroll speed, unit `px/s`（In particular, word wrap when `speed` is `0` and the text is extraordinarily long） | `number`                                    | `50`               |
 
 ### CSS Variables
 

--- a/src/components/notice-bar/index.en.md
+++ b/src/components/notice-bar/index.en.md
@@ -35,4 +35,5 @@ It is applicable to the notification of information in the current page, which i
 | --font-size        | Font size of notice text content. | `15px`    |
 | --height           | Height of the whole element.      | `38px`    |
 | --icon-font-size   | Font size of left icon.           | `18px`    |
+| --line-height      | Height of the line                | `38px`    |
 | --text-color       | text color                        | `#ffffff` |

--- a/src/components/notice-bar/index.en.md
+++ b/src/components/notice-bar/index.en.md
@@ -35,5 +35,4 @@ It is applicable to the notification of information in the current page, which i
 | --font-size        | Font size of notice text content. | `15px`    |
 | --height           | Height of the whole element.      | `38px`    |
 | --icon-font-size   | Font size of left icon.           | `18px`    |
-| --line-height      | Height of the line                | `38px`    |
 | --text-color       | text color                        | `#ffffff` |

--- a/src/components/notice-bar/index.zh.md
+++ b/src/components/notice-bar/index.zh.md
@@ -35,5 +35,4 @@
 | --font-size        | 文字字号       | `15px`    |
 | --height           | 整体高度       | `38px`    |
 | --icon-font-size   | 左侧图标的字号 | `18px`    |
-| --line-height      | 行高           | `38px`    |
 | --text-color       | 文字颜色       | `#ffffff` |

--- a/src/components/notice-bar/index.zh.md
+++ b/src/components/notice-bar/index.zh.md
@@ -24,7 +24,7 @@
 | icon      | 左侧广播图标                     | `React.ReactNode`                           | `<SoundOutline />` |
 | onClose   | 关闭时的回调                     | `() => void`                                | -                  |
 | speed     | 滚动速度，单位 `px/s`            | `number`                                    | `50`               |
-| wrap      | 是否自动换行                     | `boolean`                                   | `false`            |
+| wrap      | 是否多行展示                     | `boolean`                                   | `false`            |
 
 ### CSS 变量
 

--- a/src/components/notice-bar/index.zh.md
+++ b/src/components/notice-bar/index.zh.md
@@ -33,6 +33,6 @@
 | --background-color | 背景色         | `#ababab` |
 | --border-color     | 边框颜色       | `#999999` |
 | --font-size        | 文字字号       | `15px`    |
-| --height           | 整体高度       | `38px`    |
+| --height           | 整体高度       | `40px`    |
 | --icon-font-size   | 左侧图标的字号 | `18px`    |
 | --text-color       | 文字颜色       | `#ffffff` |

--- a/src/components/notice-bar/index.zh.md
+++ b/src/components/notice-bar/index.zh.md
@@ -35,4 +35,5 @@
 | --font-size        | 文字字号       | `15px`    |
 | --height           | 整体高度       | `38px`    |
 | --icon-font-size   | 左侧图标的字号 | `18px`    |
+| --line-height      | 行高           | `38px`    |
 | --text-color       | 文字颜色       | `#ffffff` |

--- a/src/components/notice-bar/index.zh.md
+++ b/src/components/notice-bar/index.zh.md
@@ -14,16 +14,16 @@
 
 ### 属性
 
-| 属性      | 说明                             | 类型                                        | 默认值             |
-| --------- | -------------------------------- | ------------------------------------------- | ------------------ |
-| closeable | 是否可关闭                       | `boolean`                                   | `false`            |
-| color     | 通告栏的类型                     | `'default' \| 'alert' \| 'error' \| 'info'` | `'default'`        |
-| content   | 公告内容                         | `React.ReactNode`                           | -                  |
-| delay     | 开始滚动的延迟，单位 `ms`        | `number`                                    | `2000`             |
-| extra     | 额外操作区域，显示在关闭按钮左侧 | `React.ReactNode`                           | -                  |
-| icon      | 左侧广播图标                     | `React.ReactNode`                           | `<SoundOutline />` |
-| onClose   | 关闭时的回调                     | `() => void`                                | -                  |
-| speed     | 滚动速度，单位 `px/s`            | `number`                                    | `50`               |
+| 属性      | 说明                                                                  | 类型                                        | 默认值             |
+| --------- | --------------------------------------------------------------------- | ------------------------------------------- | ------------------ |
+| closeable | 是否可关闭                                                            | `boolean`                                   | `false`            |
+| color     | 通告栏的类型                                                          | `'default' \| 'alert' \| 'error' \| 'info'` | `'default'`        |
+| content   | 公告内容                                                              | `React.ReactNode`                           | -                  |
+| delay     | 开始滚动的延迟，单位 `ms`                                             | `number`                                    | `2000`             |
+| extra     | 额外操作区域，显示在关闭按钮左侧                                      | `React.ReactNode`                           | -                  |
+| icon      | 左侧广播图标                                                          | `React.ReactNode`                           | `<SoundOutline />` |
+| onClose   | 关闭时的回调                                                          | `() => void`                                | -                  |
+| speed     | 滚动速度，单位 `px/s`(特别的，当`speed`为 `0` 且文字超长时，自动换行) | `number`                                    | `50`               |
 
 ### CSS 变量
 

--- a/src/components/notice-bar/index.zh.md
+++ b/src/components/notice-bar/index.zh.md
@@ -14,16 +14,17 @@
 
 ### 属性
 
-| 属性      | 说明                                                                  | 类型                                        | 默认值             |
-| --------- | --------------------------------------------------------------------- | ------------------------------------------- | ------------------ |
-| closeable | 是否可关闭                                                            | `boolean`                                   | `false`            |
-| color     | 通告栏的类型                                                          | `'default' \| 'alert' \| 'error' \| 'info'` | `'default'`        |
-| content   | 公告内容                                                              | `React.ReactNode`                           | -                  |
-| delay     | 开始滚动的延迟，单位 `ms`                                             | `number`                                    | `2000`             |
-| extra     | 额外操作区域，显示在关闭按钮左侧                                      | `React.ReactNode`                           | -                  |
-| icon      | 左侧广播图标                                                          | `React.ReactNode`                           | `<SoundOutline />` |
-| onClose   | 关闭时的回调                                                          | `() => void`                                | -                  |
-| speed     | 滚动速度，单位 `px/s`(特别的，当`speed`为 `0` 且文字超长时，自动换行) | `number`                                    | `50`               |
+| 属性      | 说明                             | 类型                                        | 默认值             |
+| --------- | -------------------------------- | ------------------------------------------- | ------------------ |
+| closeable | 是否可关闭                       | `boolean`                                   | `false`            |
+| color     | 通告栏的类型                     | `'default' \| 'alert' \| 'error' \| 'info'` | `'default'`        |
+| content   | 公告内容                         | `React.ReactNode`                           | -                  |
+| delay     | 开始滚动的延迟，单位 `ms`        | `number`                                    | `2000`             |
+| extra     | 额外操作区域，显示在关闭按钮左侧 | `React.ReactNode`                           | -                  |
+| icon      | 左侧广播图标                     | `React.ReactNode`                           | `<SoundOutline />` |
+| onClose   | 关闭时的回调                     | `() => void`                                | -                  |
+| speed     | 滚动速度，单位 `px/s`            | `number`                                    | `50`               |
+| wrap      | 是否自动换行                     | `boolean`                                   | `false`            |
 
 ### CSS 变量
 

--- a/src/components/notice-bar/notice-bar.less
+++ b/src/components/notice-bar/notice-bar.less
@@ -8,7 +8,6 @@
   --icon-font-size: var(--adm-font-size-10);
   --height: 38px;
 
-  height: var(--height);
   box-sizing: border-box;
   font-size: var(--font-size);
   line-height: var(--height);
@@ -59,7 +58,6 @@
     & .@{class-prefix-notice-bar}-content-inner {
       width: auto;
       transition-timing-function: linear;
-      position: absolute;
       white-space: nowrap;
     }
   }

--- a/src/components/notice-bar/notice-bar.less
+++ b/src/components/notice-bar/notice-bar.less
@@ -6,11 +6,13 @@
   --text-color: var(--adm-color-white);
   --font-size: var(--adm-font-size-7);
   --icon-font-size: var(--adm-font-size-10);
+  --line-height: 38px;
   --height: 38px;
 
+  height: var(--height);
   box-sizing: border-box;
   font-size: var(--font-size);
-  line-height: var(--height);
+  line-height: var(--line-height);
   padding: 0 12px;
   display: flex;
   align-items: center;
@@ -58,12 +60,11 @@
     & .@{class-prefix-notice-bar}-content-inner {
       width: auto;
       transition-timing-function: linear;
-    }
-    & .@{class-prefix-notice-bar}-content-inner-no-wrap {
       white-space: nowrap;
     }
+
     & .@{class-prefix-notice-bar}-content-inner-wrap {
-      white-space: pre-wrap;
+      white-space: normal;
     }
   }
   & .@{class-prefix-notice-bar}-right {

--- a/src/components/notice-bar/notice-bar.less
+++ b/src/components/notice-bar/notice-bar.less
@@ -6,12 +6,11 @@
   --text-color: var(--adm-color-white);
   --font-size: var(--adm-font-size-7);
   --icon-font-size: var(--adm-font-size-10);
-  --height: 38px;
+  --height: 40px;
 
   height: var(--height);
   box-sizing: border-box;
   font-size: var(--font-size);
-  line-height: var(--height);
   padding: 0 12px;
   display: flex;
   align-items: center;
@@ -46,7 +45,6 @@
     flex-shrink: 0;
     margin-right: 8px;
     font-size: var(--icon-font-size);
-    line-height: var(--height);
   }
   & .@{class-prefix-notice-bar}-content {
     flex: 1;
@@ -88,5 +86,8 @@
   &-wrap {
     height: auto;
     align-items: flex-start;
+    padding-top: 8px;
+    padding-bottom: 8px;
+    line-height: 22px;
   }
 }

--- a/src/components/notice-bar/notice-bar.less
+++ b/src/components/notice-bar/notice-bar.less
@@ -58,7 +58,12 @@
     & .@{class-prefix-notice-bar}-content-inner {
       width: auto;
       transition-timing-function: linear;
+    }
+    & .@{class-prefix-notice-bar}-content-inner-no-wrap {
       white-space: nowrap;
+    }
+    & .@{class-prefix-notice-bar}-content-inner-wrap {
+      white-space: pre-wrap;
     }
   }
   & .@{class-prefix-notice-bar}-right {

--- a/src/components/notice-bar/notice-bar.less
+++ b/src/components/notice-bar/notice-bar.less
@@ -6,13 +6,12 @@
   --text-color: var(--adm-color-white);
   --font-size: var(--adm-font-size-7);
   --icon-font-size: var(--adm-font-size-10);
-  --line-height: 38px;
   --height: 38px;
 
   height: var(--height);
   box-sizing: border-box;
   font-size: var(--font-size);
-  line-height: var(--line-height);
+  line-height: var(--height);
   padding: 0 12px;
   display: flex;
   align-items: center;
@@ -61,12 +60,13 @@
       width: auto;
       transition-timing-function: linear;
       white-space: nowrap;
-    }
 
-    & .@{class-prefix-notice-bar}-content-inner-wrap {
-      white-space: normal;
+      .@{class-prefix-notice-bar}-wrap& {
+        white-space: normal;
+      }
     }
   }
+
   & .@{class-prefix-notice-bar}-right {
     flex-shrink: 0;
     margin-left: 12px;
@@ -83,5 +83,9 @@
 
   &-close-icon {
     font-size: var(--adm-font-size-10);
+  }
+
+  &-wrap {
+    height: auto;
   }
 }

--- a/src/components/notice-bar/notice-bar.less
+++ b/src/components/notice-bar/notice-bar.less
@@ -87,5 +87,6 @@
 
   &-wrap {
     height: auto;
+    align-items: flex-start;
   }
 }

--- a/src/components/notice-bar/notice-bar.tsx
+++ b/src/components/notice-bar/notice-bar.tsx
@@ -62,6 +62,11 @@ export const NoticeBar = memo<NoticeBarProps>(p => {
     const text = textRef.current
     if (!container || !text) return
 
+    if (props.speed === 0) {
+      text.style.whiteSpace = 'pre-wrap'
+      return
+    }
+
     if (container.offsetWidth >= text.offsetWidth) {
       animatingRef.current = false
       text.style.removeProperty('transition-duration')
@@ -86,10 +91,13 @@ export const NoticeBar = memo<NoticeBarProps>(p => {
     text.style.transform = `translateX(-${text.offsetWidth}px)`
   }
 
-  useTimeout(() => {
-    delayLockRef.current = false
-    start()
-  }, props.delay)
+  useTimeout(
+    () => {
+      delayLockRef.current = false
+      start()
+    },
+    props.speed === 0 ? 0 : props.delay
+  )
 
   useResizeEffect(() => {
     start()

--- a/src/components/notice-bar/notice-bar.tsx
+++ b/src/components/notice-bar/notice-bar.tsx
@@ -10,14 +10,23 @@ import { useMutationEffect } from '../../utils/use-mutation-effect'
 const classPrefix = `adm-notice-bar`
 
 export type NoticeBarProps = {
+  /** The type of the NoticeBar */
   color?: 'default' | 'alert' | 'error' | 'info'
+  /** TDelay to start scrolling, unit ms */
   delay?: number
+  /** Scroll speed, unit px/s */
   speed?: number
+  /** The content of the NoticeBar */
   content: React.ReactNode
+  /** Whether it can be closed */
   closeable?: boolean
+  /** Callback when closed */
   onClose?: () => void
+  /** Additional operating area, displayed to the left of the close button */
   extra?: React.ReactNode
+  /** Radio icon on the left */
   icon?: React.ReactNode
+  /** Whether to display multiple lines */
   wrap?: boolean
 } & NativeProps<
   | '--background-color'

--- a/src/components/notice-bar/notice-bar.tsx
+++ b/src/components/notice-bar/notice-bar.tsx
@@ -106,7 +106,11 @@ export const NoticeBar = memo<NoticeBarProps>(p => {
 
   return withNativeProps(
     props,
-    <div className={classNames(classPrefix, `${classPrefix}-${props.color}`)}>
+    <div
+      className={classNames(classPrefix, `${classPrefix}-${props.color}`, {
+        [`${classPrefix}-wrap`]: props.wrap,
+      })}
+    >
       {props.icon && (
         <span className={`${classPrefix}-left`}>{props.icon}</span>
       )}
@@ -117,9 +121,7 @@ export const NoticeBar = memo<NoticeBarProps>(p => {
             start()
           }}
           ref={textRef}
-          className={classNames(`${classPrefix}-content-inner`, {
-            [`${classPrefix}-content-inner-wrap`]: props.wrap,
-          })}
+          className={`${classPrefix}-content-inner`}
         >
           {props.content}
         </span>

--- a/src/components/notice-bar/notice-bar.tsx
+++ b/src/components/notice-bar/notice-bar.tsx
@@ -26,7 +26,6 @@ export type NoticeBarProps = {
   | '--font-size'
   | '--icon-font-size'
   | '--height'
-  | '--line-height'
 >
 
 const defaultProps = {

--- a/src/components/notice-bar/notice-bar.tsx
+++ b/src/components/notice-bar/notice-bar.tsx
@@ -10,23 +10,14 @@ import { useMutationEffect } from '../../utils/use-mutation-effect'
 const classPrefix = `adm-notice-bar`
 
 export type NoticeBarProps = {
-  /** 通告栏的类型 */
   color?: 'default' | 'alert' | 'error' | 'info'
-  /** 开始滚动的延迟，单位 ms */
   delay?: number
-  /** 滚动速度，单位 px/s */
   speed?: number
-  /** 公告内容 */
   content: React.ReactNode
-  /** 是否可关闭 */
   closeable?: boolean
-  /** 关闭时的回调 */
   onClose?: () => void
-  /** 额外操作区域，显示在关闭按钮左侧 */
   extra?: React.ReactNode
-  /** 左侧广播图标 */
   icon?: React.ReactNode
-  /** 是否自动换行 */
   wrap?: boolean
 } & NativeProps<
   | '--background-color'

--- a/src/components/notice-bar/notice-bar.tsx
+++ b/src/components/notice-bar/notice-bar.tsx
@@ -35,6 +35,7 @@ export type NoticeBarProps = {
   | '--font-size'
   | '--icon-font-size'
   | '--height'
+  | '--line-height'
 >
 
 const defaultProps = {
@@ -125,12 +126,9 @@ export const NoticeBar = memo<NoticeBarProps>(p => {
             start()
           }}
           ref={textRef}
-          className={classNames(
-            `${classPrefix}-content-inner`,
-            props.wrap
-              ? `${classPrefix}-content-inner-wrap`
-              : `${classPrefix}-content-inner-no-wrap`
-          )}
+          className={classNames(`${classPrefix}-content-inner`, {
+            [`${classPrefix}-content-inner-wrap`]: props.wrap,
+          })}
         >
           {props.content}
         </span>

--- a/src/components/notice-bar/notice-bar.tsx
+++ b/src/components/notice-bar/notice-bar.tsx
@@ -59,16 +59,11 @@ export const NoticeBar = memo<NoticeBarProps>(p => {
   const animatingRef = useRef(false)
 
   function start() {
-    if (delayLockRef.current) return
+    if (delayLockRef.current || props.wrap) return
 
     const container = containerRef.current
     const text = textRef.current
     if (!container || !text) return
-
-    if (props.wrap) {
-      text.style.whiteSpace = 'pre-wrap'
-      return
-    }
 
     if (container.offsetWidth >= text.offsetWidth) {
       animatingRef.current = false
@@ -94,13 +89,10 @@ export const NoticeBar = memo<NoticeBarProps>(p => {
     text.style.transform = `translateX(-${text.offsetWidth}px)`
   }
 
-  useTimeout(
-    () => {
-      delayLockRef.current = false
-      start()
-    },
-    props.wrap ? 0 : props.delay
-  )
+  useTimeout(() => {
+    delayLockRef.current = false
+    start()
+  }, props.delay)
 
   useResizeEffect(() => {
     start()
@@ -133,7 +125,12 @@ export const NoticeBar = memo<NoticeBarProps>(p => {
             start()
           }}
           ref={textRef}
-          className={`${classPrefix}-content-inner`}
+          className={classNames(
+            `${classPrefix}-content-inner`,
+            props.wrap
+              ? `${classPrefix}-content-inner-wrap`
+              : `${classPrefix}-content-inner-no-wrap`
+          )}
         >
           {props.content}
         </span>

--- a/src/components/notice-bar/notice-bar.tsx
+++ b/src/components/notice-bar/notice-bar.tsx
@@ -26,6 +26,8 @@ export type NoticeBarProps = {
   extra?: React.ReactNode
   /** 左侧广播图标 */
   icon?: React.ReactNode
+  /** 是否自动换行 */
+  wrap?: boolean
 } & NativeProps<
   | '--background-color'
   | '--border-color'
@@ -39,6 +41,7 @@ const defaultProps = {
   color: 'default',
   delay: 2000,
   speed: 50,
+  wrap: false,
   icon: <SoundOutline />,
 }
 
@@ -62,7 +65,7 @@ export const NoticeBar = memo<NoticeBarProps>(p => {
     const text = textRef.current
     if (!container || !text) return
 
-    if (props.speed === 0) {
+    if (props.wrap) {
       text.style.whiteSpace = 'pre-wrap'
       return
     }
@@ -96,7 +99,7 @@ export const NoticeBar = memo<NoticeBarProps>(p => {
       delayLockRef.current = false
       start()
     },
-    props.speed === 0 ? 0 : props.delay
+    props.wrap ? 0 : props.delay
   )
 
   useResizeEffect(() => {

--- a/src/components/notice-bar/tests/notice-bar.test.tsx
+++ b/src/components/notice-bar/tests/notice-bar.test.tsx
@@ -53,7 +53,7 @@ describe('NoticeBar', () => {
   })
 
   test('long content', async () => {
-    const { container, debug } = render(
+    const { container } = render(
       <NoticeBar
         delay={100}
         speed={500}
@@ -77,5 +77,22 @@ describe('NoticeBar', () => {
 
     await sleep(200)
     expect(container).toMatchSnapshot()
+  })
+
+  test('`wrap` prop', () => {
+    render(
+      <NoticeBar
+        content={
+          <>
+            <div>1</div>
+            <div>2</div>
+          </>
+        }
+        wrap
+      />
+    )
+    expect(document.querySelector(`.${classPrefix}`)).toHaveClass(
+      `${classPrefix}-wrap`
+    )
   })
 })


### PR DESCRIPTION
pr 改动想法：
1. 去除文本的`position:absolute`样式和最外层`height`样式，高度自适应；
2. 当`speed`为`0`时，将文本设为可换行；
3. 当文本设置为可换行时，`delay` 属性就没有必要了，应该直接渲染出换行的样子。
#5796 