### PR TITLE
fix(ImageUploader): upload dont work while another is uploading

### DIFF
--- a/src/components/image-uploader/image-uploader.tsx
+++ b/src/components/image-uploader/image-uploader.tsx
@@ -195,18 +195,7 @@ export const ImageUploader: FC<ImageUploaderProps> = p => {
       newTasks.map(async currentTask => {
         try {
           const result = await props.upload(currentTask.file)
-          setTasks(prev => {
-            return prev.map(task => {
-              if (task.id === currentTask.id) {
-                return {
-                  ...task,
-                  status: 'success',
-                  url: result.url,
-                }
-              }
-              return task
-            })
-          })
+          setTasks(prev => prev.filter(task => task.id !== currentTask.id))
           setValue(prev => {
             const newVal = { ...result }
             return [...prev, newVal]


### PR DESCRIPTION
fix #5833

https://github.com/ant-design/ant-design-mobile/blob/56675ff887016ebec115666b2a7021d247d3a671/src/components/image-uploader/image-uploader.tsx#L252
修改处原有的逻辑会导致上传成功后的数据（刚开始）同时存在于 tasks 和 value 中，导致 `showUpload` 这个比较有问题