### PR TITLE
feat(Input): 支持原生 step 属性

### DIFF
--- a/src/components/input/index.en.md
+++ b/src/components/input/index.en.md
@@ -34,7 +34,7 @@ The `Input` component is layout-independent. It only includes the most basic inp
 | readOnly | Whether it is readonly or not | `boolean` | `false` |
 | value | The input value | `string` | - |
 
-In addition, the following native attributes are supported: `maxLength` `minLength` `max` `min` `autoComplete` `autoFocus` `enterKeyHint` `pattern` `inputMode` `type` `onFocus` `onBlur` `autoCapitalize` `autoCorrect` `onKeyDown` `onKeyUp` `onCompositionStart` `onCompositionEnd` `onClick`
+In addition, the following native attributes are supported: `maxLength` `minLength` `max` `min` `autoComplete` `autoFocus` `enterKeyHint` `pattern` `inputMode` `type` `onFocus` `onBlur` `autoCapitalize` `autoCorrect` `onKeyDown` `onKeyUp` `onCompositionStart` `onCompositionEnd` `onClick` `step`
 
 ### CSS Variables
 

--- a/src/components/input/index.zh.md
+++ b/src/components/input/index.zh.md
@@ -34,7 +34,7 @@
 | readOnly | 是否只读 | `boolean` | `false` |
 | value | 输入值 | `string` | - |
 
-此外还支持以下原生属性：`maxLength` `minLength` `autoComplete` `autoFocus` `enterKeyHint` `pattern` `inputMode` `type` `onFocus` `onBlur` `autoCapitalize` `autoCorrect` `onKeyDown` `onKeyUp` `onCompositionStart` `onCompositionEnd` `onClick`
+此外还支持以下原生属性：`maxLength` `minLength` `autoComplete` `autoFocus` `enterKeyHint` `pattern` `inputMode` `type` `onFocus` `onBlur` `autoCapitalize` `autoCorrect` `onKeyDown` `onKeyUp` `onCompositionStart` `onCompositionEnd` `onClick` `step`
 
 ### CSS 变量
 

--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -190,6 +190,7 @@ export const Input = forwardRef<InputRef, InputProps>((p, ref) => {
           props.onCompositionEnd?.(e)
         }}
         onClick={props.onClick}
+        step={props.step}
         role={props.role}
         aria-valuenow={props['aria-valuenow']}
         aria-valuemax={props['aria-valuemax']}

--- a/src/components/input/tests/input.test.tsx
+++ b/src/components/input/tests/input.test.tsx
@@ -142,6 +142,30 @@ describe('Input', () => {
     })
   })
 
+  test('input value should be limited by min and step attributes', async () => {
+    const ref = React.createRef<InputRef>()
+    render(<Input ref={ref} clearable type='number' step='0.01' min={0} />)
+    const input = ref.current?.nativeElement as HTMLInputElement
+    expect(ref.current).toBeDefined()
+    expect(ref.current?.nativeElement).toBeInTheDocument()
+
+    // Try to set the value to a number below the minimum
+    fireEvent.change(input, { target: { value: '-1' } })
+    expect(input.checkValidity()).toBe(false)
+
+    // Try to set the value to a number above the minimum
+    fireEvent.change(input, { target: { value: '1' } })
+    expect(input.checkValidity()).toBe(true)
+
+    // Try to set the value to a number that is not a multiple of the step
+    fireEvent.change(input, { target: { value: '2.333' } })
+    expect(input.checkValidity()).toBe(false)
+
+    // Try to set the value to a number that is a multiple of the step
+    fireEvent.change(input, { target: { value: '2.33' } })
+    expect(input.checkValidity()).toBe(true)
+  })
+
   test('should works with `onEnterPress`', async () => {
     const onEnterPress = jest.fn()
     render(<Input defaultValue={'testValue'} onEnterPress={onEnterPress} />)

--- a/src/components/input/tests/input.test.tsx
+++ b/src/components/input/tests/input.test.tsx
@@ -142,28 +142,10 @@ describe('Input', () => {
     })
   })
 
-  test('input value should be limited by min and step attributes', async () => {
-    const ref = React.createRef<InputRef>()
-    render(<Input ref={ref} clearable type='number' step='0.01' min={0} />)
-    const input = ref.current?.nativeElement as HTMLInputElement
-    expect(ref.current).toBeDefined()
-    expect(ref.current?.nativeElement).toBeInTheDocument()
-
-    // Try to set the value to a number below the minimum
-    fireEvent.change(input, { target: { value: '-1' } })
-    expect(input.checkValidity()).toBe(false)
-
-    // Try to set the value to a number above the minimum
-    fireEvent.change(input, { target: { value: '1' } })
-    expect(input.checkValidity()).toBe(true)
-
-    // Try to set the value to a number that is not a multiple of the step
-    fireEvent.change(input, { target: { value: '2.333' } })
-    expect(input.checkValidity()).toBe(false)
-
-    // Try to set the value to a number that is a multiple of the step
-    fireEvent.change(input, { target: { value: '2.33' } })
-    expect(input.checkValidity()).toBe(true)
+  test('should work with `type="number"` and step', async () => {
+    const { container } = render(<Input type='number' step='0.01' min={0} />)
+    const input = container.querySelector('input') as HTMLInputElement
+    expect(input.step).toBe('0.01')
   })
 
   test('should works with `onEnterPress`', async () => {


### PR DESCRIPTION
input type 为 number 并且配置 min 属性时，输入小数，表单提交会提示 “输入有效值”，配置 step 属性即可解决这个问题