### PR TITLE
fix(Footer): adjust `Divider` import path

### DIFF
--- a/src/components/footer/footer.tsx
+++ b/src/components/footer/footer.tsx
@@ -2,7 +2,7 @@ import React, { FC, ReactNode } from 'react'
 import classNames from 'classnames'
 import { NativeProps, withNativeProps } from '../../utils/native-props'
 import { mergeProps } from '../../utils/with-default-props'
-import { Divider } from '../divider/divider'
+import Divider from '../divider'
 
 const classPrefix = `adm-footer`
 


### PR DESCRIPTION
原本的 `import { Divider } from '../divider/divider'` 会缺少 divider 的样式