### PR TITLE
fix(Input): imperative call not call `onClear`

### DIFF
--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -91,6 +91,7 @@ export const Input = forwardRef<InputRef, InputProps>((p, ref) => {
   useImperativeHandle(ref, () => ({
     clear: () => {
       setValue('')
+      props.onClear?.()
     },
     focus: () => {
       nativeInputRef.current?.focus()

--- a/src/components/input/tests/input.test.tsx
+++ b/src/components/input/tests/input.test.tsx
@@ -173,12 +173,14 @@ describe('Input', () => {
     const ref = createRef<InputRef>()
     const onFocus = jest.fn()
     const onBlur = jest.fn()
+    const onClear = jest.fn()
     render(
       <Input
         defaultValue={'testValue'}
         ref={ref}
         onFocus={onFocus}
         onBlur={onBlur}
+        onClear={onClear}
       />
     )
     ref.current?.focus()
@@ -189,5 +191,6 @@ describe('Input', () => {
       ref.current?.clear()
     })
     expect(ref.current?.nativeElement?.value).toBe('')
+    expect(onBlur).toBeCalledTimes(1)
   })
 })


### PR DESCRIPTION
https://mobile.ant.design/zh/components/search-bar

事件监听和 Ref 里的清空内容不会触发回调