### PR TITLE
feat(number-keyboard): extend type of confirmText

### DIFF
--- a/src/components/number-keyboard/demos/demo2.tsx
+++ b/src/components/number-keyboard/demos/demo2.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { List, NumberKeyboard } from 'antd-mobile'
+import { Button, List, NumberKeyboard } from 'antd-mobile'
 import { DemoBlock } from 'demos'
 
 export default () => {
@@ -45,7 +45,7 @@ export default () => {
         visible={visible === 'demo3'}
         onClose={onClose}
         customKey={'-'}
-        confirmText='确定'
+        confirmText={<Button color='primary'>确定</Button>}
       />
       <NumberKeyboard
         visible={visible === 'demo4'}

--- a/src/components/number-keyboard/index.en.md
+++ b/src/components/number-keyboard/index.en.md
@@ -25,7 +25,7 @@ If possible, we recommend using the native keyboard provided by the system or cl
 | afterClose | Callback when the keyboard is completely put away | `() => void` | - |
 | afterShow | Callback when the keyboard is completely bounced | `() => void` | - |
 | closeOnConfirm | Whether to automatically close when the ok button is clicked | `boolean` | `true` |
-| confirmText | The text of the confirm button, if `null` is set, it would be shown | `string \| null` | `null` |
+| confirmText | The text of the confirm button, if `null` is set, it would be shown | `string \| null \| ReactNode`  | `null` |
 | customKey | Customized button | `string \| [string, string]` | - |
 | destroyOnClose | Unmount content when not visible | `boolean` | `false` |
 | forceRender | Render content forcely | `boolean` | `false` |

--- a/src/components/number-keyboard/index.zh.md
+++ b/src/components/number-keyboard/index.zh.md
@@ -25,7 +25,7 @@
 | afterClose | 键盘完全收起回调 | `() => void` | - |
 | afterShow | 键盘完全弹出回调 | `() => void` | - |
 | closeOnConfirm | 是否在点击确定按钮时自动关闭 | `boolean` | `true` |
-| confirmText | 完成按钮文案，`null` 不展示 | `string \| null` | `null` |
+| confirmText | 完成按钮文案，`null` 不展示 | `string \| null \| ReactNode` | `null` |
 | customKey | 自定义按钮 | `string \| [string, string]` | - |
 | destroyOnClose | 不可见时卸载内容 | `boolean` | `false` |
 | forceRender | 强制渲染内容 | `boolean` | `false` |

--- a/src/components/number-keyboard/number-keyboard.tsx
+++ b/src/components/number-keyboard/number-keyboard.tsx
@@ -1,4 +1,10 @@
-import React, { useRef, useMemo, TouchEvent, MouseEvent } from 'react'
+import React, {
+  useRef,
+  useMemo,
+  TouchEvent,
+  MouseEvent,
+  ReactNode,
+} from 'react'
 import classNames from 'classnames'
 import { DownOutline, TextDeletionOutline } from 'antd-mobile-icons'
 import { mergeProps } from '../../utils/with-default-props'
@@ -13,7 +19,7 @@ const classPrefix = 'adm-number-keyboard'
 export type NumberKeyboardProps = {
   visible?: boolean
   title?: string
-  confirmText?: string | null
+  confirmText?: string | null | ReactNode
   customKey?: string | [string, string]
   randomOrder?: boolean
   showCloseButton?: boolean
@@ -227,13 +233,17 @@ export const NumberKeyboard: React.FC<NumberKeyboardProps> = p => {
                 >
                   <TextDeletionOutline />
                 </div>
-                <div
-                  className={`${classPrefix}-key ${classPrefix}-key-extra ${classPrefix}-key-ok`}
-                  onTouchEnd={e => onKeyPress(e, 'OK')}
-                  role='button'
-                >
-                  {confirmText}
-                </div>
+                {typeof confirmText === 'string' ? (
+                  <div
+                    className={`${classPrefix}-key ${classPrefix}-key-extra ${classPrefix}-key-ok`}
+                    onTouchEnd={e => onKeyPress(e, 'OK')}
+                    role='button'
+                  >
+                    {confirmText}
+                  </div>
+                ) : (
+                  <div onTouchEnd={e => onKeyPress(e, 'OK')}>{confirmText}</div>
+                )}
               </div>
             )}
           </div>


### PR DESCRIPTION
  1. 这里只是给 confirmText 多加了一个类型，避免引起 break change。
  2. 当 confirmText 为 ReactNode 时，直接用它替换现有的 Confirm button，而不是作为其子元素。这样虽然需要自己额外写样式，但是可以避免只点击 Confirm button 而没点击到 confirmText 的情况（可能 confirmText 比较小，没填满 Confirm button）。
