### PR TITLE
fix(Steps): icon background color should be unnecessary

### DIFF
--- a/src/components/steps/steps.less
+++ b/src/components/steps/steps.less
@@ -16,7 +16,6 @@
     .@{class-prefix-step}-icon-container {
       position: absolute;
       z-index: 1;
-      background: var(--adm-color-background);
       color: var(--icon-color);
       > .antd-mobile-icon {
         display: block;


### PR DESCRIPTION
Stpe组件icon的背景色应该去掉才对，如果有个透明底色的图片会直接被默认的白色覆盖 