### PR TITLE
feat: when double slider show all popover

### DIFF
--- a/src/components/slider/demos/demo2.tsx
+++ b/src/components/slider/demos/demo2.tsx
@@ -39,6 +39,7 @@ export default () => {
           marks={marks}
           ticks
           range
+          popover
           onAfterChange={toastValue}
           onChange={value => {
             console.log(value)

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode, useMemo, useRef } from 'react'
+import React, { FC, ReactNode, useMemo, useRef, useState } from 'react'
 import { NativeProps, withNativeProps } from '../../utils/native-props'
 import classNames from 'classnames'
 import Ticks from './ticks'
@@ -45,7 +45,7 @@ const defaultProps = {
 export const Slider: FC<SliderProps> = p => {
   const props = mergeProps(defaultProps, p)
   const { min, max, disabled, marks, ticks, step, icon } = props
-
+  const [anotherPopover, setAnotherPopover] = useState<boolean>(false)
   function sortValue(val: [number, number]): [number, number] {
     return val.sort((a, b) => a - b)
   }
@@ -185,6 +185,7 @@ export const Slider: FC<SliderProps> = p => {
         disabled={disabled}
         trackRef={trackRef}
         icon={icon}
+        showPopover={anotherPopover}
         popover={props.popover}
         residentPopover={props.residentPopover}
         onDrag={(position, first, last) => {
@@ -197,11 +198,15 @@ export const Slider: FC<SliderProps> = p => {
           if (!valueBeforeDrag) return
           const next = [...valueBeforeDrag] as [number, number]
           next[index] = val
+          if (props.range) {
+            setAnotherPopover(true)
+          }
           setSliderValue(next)
           if (last) {
             onAfterChange(next)
             window.setTimeout(() => {
               dragLockRef.current -= 1
+              setAnotherPopover(false)
             }, 100)
           }
         }}

--- a/src/components/slider/tests/slider.test.tsx
+++ b/src/components/slider/tests/slider.test.tsx
@@ -145,6 +145,39 @@ describe('Slider', () => {
     expect(popover).toHaveTextContent('60')
   })
 
+  test('double sliders all show popover when swiping', () => {
+    render(<Slider step={20} range popover />)
+
+    const thumb1 = screen.getAllByRole('slider')[0]
+
+    drag(thumb1, 20)
+
+    const popover1 = $$('.adm-popover')[0]
+    const popover2 = $$('.adm-popover')[1]
+    expect(popover1).toBeInTheDocument()
+    expect(popover2).toBeInTheDocument()
+    expect(popover1).toHaveTextContent('0')
+    expect(popover2).toHaveTextContent('20')
+  })
+
+  test('double slider custom popover', () => {
+    const { getByText } = render(
+      <Slider range popover={value => <div>popover {value}</div>} />
+    )
+
+    const thumb = screen.getAllByRole('slider')[0]
+    fireEvent.mouseDown(thumb, {
+      buttons: 1,
+    })
+    fireEvent.mouseMove(thumb, {
+      buttons: 1,
+      clientX: 60,
+    })
+
+    expect(getByText('popover 60')).toBeInTheDocument()
+    expect(getByText('popover 0')).toBeInTheDocument()
+  })
+
   test('custom popover', () => {
     const { getByText } = render(
       <Slider popover={value => <div>popover {value}</div>} />

--- a/src/components/slider/thumb.tsx
+++ b/src/components/slider/thumb.tsx
@@ -15,6 +15,7 @@ type ThumbProps = {
   onDrag: (value: number, first: boolean, last: boolean) => void
   trackRef: RefObject<HTMLDivElement>
   icon?: React.ReactNode
+  showPopover: boolean
   popover: boolean | ((value: number) => ReactNode)
   residentPopover: boolean
 } & NativeProps
@@ -81,7 +82,7 @@ const Thumb: FC<ThumbProps> = props => {
         <Popover
           content={renderPopoverContent(value)}
           placement='top'
-          visible={residentPopover || dragging}
+          visible={residentPopover || dragging || props.showPopover}
           getContainer={null}
           mode='dark'
         >


### PR DESCRIPTION
**灵感**：看了[issues #5973](https://github.com/ant-design/ant-design-mobile/issues/5973)，两个滑块滑动不松鼠标的时候当前一个超过后一个，或后一个低于前一个的时候，`popover`只会显示在相交位置，本意想解决这个bug
**过程**：做出很多修改都不太满意，最后尝试当两个滑块的时候，滑动时都显示popover，希望采纳
**结果**：新增都显示popover的功能并新增两个测试用例，都能跑通