### PR TITLE
chore: extract motion subscribe into single fn

### DIFF
--- a/src/utils/reduce-and-restore-motion.ts
+++ b/src/utils/reduce-and-restore-motion.ts
@@ -31,11 +31,13 @@ export function isMotionReduced() {
   return reduced
 }
 
+function subscribe(onStoreChange: () => void) {
+  subscribers.add(onStoreChange)
+  return () => {
+    subscribers.delete(onStoreChange)
+  }
+}
+
 export function useMotionReduced() {
-  return useSyncExternalStore(onStoreChange => {
-    subscribers.add(onStoreChange)
-    return () => {
-      subscribers.delete(onStoreChange)
-    }
-  }, isMotionReduced)
+  return useSyncExternalStore(subscribe, isMotionReduced)
 }


### PR DESCRIPTION
According to [doc](https://beta.reactjs.org/reference/react/useSyncExternalStore#caveats), subscribe fn reference should be stable, so just extract it into single fn. 😂