### PR TITLE
enhance(Popover): use global css variables to control font color

### DIFF
--- a/src/components/popover/popover.less
+++ b/src/components/popover/popover.less
@@ -10,7 +10,7 @@
   &&-dark {
     --background: rgba(0, 0, 0, 0.75);
     --adm-color-text: #ffffff;
-    color: var(--adm-color-text);
+    color: #ffffff;
     .adm-popover-inner {
       box-shadow: none;
     }

--- a/src/components/popover/popover.less
+++ b/src/components/popover/popover.less
@@ -10,13 +10,13 @@
   &&-dark {
     --background: rgba(0, 0, 0, 0.75);
     --adm-color-text: #ffffff;
-    color: #ffffff;
+    color: var(--adm-color-text);
     .adm-popover-inner {
       box-shadow: none;
     }
   }
 
-  color: #333333;
+  color: var(--adm-color-text);
   position: absolute;
   top: 0;
   left: 0;

--- a/src/components/popover/popover.patch.less
+++ b/src/components/popover/popover.patch.less
@@ -8,6 +8,7 @@
     }
   }
   z-index: 1030;
+  color: #333333;
 
   &-inner {
     background-color: #ffffff;


### PR DESCRIPTION
Another question:

in `theme-dark.less` defined  `--adm-color-text: #e6e6e6;`.

in `popover.less` defined 

```css
/* The new colors are defined here */
 &&-dark {
    --adm-color-text: #ffffff;
    color: #ffffff;
  }
```
why use white color instead of `#e6e6e6` ?

So is this by design, or is there a deviation?