### PR TITLE
fix(Popup): omit transform to fixed nested fixed position

### DIFF
--- a/src/components/action-sheet/tests/__snapshots__/action-sheet.test.tsx.snap
+++ b/src/components/action-sheet/tests/__snapshots__/action-sheet.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`ActionSheet basic usage 1`] = `
     </div>
     <div
       class="adm-popup-body adm-popup-body-position-bottom"
-      style="transform: translate(0, 0%);"
+      style="transform: none;"
     >
       <div
         class="adm-action-sheet"

--- a/src/components/action-sheet/tests/action-sheet.test.tsx
+++ b/src/components/action-sheet/tests/action-sheet.test.tsx
@@ -52,7 +52,7 @@ describe('ActionSheet', () => {
     await waitFor(() =>
       // end of animation
       expect(baseElement.querySelectorAll('.adm-popup-body')[0]).toHaveStyle(
-        'transform: translate(0, 0%);'
+        'transform: none;'
       )
     )
 

--- a/src/components/popup/popup.tsx
+++ b/src/components/popup/popup.tsx
@@ -100,17 +100,19 @@ export const Popup: FC<PopupProps> = p => {
           style={{
             ...props.bodyStyle,
             transform: percent.to(v => {
-              if (props.position === 'bottom') {
-                return `translate(0, ${v}%)`
-              }
-              if (props.position === 'top') {
-                return `translate(0, -${v}%)`
-              }
-              if (props.position === 'left') {
-                return `translate(-${v}%, 0)`
-              }
-              if (props.position === 'right') {
-                return `translate(${v}%, 0)`
+              if (v) {
+                if (props.position === 'bottom') {
+                  return `translate(0, ${v}%)`
+                }
+                if (props.position === 'top') {
+                  return `translate(0, -${v}%)`
+                }
+                if (props.position === 'left') {
+                  return `translate(-${v}%, 0)`
+                }
+                if (props.position === 'right') {
+                  return `translate(${v}%, 0)`
+                }
               }
               return 'none'
             }),


### PR DESCRIPTION
当 `percent.to` 回参为 0 时，设置 `Popup` 的 `transform` 为 `none`，以解决该样式导致的定位相对位置变化问题。

![image](https://user-images.githubusercontent.com/7709602/226833178-f7018523-1c75-4eff-b6cd-60ed4ff7ea04.png)

参考链接：[MDN position](https://developer.mozilla.org/zh-CN/docs/Web/CSS/position)