### PR TITLE
fix(Toast): toast cannot be closed when calling `Toast.show` and immediately calling `Toast.clear`

### DIFF
--- a/src/components/toast/tests/toast.test.tsx
+++ b/src/components/toast/tests/toast.test.tsx
@@ -234,4 +234,27 @@ describe('Toast', () => {
     expect(mask).toHaveStyle('pointer-events: auto')
     await waitForElementToBeRemoved(mask)
   })
+
+  test('close should be work when the toast is not mounted', async () => {
+    const { getByText } = render(
+      <button
+        onClick={() => {
+          Toast.show({
+            content: 'content',
+            duration: 0,
+          })
+          Toast.clear()
+          Toast.show({
+            content: 'content2',
+            duration: 0,
+          })
+        }}
+      >
+        btn
+      </button>
+    )
+    fireEvent.click(getByText('btn'))
+    await waitForContentShow('content2')
+    expect(document.querySelectorAll(`.${classPrefix}-main`).length)
+  })
 })

--- a/src/utils/render-imperatively.tsx
+++ b/src/utils/render-imperatively.tsx
@@ -61,8 +61,13 @@ export function renderImperatively(element: TargetElement) {
   const wrapperRef = React.createRef<ImperativeHandler>()
   const unmount = renderToBody(<Wrapper ref={wrapperRef} />)
   return {
-    close: () => {
-      wrapperRef.current?.close()
+    close: async () => {
+      if (!wrapperRef.current) {
+        // it means the wrapper is not mounted yet, call `unmount` directly
+        unmount()
+      } else {
+        wrapperRef.current?.close()
+      }
     },
     replace: element => {
       wrapperRef.current?.replace(element)


### PR DESCRIPTION
#6057 
#5859