### PR TITLE
fix(ellipsis): fix only collapseText without expandText

### DIFF
--- a/src/components/ellipsis/ellipsis.tsx
+++ b/src/components/ellipsis/ellipsis.tsx
@@ -194,7 +194,7 @@ export const Ellipsis: FC<EllipsisProps> = p => {
       : null
 
   const collapseActionElement =
-    exceeded && props.expandText
+    exceeded && props.collapseText
       ? withStopPropagation(
           props.stopPropagationForActionButtons,
           <a


### PR DESCRIPTION
修复默认展开时，只有 `收起` 没有 `展开` 按钮的情况
```
<Ellipsis
  content={content}
  defaultExpanded={true}
  collapseText='收起'
/>
```
before:
![1680165070497](https://user-images.githubusercontent.com/47295879/228777655-0df3a934-057d-4254-811f-99561b43efec.png)


after:
![image](https://user-images.githubusercontent.com/47295879/228777971-6375cc9b-57e9-4b11-a041-ab00a11e9a7b.png)


