### PR TITLE
fix: pin dev node version to node16-lts

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/Gallium


### PR DESCRIPTION
Local dev not support node18 right now.
```node
node:internal/crypto/hash:71
  this[kHandle] = new _Hash(algorithm, xofLen);
                  ^

Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:71:19)
    at Object.createHash (node:crypto:133:10)
    at module.exports.__webpack_modules__.57442.module.exports (...\ant-design-mobile\node_modules\.pnpm\@umijs+deps@3.5.35\node_modules\@umijs\deps\compiled\webpack\
4\bundle4.js:135907:62)
    at NormalModule._initBuildHash (...\ant-design-mobile\node_modules\.pnpm\@umijs+deps@3.5.35\node_modules\@umijs\deps\compiled\webpack\4\bundle4.js:109317:16)     
    at ...\ant-design-mobile\node_modules\.pnpm\@umijs+deps@3.5.35\node_modules\@umijs\deps\compiled\webpack\4\bundle4.js:109352:10
    at ...\ant-design-mobile\node_modules\.pnpm\@umijs+deps@3.5.35\node_modules\@umijs\deps\compiled\webpack\4\bundle4.js:109223:13
    at ...\ant-design-mobile\node_modules\.pnpm\@umijs+deps@3.5.35\node_modules\@umijs\deps\compiled\webpack\4\bundle4.js:61151:11
    at ...\ant-design-mobile\node_modules\.pnpm\@umijs+deps@3.5.35\node_modules\@umijs\deps\compiled\webpack\4\bundle4.js:61017:18
    at context.callback (...\ant-design-mobile\node_modules\.pnpm\@umijs+deps@3.5.35\node_modules\@umijs\deps\compiled\webpack\4\bundle4.js:60895:13)
    at ...\ant-design-mobile\node_modules\.pnpm\@umijs+deps@3.5.35\node_modules\@umijs\deps\compiled\babel-loader\index.js:1:130029 {
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
}

Node.js v18.15.0
```