### PR TITLE
fix: form context disabled props for es6

### DIFF
--- a/src/components/form/form.tsx
+++ b/src/components/form/form.tsx
@@ -130,7 +130,7 @@ export const Form = forwardRef<FormInstance, FormProps>((p, ref) => {
           hasFeedback,
           layout,
           requiredMarkStyle,
-          disabled: disabled,
+          disabled,
         }}
       >
         {lists}


### PR DESCRIPTION
Form context disabled props for es6