### PR TITLE
feat(Collapse): add active classname when panel is active 

### DIFF
--- a/src/components/collapse/collapse.tsx
+++ b/src/components/collapse/collapse.tsx
@@ -81,7 +81,9 @@ const CollapsePanelContent: FC<{
 
   return (
     <animated.div
-      className={`${classPrefix}-panel-content`}
+      className={classNames(`${classPrefix}-panel-content`, {
+        [`${classPrefix}-panel-content-active`]: visible,
+      })}
       style={{
         height: height.to(v => {
           if (height.idle && visible) {


### PR DESCRIPTION
issues #6068 

激活类名为 `adm-collapse-panel-content-active`