### PR TITLE
 Fix FormItem onClick execute twice bug

### DIFF
--- a/src/components/form/form-item.tsx
+++ b/src/components/form/form-item.tsx
@@ -439,6 +439,10 @@ export const FormItem: FC<FormItemProps> = props => {
           if (!childProps.id) {
             childProps.id = fieldId
           }
+          // Fix FormItem onClick execute twice bug
+          childProps.onClick = (e: Event) => {
+            e.stopPropagation()
+          }
 
           // We should keep user origin event handler
           const triggers = new Set<string>([


### PR DESCRIPTION
FormItem 中的onClick方法在点击label区域时，会触发两次。通过禁止子组件的事件捕获可以修复