### PR TITLE
optimize: swiper onIndexChange 事件 和 react-spring api 同步执行

### DIFF
--- a/src/components/swiper/swiper.tsx
+++ b/src/components/swiper/swiper.tsx
@@ -20,7 +20,7 @@ import PageIndicator, { PageIndicatorProps } from '../page-indicator'
 import { staged } from 'staged-components'
 import { useRefState } from '../../utils/use-ref-state'
 import { bound } from '../../utils/bound'
-import { useIsomorphicLayoutEffect, useUpdateEffect } from 'ahooks'
+import { useIsomorphicLayoutEffect } from 'ahooks'
 import { mergeFuncProps } from '../../utils/with-func-props'
 
 const classPrefix = `adm-swiper`
@@ -126,10 +126,6 @@ export const Swiper = forwardRef<SwiperRef, SwiperProps>(
       }
 
       const [current, setCurrent] = useState(props.defaultIndex)
-
-      useUpdateEffect(() => {
-        props.onIndexChange?.(current)
-      }, [current])
 
       const [dragging, setDragging, draggingRef] = useRefState(false)
 
@@ -242,6 +238,9 @@ export const Swiper = forwardRef<SwiperRef, SwiperProps>(
           ? modulus(roundedIndex, count)
           : bound(roundedIndex, 0, count - 1)
         setCurrent(targetIndex)
+        if (targetIndex !== current) {
+          props.onIndexChange?.(targetIndex)
+        }
         api.start({
           position: (loop ? roundedIndex : boundIndex(roundedIndex)) * 100,
           immediate,
@@ -293,7 +292,9 @@ export const Swiper = forwardRef<SwiperRef, SwiperProps>(
               {React.Children.map(validChildren, (child, index) => {
                 return (
                   <animated.div
-                    className={`${classPrefix}-slide`}
+                    className={classNames(`${classPrefix}-slide`, {
+                      [`${classPrefix}-slide-active`]: current === index,
+                    })}
                     style={{
                       [isVertical ? 'y' : 'x']: position.to(position => {
                         let finalPosition = -position + index * 100

--- a/src/components/swiper/tests/__snapshots__/swiper.test.tsx.snap
+++ b/src/components/swiper/tests/__snapshots__/swiper.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`Swiper loop 1`] = `
           </div>
         </div>
         <div
-          class="adm-swiper-slide"
+          class="adm-swiper-slide adm-swiper-slide-active"
           style="left: -200%; transform: none;"
         >
           <div
@@ -90,7 +90,7 @@ exports[`Swiper loop 2`] = `
         class="adm-swiper-track-inner"
       >
         <div
-          class="adm-swiper-slide"
+          class="adm-swiper-slide adm-swiper-slide-active"
           style="left: -0%; transform: none;"
         >
           <div

--- a/src/components/swiper/tests/swiper.test.tsx
+++ b/src/components/swiper/tests/swiper.test.tsx
@@ -184,6 +184,31 @@ describe('Swiper', () => {
     expect(onIndexChange).toBeCalledWith(2)
   })
 
+  test('`onIndexChange` should not be called when use `swipeTo` equal value', () => {
+    const onIndexChange = jest.fn()
+    const App = () => {
+      const ref = useRef<SwiperRef>(null)
+      return (
+        <>
+          <Swiper defaultIndex={0} ref={ref} onIndexChange={onIndexChange}>
+            {items}
+          </Swiper>
+          <button
+            onClick={() => {
+              ref.current?.swipeTo(0)
+            }}
+          >
+            to
+          </button>
+        </>
+      )
+    }
+    const { getByText } = render(<App />)
+
+    fireEvent.click(getByText('to'))
+    expect(onIndexChange).not.toBeCalled()
+  })
+
   test(`dont't allow touch move`, () => {
     render(<Swiper allowTouchMove={false}>{items}</Swiper>)
 


### PR DESCRIPTION
问题场景：现在代码中是监听 index 来触发 props.onIndexChange?.(index) 执行。当外部注册 onIndexChange 事件，根据最新的 index 设置当前激活的 SwiperItem 样式。面临的渲染时序将是这样的：
react-spring、setIndex -> onIndexChange，在 onIndexChange 回调设置的样式将会比 react-spring 慢一拍，在安卓机低端机上特别明显，有很强的卡顿感；

PR 修改：在执行 react-spring 动画时同时执行 onIndexChange，保证在同一拍重渲染；同时给当前激活的 SwiperItem 增加样式，方便使用者覆盖样式