### PR TITLE
enhance: ellipsis display glint

### DIFF
--- a/src/components/ellipsis/ellipsis.tsx
+++ b/src/components/ellipsis/ellipsis.tsx
@@ -224,25 +224,22 @@ export const Ellipsis: FC<EllipsisProps> = p => {
       : null
 
   const renderContent = () => {
-    if (!exceeded) {
-      return props.content
-    }
-    if (expanded) {
+    if (!exceeded) return props.content
+
+    if (expanded)
       return (
         <>
           {props.content}
           {collapseActionElement}
         </>
       )
-    } else {
-      return (
-        <>
-          {ellipsised.leading}
-          {expandActionElement}
-          {ellipsised.tailing}
-        </>
-      )
-    }
+    return (
+      <>
+        {ellipsised.leading}
+        {expandActionElement}
+        {ellipsised.tailing}
+      </>
+    )
   }
 
   return withNativeProps(

--- a/src/components/ellipsis/ellipsis.tsx
+++ b/src/components/ellipsis/ellipsis.tsx
@@ -56,18 +56,20 @@ export const Ellipsis: FC<EllipsisProps> = p => {
   function calcEllipsised() {
     const root = rootRef.current
     if (!root) return
-    if (!root.offsetParent) return
+
+    const originDisplay = root.style.display
+    root.style.display = 'block'
 
     const originStyle = window.getComputedStyle(root)
     const container = document.createElement('div')
+
     const styleNames: string[] = Array.prototype.slice.apply(originStyle)
     styleNames.forEach(name => {
       container.style.setProperty(name, originStyle.getPropertyValue(name))
     })
-    container.style.position = 'fixed'
-    container.style.left = '999999px'
-    container.style.top = '999999px'
-    container.style.zIndex = '-1000'
+
+    root.style.display = originDisplay
+
     container.style.height = 'auto'
     container.style.minHeight = 'auto'
     container.style.maxHeight = 'auto'

--- a/src/components/ellipsis/tests/__snapshots__/ellipsis.test.tsx.snap
+++ b/src/components/ellipsis/tests/__snapshots__/ellipsis.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`Ellipsis direction end 1`] = `
 <div
   class="adm-ellipsis"
   data-testid="ellipsis"
+  style=""
 >
   蚂蚁的企业级产品是一个庞大且复杂的体系。这类产品不仅...
 </div>
@@ -13,6 +14,7 @@ exports[`Ellipsis direction middle 1`] = `
 <div
   class="adm-ellipsis"
   data-testid="ellipsis"
+  style=""
 >
   蚂蚁的企业级产品是一个庞...
   ...些稳定且高复用性的内容。
@@ -23,6 +25,7 @@ exports[`Ellipsis direction start 1`] = `
 <div
   class="adm-ellipsis"
   data-testid="ellipsis"
+  style=""
 >
   ...以及组件，可以通过抽象得到一些稳定且高复用性的内容。
 </div>
@@ -32,6 +35,7 @@ exports[`Ellipsis expand and collapse 1`] = `
 <div
   class="adm-ellipsis"
   data-testid="ellipsis"
+  style=""
 >
   蚂蚁的企业级产品是一个庞大且复杂的体系。这类产品不仅量级巨大且功能复杂，而且变动和并发频繁，常常需要设计与开发能够快速的做出响应。同时这类产品中有存在很多类似的页面以及组件，可以通过抽象得到一些稳定且高复用性的内容。
   <a>
@@ -44,6 +48,7 @@ exports[`Ellipsis expand and collapse 2`] = `
 <div
   class="adm-ellipsis"
   data-testid="ellipsis"
+  style=""
 >
   蚂蚁的企业级产品是一个庞大且复杂的体系。...
   <a>
@@ -56,6 +61,7 @@ exports[`Ellipsis multi line 1`] = `
 <div
   class="adm-ellipsis"
   data-testid="ellipsis"
+  style=""
 >
   蚂蚁的企业级产品是一个庞大且复杂的体系。这类产品不仅量级巨大且功能复杂，而且变动和并发频繁，常常需要设计与开发能够快速的做出响应。同时这类产品中有存在很多类似的...
 </div>

--- a/src/components/ellipsis/tests/ellipsis.test.tsx
+++ b/src/components/ellipsis/tests/ellipsis.test.tsx
@@ -17,10 +17,6 @@ describe('Ellipsis', () => {
       style.lineHeight = `${lineHeight}px`
       return style
     }
-
-    Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
-      value: {},
-    })
   })
 
   beforeEach(() => {


### PR DESCRIPTION
#6063

 `root` 被`display`为`none` 时，`originStyle` 的 `width` 计算有误，导致 `container` 容器处理完的 文本塞进 `root` 后出现 抖动闪烁
