### PR TITLE
enhance(List): ListItem `onClick` type completion

### DIFF
--- a/src/components/list/list-item.tsx
+++ b/src/components/list/list-item.tsx
@@ -15,7 +15,7 @@ export type ListItemProps = {
   clickable?: boolean
   arrow?: boolean | ReactNode
   disabled?: boolean
-  onClick?: (e: React.MouseEvent) => void
+  onClick?: (e: React.MouseEvent<HTMLElement>) => void
 } & NativeProps<
   '--prefix-width' | '--align-items' | '--active-background-color'
 >


### PR DESCRIPTION
`React.MouseEvent`默认泛型为`Element`会导致使用`e.currentTarget.dataset`时ts报错,明确为`HTMLElement`

(或许可以根据onClick和clickable进一步明确为`HTMLDivElement`或`HTMLAnchorElement`?)