### PR TITLE
style: repair push(child) type  warning

### DIFF
--- a/src/components/calendar/convert.ts
+++ b/src/components/calendar/convert.ts
@@ -5,12 +5,8 @@ export function convertValueToRange(
   selectionMode: 'single' | 'range' | undefined,
   value: Date | [Date, Date] | null
 ): DateRange {
-  if (selectionMode === undefined) {
-    return null
-  }
-  if (value === null) {
-    return null
-  }
+  if (selectionMode === undefined || value === null) return null
+
   if (Array.isArray(value)) {
     return value
   }

--- a/src/components/capsule-tabs/capsule-tabs.tsx
+++ b/src/components/capsule-tabs/capsule-tabs.tsx
@@ -2,7 +2,7 @@ import React, {
   FC,
   ReactNode,
   ReactElement,
-  ComponentProps,
+  isValidElement,
   useRef,
 } from 'react'
 import classNames from 'classnames'
@@ -42,10 +42,10 @@ export const CapsuleTabs: FC<CapsuleTabsProps> = props => {
   const keyToIndexRecord: Record<string, number> = {}
   let firstActiveKey: string | null = null
 
-  const panes: ReactElement<ComponentProps<typeof CapsuleTab>>[] = []
+  const panes: ReactElement<CapsuleTabProps>[] = []
 
   traverseReactNode(props.children, (child, index) => {
-    if (!React.isValidElement(child)) return
+    if (!isValidElement<CapsuleTabProps>(child)) return
     const key = child.key
     if (typeof key !== 'string') return
     if (index === 0) {

--- a/src/components/collapse/collapse.tsx
+++ b/src/components/collapse/collapse.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactElement, ComponentProps, useRef } from 'react'
+import React, { FC, ReactElement, isValidElement, useRef } from 'react'
 import { NativeProps, withNativeProps } from '../../utils/native-props'
 import List from '../list'
 import { DownOutline } from 'antd-mobile-icons'
@@ -120,11 +120,12 @@ export type CollapseProps = (
 } & NativeProps
 
 export const Collapse: FC<CollapseProps> = props => {
-  const panels: ReactElement<ComponentProps<typeof CollapsePanel>>[] = []
+  const panels: ReactElement<CollapsePanelProps>[] = []
   traverseReactNode(props.children, child => {
-    if (!React.isValidElement(child)) return
+    if (!isValidElement<CollapsePanelProps>(child)) return
     const key = child.key
     if (typeof key !== 'string') return
+
     panels.push(child)
   })
 

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -9,6 +9,7 @@ import React, {
   useState,
   forwardRef,
   useImperativeHandle,
+  isValidElement,
 } from 'react'
 import Popup, { PopupProps } from '../popup'
 import Item, { ItemChildrenWrap } from './item'
@@ -84,7 +85,7 @@ const Dropdown = forwardRef<
   let popupForceRender = false
   const items: ReactElement<ComponentProps<typeof Item>>[] = []
   const navs = React.Children.map(props.children, child => {
-    if (React.isValidElement(child)) {
+    if (isValidElement<ComponentProps<typeof Item>>(child)) {
       const childProps = {
         ...child.props,
         onClick: () => {

--- a/src/components/jumbo-tabs/jumbo-tabs.tsx
+++ b/src/components/jumbo-tabs/jumbo-tabs.tsx
@@ -2,7 +2,7 @@ import React, {
   FC,
   ReactNode,
   ReactElement,
-  ComponentProps,
+  isValidElement,
   useRef,
 } from 'react'
 import classNames from 'classnames'
@@ -43,12 +43,13 @@ export const JumboTabs: FC<JumboTabsProps> = props => {
   const keyToIndexRecord: Record<string, number> = {}
   let firstActiveKey: string | null = null
 
-  const panes: ReactElement<ComponentProps<typeof JumboTab>>[] = []
+  const panes: ReactElement<JumboTabProps>[] = []
 
   traverseReactNode(props.children, (child, index) => {
-    if (!React.isValidElement(child)) return
+    if (!isValidElement<JumboTabProps>(child)) return
     const key = child.key
     if (typeof key !== 'string') return
+
     if (index === 0) {
       firstActiveKey = key
     }

--- a/src/components/rate/star.tsx
+++ b/src/components/rate/star.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { FC } from 'react'
+import type { FC } from 'react'
 
 export const Star: FC = () => {
   return (

--- a/src/components/safe-area/safe-area.tsx
+++ b/src/components/safe-area/safe-area.tsx
@@ -1,6 +1,7 @@
-import { FC } from 'react'
-import { NativeProps, withNativeProps } from '../../utils/native-props'
 import React from 'react'
+import type { FC } from 'react'
+import { NativeProps, withNativeProps } from '../../utils/native-props'
+
 import classNames from 'classnames'
 
 const classPrefix = 'adm-safe-area'

--- a/src/components/side-bar/side-bar.tsx
+++ b/src/components/side-bar/side-bar.tsx
@@ -1,5 +1,4 @@
-import { FC, ReactNode, ReactElement, ComponentProps } from 'react'
-import React from 'react'
+import React, { FC, ReactNode, ReactElement, isValidElement } from 'react'
 import classNames from 'classnames'
 import Badge, { BadgeProps } from '../badge'
 import { NativeProps, withNativeProps } from '../../utils/native-props'
@@ -32,12 +31,13 @@ export type SideBarProps = {
 export const SideBar: FC<SideBarProps> = props => {
   let firstActiveKey: string | null = null
 
-  const items: ReactElement<ComponentProps<typeof SideBarItem>>[] = []
+  const items: ReactElement<SideBarItemProps>[] = []
 
   traverseReactNode(props.children, (child, index) => {
-    if (!React.isValidElement(child)) return
+    if (!isValidElement<SideBarItemProps>(child)) return
     const key = child.key
     if (typeof key !== 'string') return
+
     if (index === 0) {
       firstActiveKey = key
     }

--- a/src/components/skeleton/skeleton.tsx
+++ b/src/components/skeleton/skeleton.tsx
@@ -1,5 +1,5 @@
-import { FC } from 'react'
 import React from 'react'
+import type { FC } from 'react'
 import { NativeProps, withNativeProps } from '../../utils/native-props'
 import classNames from 'classnames'
 import { generateIntArray } from '../../utils/generate-int-array'

--- a/src/components/tab-bar/tab-bar.tsx
+++ b/src/components/tab-bar/tab-bar.tsx
@@ -1,5 +1,4 @@
-import { FC, ReactNode, ReactElement, ComponentProps } from 'react'
-import React from 'react'
+import React, { FC, ReactNode, ReactElement, isValidElement } from 'react'
 import classNames from 'classnames'
 import { NativeProps, withNativeProps } from '../../utils/native-props'
 import { mergeProps } from '../../utils/with-default-props'
@@ -38,10 +37,10 @@ export const TabBar: FC<TabBarProps> = p => {
 
   let firstActiveKey: string | null = null
 
-  const items: ReactElement<ComponentProps<typeof TabBarItem>>[] = []
+  const items: ReactElement<TabBarItemProps>[] = []
 
   traverseReactNode(props.children, (child, index) => {
-    if (!React.isValidElement(child)) return
+    if (!isValidElement<TabBarItemProps>(child)) return
     const key = child.key
     if (typeof key !== 'string') return
     if (index === 0) {

--- a/src/components/tabs/tabs.tsx
+++ b/src/components/tabs/tabs.tsx
@@ -2,7 +2,7 @@ import React, {
   FC,
   ReactNode,
   ReactElement,
-  ComponentProps,
+  isValidElement,
   useRef,
 } from 'react'
 import classNames from 'classnames'
@@ -61,10 +61,11 @@ export const Tabs: FC<TabsProps> = p => {
   const keyToIndexRecord: Record<string, number> = {}
   let firstActiveKey: string | null = null
 
-  const panes: ReactElement<ComponentProps<typeof Tab>>[] = []
+  const panes: ReactElement<TabProps>[] = []
 
   traverseReactNode(props.children, (child, index) => {
-    if (!React.isValidElement(child)) return
+    if (!isValidElement<TabProps>(child)) return
+
     const key = child.key
     if (typeof key !== 'string') return
     if (index === 0) {


### PR DESCRIPTION
#### 修复多处 push(child) 的提示&import React处优化
`isValidElement` 增加泛型类型修复 多处 `push` 的 `ts`提示

![image](https://github.com/ant-design/ant-design-mobile/assets/77056991/192f82c1-024b-4a36-942d-b92e568081fa)

`TabBarItemProps` 与 `ComponentProps<typeof TabBarItem>` 最后结果一致  `ComponentProps` 内部用 `infer` 提取了返回值

`ReactElement` 参数可以直接用 `TabBarItemProps `

![image](https://github.com/ant-design/ant-design-mobile/assets/77056991/7f3d7569-39da-46a0-be50-2b06c656b730)

过程中顺便看到了 import React 的重复，也全局改了一下
