### PR TITLE
fix(NoticeBar): notice-bar wrap if set extra & closeable together

### DIFF
--- a/src/components/notice-bar/notice-bar.less
+++ b/src/components/notice-bar/notice-bar.less
@@ -66,6 +66,8 @@
   }
 
   & .@{class-prefix-notice-bar}-right {
+    display: flex;
+    align-items: center;
     flex-shrink: 0;
     margin-left: 12px;
   }


### PR DESCRIPTION
自从 #5448  版本 noticebar 扩展了关闭按钮的可点击区域后，右侧区域是一个 block 内嵌了一个 extra + 一个 block 的 close 按钮，而右侧区域本身不是 flex 布局的，导致同时设置 extra 和 closeable 时这俩会换行显示