### PR TITLE
fix: swiper setCurrent may force affect of getCurrent

### DIFF
--- a/src/components/swiper/swiper.tsx
+++ b/src/components/swiper/swiper.tsx
@@ -238,11 +238,12 @@ export const Swiper = forwardRef<SwiperRef, SwiperProps>(
         const targetIndex = loop
           ? modulus(roundedIndex, count)
           : bound(roundedIndex, 0, count - 1)
-        setCurrent(targetIndex)
 
         if (targetIndex !== getCurrent()) {
           props.onIndexChange?.(targetIndex)
         }
+
+        setCurrent(targetIndex)
 
         api.start({
           position: (loop ? roundedIndex : boundIndex(roundedIndex)) * 100,


### PR DESCRIPTION
微调设置顺序，以避免某些场景下 React 强制触发 flush 导致 `getCurrent` 不正确的问题