### PR TITLE
fix(TextArea): hidden textarea element is not positioned relative to its parent

### DIFF
--- a/src/components/text-area/text-area.less
+++ b/src/components/text-area/text-area.less
@@ -5,7 +5,7 @@
   --disabled-color: var(--adm-color-weak);
   --text-align: left;
   --count-text-align: right;
-
+  position: relative;
   width: 100%;
   max-width: 100%;
   max-height: 100%;


### PR DESCRIPTION
fix #6238
这个 absolute 没比较的父级定位，换行计算错误了

![image](https://github.com/ant-design/ant-design-mobile/assets/77056991/2a7d2449-8240-41e3-aeb4-19a50848858c)
