### PR TITLE
chore: type enhance

### DIFF
--- a/src/components/steps/steps.tsx
+++ b/src/components/steps/steps.tsx
@@ -36,24 +36,24 @@ export const Steps: FC<StepsProps> = p => {
     props,
     <div className={classString}>
       {React.Children.map(props.children, (child, index) => {
-        if (!React.isValidElement(child)) {
+        if (!React.isValidElement<StepProps>(child)) {
           return child
         }
-        const props = child.props as StepProps
-        let status = props.status || 'wait'
+        const childProps = child.props
+        let status = childProps.status || 'wait'
 
         if (index < current) {
-          status = props.status || 'finish'
+          status = childProps.status || 'finish'
         } else if (index === current) {
-          status = props.status || 'process'
+          status = childProps.status || 'process'
         }
 
-        const icon = props.icon ?? defaultIcon
+        const icon = childProps.icon ?? defaultIcon
 
         return React.cloneElement(child, {
           status,
           icon,
-        } as StepProps)
+        })
       })}
     </div>
   )


### PR DESCRIPTION
比 #6259 好些得写法可以不用 as 了

 `const props = child.props` 与顶部的 `const props = mergeProps(defaultProps, p)`  命名感觉有点混淆 ，然后改成 `childProps` 了
