### PR TITLE
chore: add `--inactive-color-half` type

### DIFF
--- a/src/components/rate/rate.tsx
+++ b/src/components/rate/rate.tsx
@@ -18,7 +18,12 @@ export type RateProps = {
   readOnly?: boolean
   value?: number
   onChange?: (value: number) => void
-} & NativeProps<'--star-size' | '--active-color' | '--inactive-color'>
+} & NativeProps<
+  | '--star-size'
+  | '--active-color'
+  | '--inactive-color'
+  | '--inactive-color-half'
+>
 
 const defaultProps = {
   count: 5,


### PR DESCRIPTION
fix it:
<img width="1119" alt="image" src="https://github.com/ant-design/ant-design-mobile/assets/52030677/5e7f96a2-5dbe-43fd-a08b-9b0892557626">
