### PR TITLE
enhance: passive and preventDefault coexist repair

### DIFF
--- a/src/utils/tests/use-lock-scroll.test.tsx
+++ b/src/utils/tests/use-lock-scroll.test.tsx
@@ -1,0 +1,48 @@
+import React, { useRef } from 'react'
+import { render, fireEvent } from 'testing'
+import { useLockScroll } from '../use-lock-scroll'
+
+describe('useLockScroll', () => {
+  test('onTouchMove', async () => {
+    const handleTouch = jest.fn()
+    const TestComponent = () => {
+      const divRef = useRef<HTMLDivElement>(null)
+
+      useLockScroll(divRef, true)
+
+      return (
+        <div
+          ref={divRef}
+          data-testid='lock'
+          style={{
+            height: 200,
+            overflow: 'scroll',
+            cursor: 'grab',
+            touchAction: 'none',
+          }}
+          onTouchMove={handleTouch}
+        >
+          {new Array(10).fill({}).map((_, i) => (
+            <h1 key={i}> Test component {i}</h1>
+          ))}
+        </div>
+      )
+    }
+
+    const { getByTestId } = render(<TestComponent />)
+
+    const testEl = getByTestId('lock')
+
+    fireEvent.touchStart(testEl, {
+      touches: [{ clientX: 0, clientY: 0 }],
+    })
+    fireEvent.touchMove(testEl, {
+      touches: [{ clientX: 0, clientY: 200 }],
+    })
+    fireEvent.touchEnd(testEl, {
+      touches: [{ clientX: 0, clientY: 400 }],
+    })
+
+    expect(handleTouch).toHaveBeenCalled()
+  })
+})

--- a/src/utils/use-lock-scroll.ts
+++ b/src/utils/use-lock-scroll.ts
@@ -65,7 +65,8 @@ export function useLockScroll(
       !(parseInt(status, 2) & parseInt(direction, 2))
     ) {
       if (event.cancelable) {
-        event.preventDefault()
+        // https://github.com/ant-design/ant-design-mobile/issues/6282
+        supportsPassive && event.preventDefault()
       }
     }
   }

--- a/src/utils/use-lock-scroll.ts
+++ b/src/utils/use-lock-scroll.ts
@@ -64,9 +64,9 @@ export function useLockScroll(
       touch.isVertical() &&
       !(parseInt(status, 2) & parseInt(direction, 2))
     ) {
-      if (event.cancelable) {
+      if (event.cancelable && supportsPassive) {
         // https://github.com/ant-design/ant-design-mobile/issues/6282
-        supportsPassive && event.preventDefault()
+        event.preventDefault()
       }
     }
   }


### PR DESCRIPTION
issue #6282
加的判断是这个 preventDefault 的
https://github.com/ant-design/ant-design-mobile/blob/master/src/utils/use-lock-scroll.ts#L68

下面这个 preventDefault 应该不用加吧？跟这个 PR 有关 #5738
https://github.com/ant-design/ant-design-mobile/blob/master/src/utils/use-lock-scroll.ts#L48