### PR TITLE
chore: pick type to InputHTMLAttributes

### DIFF
--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -42,13 +42,13 @@ export type InputProps = Pick<
   | 'onClick'
   | 'step'
   | 'id'
+  | 'placeholder'
+  | 'readOnly'
+  | 'disabled'
 > & {
   value?: string
   defaultValue?: string
   onChange?: (val: string) => void
-  placeholder?: string
-  disabled?: boolean
-  readOnly?: boolean
   clearable?: boolean
   onlyShowClearWhenFocus?: boolean
   onClear?: () => void


### PR DESCRIPTION
这个NativeInputProps 里得  `React.InputHTMLAttributes` 是包含 `placeholder`  `readOnly`  `disabled`  的
```ts
type NativeInputProps = React.DetailedHTMLProps<
  React.InputHTMLAttributes<HTMLInputElement>,
  HTMLInputElement
>
```
不明白为啥不直接pick 出来而是重写一个

而且可选参数会自己加上 undefined 类型 ， disabled?: boolean | undefined 和   disabled?: boolean 是一样的

![image](https://github.com/ant-design/ant-design-mobile/assets/77056991/7f7315eb-0dc7-4d64-af66-d5e545d0c6f1)
