### PR TITLE
chore: eventOptions  type fix

### DIFF
--- a/src/components/picker-view/wheel.tsx
+++ b/src/components/picker-view/wheel.tsx
@@ -201,10 +201,7 @@ export const Wheel = memo<Props>(
         axis: 'y',
         from: () => [0, y.get()],
         preventDefault: true,
-        eventOptions:
-          (supportsPassive as unknown as AddEventListenerOptions) && {
-            passive: false,
-          },
+        eventOptions: supportsPassive ? { passive: false } : undefined,
       }
     )
 

--- a/src/components/pull-to-refresh/pull-to-refresh.tsx
+++ b/src/components/pull-to-refresh/pull-to-refresh.tsx
@@ -161,9 +161,7 @@ export const PullToRefresh: FC<PullToRefreshProps> = p => {
       axis: 'y',
       target: elementRef,
       enabled: !props.disabled,
-      eventOptions: supportsPassive
-        ? { passive: false }
-        : (false as unknown as AddEventListenerOptions),
+      eventOptions: supportsPassive ? { passive: false } : undefined,
     }
   )
 


### PR DESCRIPTION
原来的 false 用 as unknown 强转到 AddEventListenerOptions 类型是错误的

eventOptions 支持的类型为 AddEventListenerOptions  | undefined

![image](https://github.com/ant-design/ant-design-mobile/assets/77056991/33ad4698-4357-4f06-b60e-25114417d2a5)
