### PR TITLE
fix(Steps): fix the style of indicator line and icon overlap

### DIFF
--- a/src/components/steps/steps.less
+++ b/src/components/steps/steps.less
@@ -20,6 +20,7 @@
       position: absolute;
       z-index: 1;
       color: var(--icon-color);
+      background-color: var(--adm-color-background);
       > .antd-mobile-icon {
         display: block;
       }
@@ -157,6 +158,7 @@
 
 .@{class-prefix-step}-icon-container {
   font-size: var(--icon-size);
+  background-color: var(--adm-color-background);
 }
 
 .@{class-prefix-step}-icon-dot {


### PR DESCRIPTION
修复Steps组件官方demo中引导线和图标重叠问题。
修复方法：图标部分添加背景色而非保持透明。
![image](https://github.com/ant-design/ant-design-mobile/assets/9269277/8b92868b-5370-461b-a701-b557e2053e4e)
