### PR TITLE
doc: add installation instructions for bun

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ $ npm install --save antd-mobile
 $ yarn add antd-mobile
 # or
 $ pnpm add antd-mobile
+# or
+$ bun add antd-mobile
 ```
 
 - **Fast**: It is carefully optimized for harsh scenes, without configuration, you can have the best package size and ultimate performance.

--- a/docs/components/icon/index.en.md
+++ b/docs/components/icon/index.en.md
@@ -8,6 +8,8 @@ npm install --save antd-mobile-icons
 yarn add antd-mobile-icons
 # or
 pnpm add antd-mobile-icons
+# or
+bun add antd-mobile-icons
 ```
 
 Then just import the icons you need from this package:

--- a/docs/components/icon/index.zh.md
+++ b/docs/components/icon/index.zh.md
@@ -8,6 +8,8 @@ npm install --save antd-mobile-icons
 yarn add antd-mobile-icons
 # or
 pnpm add antd-mobile-icons
+# or
+bun add antd-mobile-icons
 ```
 
 然后从这个包中引入你所需要的图标即可：

--- a/docs/guide/quick-start.en.md
+++ b/docs/guide/quick-start.en.md
@@ -8,6 +8,8 @@ $ npm install --save antd-mobile
 $ yarn add antd-mobile
 # or
 $ pnpm add antd-mobile
+# or
+$ bun add antd-mobile
 ```
 
 ## Import

--- a/docs/guide/quick-start.zh.md
+++ b/docs/guide/quick-start.zh.md
@@ -8,6 +8,8 @@ $ npm install --save antd-mobile
 $ yarn add antd-mobile
 # or
 $ pnpm add antd-mobile
+# or
+$ bun add antd-mobile
 ```
 
 ## 引入

--- a/docs/guide/ssr.en.md
+++ b/docs/guide/ssr.en.md
@@ -16,6 +16,8 @@ $ npm install --save-dev next-transpile-modules
 $ yarn add -D next-transpile-modules
 # or
 $ pnpm add -D next-transpile-modules
+# or
+$ bun add -D next-transpile-modules
 ```
 
 Then configure it in `next.config.js`:

--- a/docs/guide/ssr.zh.md
+++ b/docs/guide/ssr.zh.md
@@ -16,6 +16,8 @@ $ npm install --save-dev next-transpile-modules
 $ yarn add -D next-transpile-modules
 # or
 $ pnpm add -D next-transpile-modules
+# or
+$ bun add -D next-transpile-modules
 ```
 
 然后在 `next.config.js` 中进行配置：


### PR DESCRIPTION
This adds instructions for the [`bun`](https://github.com/oven-sh/bun) package manager alongside npm/yarn/pnpm. 