### PR TITLE
fix: (WaterMark) content 设置空值时，控制台存在错误提示

### DIFF
--- a/src/components/water-mark/tests/water-mark.test.tsx
+++ b/src/components/water-mark/tests/water-mark.test.tsx
@@ -58,4 +58,32 @@ describe('WaterMark', () => {
     mockCanvasContext.mockRestore()
     errorSpy.mockRestore()
   })
+
+  test('mount should not set base64Url', () => {
+    let exceeded = false
+
+    const Demo = () => {
+      const divRef = React.useRef<HTMLDivElement>(null)
+
+      React.useLayoutEffect(() => {
+        exceeded = true
+
+        const { style } = divRef.current?.querySelector(
+          '.adm-water-mark'
+        ) as HTMLElement
+
+        expect(style.backgroundImage).toBeFalsy()
+      }, [])
+
+      return (
+        <div ref={divRef}>
+          <WaterMark content='Ant Design Mobile' />
+        </div>
+      )
+    }
+
+    render(<Demo />)
+
+    expect(exceeded).toBeTruthy()
+  })
 })

--- a/src/components/water-mark/tests/water-mark.test.tsx
+++ b/src/components/water-mark/tests/water-mark.test.tsx
@@ -45,20 +45,6 @@ describe('WaterMark', () => {
     expect(getByTestId('mask')).not.toHaveClass(`${classPrefix}-full-page`)
   })
 
-  test('throw error when Canvas is not supported', () => {
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
-    const mockCanvasContext = jest.spyOn(
-      HTMLCanvasElement.prototype,
-      'getContext'
-    )
-    mockCanvasContext.mockReturnValue(null)
-    expect(() => render(<WaterMark />)).toThrow(
-      'Canvas is not supported in the current environment'
-    )
-    mockCanvasContext.mockRestore()
-    errorSpy.mockRestore()
-  })
-
   test('mount should not set base64Url', () => {
     let exceeded = false
 
@@ -85,5 +71,19 @@ describe('WaterMark', () => {
     render(<Demo />)
 
     expect(exceeded).toBeTruthy()
+  })
+
+  test('throw error when Canvas is not supported', () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    const mockCanvasContext = jest.spyOn(
+      HTMLCanvasElement.prototype,
+      'getContext'
+    )
+    mockCanvasContext.mockReturnValue(null)
+    expect(() => render(<WaterMark />)).toThrow(
+      'Canvas is not supported in the current environment'
+    )
+    mockCanvasContext.mockRestore()
+    errorSpy.mockRestore()
   })
 })

--- a/src/components/water-mark/water-mark.tsx
+++ b/src/components/water-mark/water-mark.tsx
@@ -131,7 +131,7 @@ export const WaterMark: FC<WaterMarkProps> = p => {
       style={{
         zIndex,
         backgroundSize: `${gapX + width}px`,
-        backgroundImage: `url('${base64Url}')`,
+        backgroundImage: base64Url === '' ? undefined : `url('${base64Url}')`,
       }}
     />
   )

--- a/src/components/water-mark/water-mark.tsx
+++ b/src/components/water-mark/water-mark.tsx
@@ -131,6 +131,8 @@ export const WaterMark: FC<WaterMarkProps> = p => {
       style={{
         zIndex,
         backgroundSize: `${gapX + width}px`,
+
+        // Not give `url` if its empty. Which will cause 404 error.
         backgroundImage: base64Url === '' ? undefined : `url('${base64Url}')`,
       }}
     />


### PR DESCRIPTION
fix: #6332 
content 设置空值时，background-image: url("");
控制台存在错误提示: 加载404，但不影响使用
```
<WaterMark
    content=""
  />
```
![image](https://github.com/ant-design/ant-design-mobile/assets/31531283/27c4a4f9-b914-4f5f-a2f2-a006aac78301)
content 设置不是空值时，渲染时，也会先渲染background-image: url("");也存在控制台错误提示问题