### PR TITLE
修复SwipeAction按钮点击事件里setState后子组件无法点击的问题

### DIFF
--- a/src/components/swipe-action/swipe-action.tsx
+++ b/src/components/swipe-action/swipe-action.tsx
@@ -246,15 +246,20 @@ export const SwipeAction = forwardRef<SwipeActionRef, SwipeActionProps>(
               }
             }}
           >
-            <animated.div
-              style={{
-                pointerEvents: x.to(v =>
-                  v !== 0 && x.goal !== 0 ? 'none' : 'auto'
-                ),
-              }}
-            >
-              {props.children}
-            </animated.div>
+            {React.useMemo(
+              () => (
+                <animated.div
+                  style={{
+                    pointerEvents: x.to(v =>
+                      v !== 0 && x.goal !== 0 ? 'none' : 'auto'
+                    ),
+                  }}
+                >
+                  {props.children}
+                </animated.div>
+              ),
+              [x, props.children]
+            )}
           </div>
           {withStopPropagation(
             props.stopPropagation,


### PR DESCRIPTION
详情见这个issue
https://github.com/ant-design/ant-design-mobile/issues/6184