### PR TITLE
doc(icon): add margin

### DIFF
--- a/docs/components/icon/demo-all.tsx
+++ b/docs/components/icon/demo-all.tsx
@@ -152,7 +152,7 @@ export default () => {
           return (
             <React.Fragment key={iconType_}>
               {displayedItems[iconType_].length > 0 && (
-                <h3>{nameDic[iconType_]}</h3>
+                <h3 style={{ margin: '18px 0' }}>{nameDic[iconType_]}</h3>
               )}
               <Grid columns={gridColumns}>
                 {displayedItems[iconType_].map(item => (


### PR DESCRIPTION

<img width="698" alt="image" src="https://github.com/ant-design/ant-design-mobile/assets/28420052/c8867e2b-1efd-4a50-96aa-e2d56e6b36c2">



icon组件文档图标展示部分的标题增加上下边距