### PR TITLE
fix(result-page): footer not align to center

### DIFF
--- a/src/components/result-page/result-page.less
+++ b/src/components/result-page/result-page.less
@@ -118,6 +118,7 @@
     justify-content: center;
     background-color: var(--adm-color-box);
     z-index: 3;
+    box-sizing: border-box;
 
     &-btn {
       flex: 1;


### PR DESCRIPTION
## Before

<img width="421" alt="image" src="https://github.com/ant-design/ant-design-mobile/assets/35442047/98e424ce-89d3-4362-bf3d-e33d2337dff2">

## After

<img width="421" alt="image" src="https://github.com/ant-design/ant-design-mobile/assets/35442047/d75f14ee-9a1b-4af8-a219-84d9e3135e83">

@1587315093 Could u have a look?


<!-- insert PR description above -->
-----
<a href="https://stackblitz.com/~/github/kongmoumou/ant-design-mobile/tree/fix-result-style"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz Codeflow" align="left" width="103" height="20"></a> _Submitted with [StackBlitz Codeflow](https://stackblitz.com/~/github/kongmoumou/ant-design-mobile/tree/fix-result-style)._