### PR TITLE
fix(result-page): hide footer when no btn text

### DIFF
--- a/src/components/result-page/result-page.tsx
+++ b/src/components/result-page/result-page.tsx
@@ -116,35 +116,37 @@ export const ResultPage: FC<ResultPageProps> = p => {
 
       <div className={`${classPrefix}-content`}>{props.children}</div>
 
-      <div className={`${classPrefix}-footer`}>
-        {showSecondaryButton && (
-          <Button
-            block
-            color='default'
-            fill='solid'
-            size='large'
-            onClick={onSecondaryButtonClick}
-            className={`${classPrefix}-footer-btn`}
-          >
-            {secondaryButtonText}
-          </Button>
-        )}
-        {showPrimaryButton && showSecondaryButton && (
-          <div className={`${classPrefix}-footer-space`} />
-        )}
-        {showPrimaryButton && (
-          <Button
-            block
-            color='primary'
-            fill='solid'
-            size='large'
-            onClick={onPrimaryButtonClick}
-            className={`${classPrefix}-footer-btn`}
-          >
-            {primaryButtonText}
-          </Button>
-        )}
-      </div>
+      {(showPrimaryButton || showSecondaryButton) && (
+        <div className={`${classPrefix}-footer`}>
+          {showSecondaryButton && (
+            <Button
+              block
+              color='default'
+              fill='solid'
+              size='large'
+              onClick={onSecondaryButtonClick}
+              className={`${classPrefix}-footer-btn`}
+            >
+              {secondaryButtonText}
+            </Button>
+          )}
+          {showPrimaryButton && showSecondaryButton && (
+            <div className={`${classPrefix}-footer-space`} />
+          )}
+          {showPrimaryButton && (
+            <Button
+              block
+              color='primary'
+              fill='solid'
+              size='large'
+              onClick={onPrimaryButtonClick}
+              className={`${classPrefix}-footer-btn`}
+            >
+              {primaryButtonText}
+            </Button>
+          )}
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
Currently, result page footer would show even when secondaryButtonText and primaryButtonText are both empty, like screenshot below ⬇️. The fixed empty footer would cover other element unexpectedly.

<img width="1087" alt="image" src="https://github.com/ant-design/ant-design-mobile/assets/35442047/a34af2a7-d0e1-4811-9267-f9bff5236dbd">
