### PR TITLE
chore: type and code optimize

### DIFF
--- a/src/components/image-viewer/image-viewer.tsx
+++ b/src/components/image-viewer/image-viewer.tsx
@@ -50,9 +50,7 @@ export const ImageViewer: FC<ImageViewerProps> = p => {
         {props.image && (
           <Slide
             image={props.image}
-            onTap={() => {
-              props.onClose?.()
-            }}
+            onTap={props.onClose}
             maxZoom={props.maxZoom}
           />
         )}
@@ -123,9 +121,7 @@ export const MultiImageViewer = forwardRef<
             defaultIndex={index}
             onIndexChange={onSlideChange}
             images={props.images}
-            onTap={() => {
-              props.onClose?.()
-            }}
+            onTap={props.onClose}
             maxZoom={props.maxZoom}
           />
         )}

--- a/src/components/image-viewer/slide.tsx
+++ b/src/components/image-viewer/slide.tsx
@@ -12,7 +12,7 @@ const classPrefix = `adm-image-viewer`
 type Props = {
   image: string
   maxZoom: number | 'auto'
-  onTap: () => void
+  onTap?: () => void
   onZoomChange?: (zoom: number) => void
   dragLockRef?: MutableRefObject<boolean>
 }
@@ -176,7 +176,7 @@ export const Slide: FC<Props> = props => {
 
         if (state.tap && state.elapsedTime > 0 && state.elapsedTime < 1000) {
           // 判断点击时间>0是为了过滤掉非正常操作，例如用户长按选择图片之后的取消操作（也是一次点击）
-          props.onTap()
+          props.onTap?.()
           return
         }
         const currentZoom = mat.getScaleX(matrix.get())
@@ -281,7 +281,6 @@ export const Slide: FC<Props> = props => {
     {
       target: controlRef,
       drag: {
-        // filterTaps: true,
         from: () => [
           mat.getTranslateX(matrix.get()),
           mat.getTranslateY(matrix.get()),

--- a/src/components/image-viewer/slides.tsx
+++ b/src/components/image-viewer/slides.tsx
@@ -9,7 +9,7 @@ const classPrefix = `adm-image-viewer`
 
 export type SlidesType = {
   images: string[]
-  onTap: () => void
+  onTap?: () => void
   maxZoom: number
   defaultIndex: number
   onIndexChange?: (index: number) => void
@@ -67,12 +67,10 @@ export const Slides = forwardRef<SlidesRef, SlidesType>((props, ref) => {
     {
       transform: ([x, y]) => [-x, y],
       from: () => [x.get(), 0],
-      bounds: () => {
-        return {
-          left: 0,
-          right: (count - 1) * slideWidth,
-        }
-      },
+      bounds: () => ({
+        left: 0,
+        right: (count - 1) * slideWidth,
+      }),
       rubberband: true,
       axis: 'x',
       pointer: { touch: true },


### PR DESCRIPTION
`onTap` 由 image-viewer.tsx 入口的 `props.onClose` 传递进去赋值。

但 `onTap` 的类型为 onTap: () => void 而 `props.onClose` 为 onTap?: () => void 是可选的

为了兼容必传类型的 `onTap` ，image-viewer 传递是 写法是传递了个函数，然后在里面执行 props.onClose?.()，感觉可以修改一下类型和传递源一致