### PR TITLE
fix: license field is missing on npmjs.com #6392

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "antd-mobile",
   "version": "5.32.4",
+  "license": "MIT",
   "scripts": {
     "start": "dumi dev",
     "build": "gulp",


### PR DESCRIPTION
fix #6392