### PR TITLE
fix: for inconsistent switch width changes

### DIFF
--- a/src/components/switch/switch.less
+++ b/src/components/switch/switch.less
@@ -72,7 +72,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    margin: 0 8px 0 calc(var(--height) - var(--border-width) + 4px);
+    margin: 0 8px 0 calc(var(--height) - var(--border-width) + 5px);
     height: 100%;
     color: var(--adm-color-weak);
     transition: margin 200ms;
@@ -92,7 +92,7 @@
     }
 
     .@{class-prefix-switch}-inner {
-      margin: 0 calc(var(--height) - var(--border-width) + 5px) 0 10px;
+      margin: 0 calc(var(--height) - var(--border-width) + 5px) 0 8px;
       color: var(--adm-color-text-light-solid);
     }
   }


### PR DESCRIPTION
resolved: #6418


原因是 两个class 的 margin 数值不一致的问题

修复前的margin： 开状态 0 34px 0 10px。 关状态： 0 8px 0 33px

修复后的margin： 开状态 0 34px 0 8px。 关状态： 0 8px 0 34px



