### PR TITLE
Optional `locale` props in `ConfigProvider`

### DIFF
--- a/src/components/config-provider/config-provider.tsx
+++ b/src/components/config-provider/config-provider.tsx
@@ -26,7 +26,7 @@ export function getDefaultConfig() {
 
 const ConfigContext = React.createContext<Config | null>(null)
 
-export type ConfigProviderProps = Config
+export type ConfigProviderProps = Omit<Config, 'locale'> & { locale?: Locale }
 
 export const ConfigProvider: FC<ConfigProviderProps> = props => {
   const { children, ...config } = props


### PR DESCRIPTION
Because the `locale` attribute has default corpus settings, in order to simplify the use of `ConfigProvider`, the `locale` attribute can be made optional.