### PR TITLE
fix(VirtualInput): should not  block of long press

### DIFF
--- a/src/components/number-keyboard/number-keyboard.tsx
+++ b/src/components/number-keyboard/number-keyboard.tsx
@@ -229,6 +229,10 @@ export const NumberKeyboard: FC<NumberKeyboardProps> = p => {
                     onKeyPress(e, 'BACKSPACE')
                     onBackspacePressEnd()
                   }}
+                  onContextMenu={e => {
+                    // Long press should not trigger native context menu
+                    e.preventDefault()
+                  }}
                   title='BACKSPACE'
                   role='grid'
                   tabIndex={-1}

--- a/src/components/virtual-input/virtual-input.tsx
+++ b/src/components/virtual-input/virtual-input.tsx
@@ -107,6 +107,11 @@ export const VirtualInput = forwardRef<VirtualInputRef, VirtualInputProps>(
         },
         visible: hasFocus,
         onClose: () => {
+          // Long press the delete button to close the keyboard, the focus will be lost
+          // We need to focus the input element again first
+          rootRef.current?.focus()
+
+          // Then we can close the keyboard
           rootRef.current?.blur()
           keyboard.props.onClose?.()
         },


### PR DESCRIPTION
长按后聚焦元素不在 root 上，关闭逻辑里加一个聚焦让它可以正确触发。

close #6474