### PR TITLE
fix: resolve where measuring elements would cause the browser to print an extra blank page

### DIFF
--- a/src/global/global.less
+++ b/src/global/global.less
@@ -45,8 +45,8 @@ div.adm-px-tester {
   height: calc(var(--size) / 2 * 2px);
   width: 0;
   position: fixed;
-  right: -100vw;
-  bottom: -100vh;
+  left: -100vw;
+  top: -100vh;
   user-select: none;
   pointer-events: none;
 }


### PR DESCRIPTION
resolve #6487

修复测量元素会导致浏览器打印多出一个空白页的问题。