### PR TITLE
feat: extend CSS for selector-item to support text overflow

### DIFF
--- a/src/components/selector/selector.less
+++ b/src/components/selector/selector.less
@@ -41,6 +41,8 @@
     text-align: center;
     overflow: hidden;
     vertical-align: top;
+    white-space: nowrap;
+    text-overflow: ellipsis;
 
     &-description {
       font-size: var(--adm-font-size-main);


### PR DESCRIPTION
### problem

Items of selector  have different height leading looks like very strange with the layout 

selector的内容会换行会导致布局看起来很怪

### resolution

i think selector should have an ability with boundary processing , so items of selector will not have different height 

我认为selector组件应该具有边界处理的能力，这样布局能拥有一致性.

**Compared**：
<img width="1437" alt="image" src="https://github.com/ant-design/ant-design-mobile/assets/68573559/457f8146-381b-45e3-af9d-484ee0bf11ce">
<img width="1435" alt="image" src="https://github.com/ant-design/ant-design-mobile/assets/68573559/e495a3bd-7540-4623-a1a2-4f040f83f100">



