### PR TITLE
Update text-area.less

### DIFF
--- a/src/components/text-area/text-area.less
+++ b/src/components/text-area/text-area.less
@@ -60,10 +60,6 @@
     display: none;
   }
 
-  &[readonly] {
-    pointer-events: none;
-  }
-
   &-hidden {
     visibility: hidden;
     position: absolute;


### PR DESCRIPTION
删除 readonly pointer-events:none属性，解决 readonly状态下，超出不可滚动问题

fix #6508