### PR TITLE
feat: `TextArea` add `setSelectionRange `

### DIFF
--- a/src/components/text-area/index.en.md
+++ b/src/components/text-area/index.en.md
@@ -41,9 +41,10 @@ In addition, the following native attributes are supported: `autoComplete` `auto
 
 ### Ref
 
-| Name | Description | Type |
-| --- | --- | --- |
-| blur | Let the input box lose focus | `() => void` |
-| clear | Clear the input content | `() => void` |
-| focus | Let the input box get focus | `() => void` |
-| nativeElement | Native text-area element | `HTMLTextAreaElement` \| `null` |
+| Name | Description | Type | Version |
+| --- | --- | --- | --- |
+| blur | Let the input box lose focus | `() => void` | - |
+| clear | Clear the input content | `() => void` | - |
+| focus | Let the input box get focus | `() => void` | - |
+| setSelectionRange | sets the start and end positions of the current text selection | `(startPos: number, endPos: number) => void` | 5.34.1 |
+| nativeElement | Native text-area element | `HTMLTextAreaElement` \| `null` | - |

--- a/src/components/text-area/index.zh.md
+++ b/src/components/text-area/index.zh.md
@@ -41,9 +41,10 @@
 
 ### Ref
 
-| 属性          | 说明                | 类型                            |
-| ------------- | ------------------- | ------------------------------- |
-| blur          | 让输入框失去焦点    | `() => void`                    |
-| clear         | 清空输入内容        | `() => void`                    |
-| focus         | 让输入框获得焦点    | `() => void`                    |
-| nativeElement | 原始 text-area 元素 | `HTMLTextAreaElement` \| `null` |
+| 属性 | 说明 | 类型 | Version |
+| --- | --- | --- | --- |
+| blur | 让输入框失去焦点 | `() => void` | - |
+| clear | 清空输入内容 | `() => void` | - |
+| focus | 让输入框获得焦点 | `() => void` | - |
+| setSelectionRange | 设定当前选中文本的起始和结束位置 | `(startPos: number, endPos: number) => void` | 5.34.1 |
+| nativeElement | 原始 text-area 元素 | `HTMLTextAreaElement` \| `null` | - |

--- a/src/components/text-area/tests/text-area.test.tsx
+++ b/src/components/text-area/tests/text-area.test.tsx
@@ -101,6 +101,12 @@ describe('TextArea', () => {
 
     fireEvent.change(textarea, { target: { value: 'abc' } })
     expect(textarea.value).toBe('abc')
+    ref.current?.setSelectionRange(0, 2)
+    expect(textarea.selectionStart).toBe(0)
+    expect(textarea.selectionEnd).toBe(2)
+    ref.current?.setSelectionRange(1, 1)
+    expect(textarea.selectionStart).toBe(1)
+    expect(textarea.selectionEnd).toBe(1)
     act(() => ref.current?.clear())
     expect(textarea.value).toBe('')
     expect(ref.current?.nativeElement).toBeDefined()

--- a/src/components/text-area/text-area.tsx
+++ b/src/components/text-area/text-area.tsx
@@ -52,6 +52,7 @@ export type TextAreaRef = {
   clear: () => void
   focus: () => void
   blur: () => void
+  setSelectionRange: (startPos: number, endPos: number) => void
   nativeElement: HTMLTextAreaElement | null
 }
 
@@ -92,7 +93,7 @@ export const TextArea = forwardRef<TextAreaRef, TextAreaProps>(
       blur: () => {
         nativeTextAreaRef.current?.blur()
       },
-      setSelectionRange: (startPos: number, endPos: number) => {
+      setSelectionRange: (startPos, endPos) => {
         nativeTextAreaRef.current?.setSelectionRange(startPos, endPos)
       },
       get nativeElement() {

--- a/src/components/text-area/text-area.tsx
+++ b/src/components/text-area/text-area.tsx
@@ -92,6 +92,9 @@ export const TextArea = forwardRef<TextAreaRef, TextAreaProps>(
       blur: () => {
         nativeTextAreaRef.current?.blur()
       },
+      setSelectionRange: (startPos: number, endPos: number) => {
+        nativeTextAreaRef.current?.setSelectionRange(startPos, endPos)
+      },
       get nativeElement() {
         return nativeTextAreaRef.current
       },


### PR DESCRIPTION


Background:  In my project, there is a need to insert some characters into a textarea using JavaScript. Currently, the `TextArea` component doesn't provide the [setSelectionRange](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/setSelectionRange) method, which results in the cursor not being positioned after the inserted characters. This leads to a poor user input experience. Therefore, in this PR, I have added this method.