### PR TITLE
替换 lodash/memoize 为 nano-memoize

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "classnames": "^2.3.2",
     "dayjs": "^1.11.7",
     "lodash": "^4.17.21",
+    "nano-memoize": "^3.0.16",
     "rc-field-form": "~1.27.4",
     "rc-util": "^5.38.1",
     "react-is": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "nano-memoize": "^3.0.16",
     "rc-field-form": "~1.27.4",
     "rc-util": "^5.38.1",
+    "react-fast-compare": "^3.2.2",
     "react-is": "^18.2.0",
     "runes2": "^1.1.2",
     "staged-components": "^1.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ dependencies:
   lodash:
     specifier: ^4.17.21
     version: 4.17.21
+  nano-memoize:
+    specifier: ^3.0.16
+    version: 3.0.16
   rc-field-form:
     specifier: ~1.27.4
     version: 1.27.4(react-dom@18.2.0)(react@18.2.0)
@@ -12594,6 +12597,10 @@ packages:
     dev: true
     optional: true
 
+  /nano-memoize@3.0.16:
+    resolution: {integrity: sha512-JyK96AKVGAwVeMj3MoMhaSXaUNqgMbCRSQB3trUV8tYZfWEzqUBKdK1qJpfuNXgKeHOx1jv/IEYTM659ly7zUA==}
+    dev: false
+
   /nanoid@2.1.11:
     resolution: {integrity: sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==}
     dev: true
@@ -15189,6 +15196,7 @@ packages:
       react: 16.14.0
       scheduler: 0.19.1
     dev: true
+    bundledDependencies: false
 
   /react-dom@18.2.0(react@18.2.0):
     resolution: {integrity: sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==}
@@ -15418,6 +15426,7 @@ packages:
       object-assign: 4.1.1
       prop-types: 15.8.1
     dev: true
+    bundledDependencies: false
 
   /react@18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ dependencies:
   rc-util:
     specifier: ^5.38.1
     version: 5.38.1(react-dom@18.2.0)(react@18.2.0)
+  react-fast-compare:
+    specifier: ^3.2.2
+    version: 3.2.2
   react-is:
     specifier: ^18.2.0
     version: 18.2.0
@@ -15219,7 +15222,6 @@ packages:
 
   /react-fast-compare@3.2.2:
     resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
-    dev: true
 
   /react-helmet@6.1.0(react@18.2.0):
     resolution: {integrity: sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==}

--- a/src/components/cascader-view/use-cascader-value-extend.tsx
+++ b/src/components/cascader-view/use-cascader-value-extend.tsx
@@ -1,8 +1,8 @@
 import { useMemo } from 'react'
+import isEqual from 'react-fast-compare'
 import memoize from 'nano-memoize'
 import { CascaderValue, CascaderValueExtend } from './cascader-view'
 import type { CascaderOption } from './cascader-view'
-import isEqual from 'react-fast-compare'
 
 export function useCascaderValueExtend(
   options: CascaderOption[],

--- a/src/components/cascader-view/use-cascader-value-extend.tsx
+++ b/src/components/cascader-view/use-cascader-value-extend.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 import memoize from 'nano-memoize'
 import { CascaderValue, CascaderValueExtend } from './cascader-view'
 import type { CascaderOption } from './cascader-view'
+import isEqual from 'react-fast-compare'
 
 export function useCascaderValueExtend(
   options: CascaderOption[],
@@ -28,7 +29,7 @@ export function useCascaderValueExtend(
         return ret
       },
       {
-        serializer: JSON.stringify,
+        equals: isEqual,
       }
     )
   }, [options])
@@ -47,7 +48,7 @@ export function useCascaderValueExtend(
         return children.length === 0
       },
       {
-        serializer: JSON.stringify,
+        equals: isEqual,
       }
     )
   }, [options])

--- a/src/components/cascader-view/use-cascader-value-extend.tsx
+++ b/src/components/cascader-view/use-cascader-value-extend.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import memoize from 'lodash/memoize'
+import memoize from 'nano-memoize'
 import { CascaderValue, CascaderValueExtend } from './cascader-view'
 import type { CascaderOption } from './cascader-view'
 
@@ -27,7 +27,9 @@ export function useCascaderValueExtend(
 
         return ret
       },
-      val => JSON.stringify(val)
+      {
+        serializer: JSON.stringify,
+      }
     )
   }, [options])
 
@@ -44,7 +46,9 @@ export function useCascaderValueExtend(
 
         return children.length === 0
       },
-      val => JSON.stringify(val)
+      {
+        serializer: JSON.stringify,
+      }
     )
   }, [options])
 


### PR DESCRIPTION
## 打包体积比较（越小越好）

```
lodash/memoize: Bundle size is 6.58 kB -> 2.67 kB (gzip) 
  nano-memoize: Bundle size is 1.12 kB -> 505 B (gzip)
```

数据来源 <https://bundlejs.com/>

## 性能比较（ops/sec越多越好）

```
lodash/memoize:  54,617,110 ops/sec
  nano-memoize: 177,773,071 ops/sec
```

数据来源 <https://github.com/anywhichway/nano-memoize#benchmarks>

相比 lodash/memoize, nano-memoize 在体积和性能上都更有优势。