### PR TITLE
refactor: replace lodash/isEqual with react-fast-compare

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "lodash": "^4.17.21",
     "rc-field-form": "~1.27.4",
     "rc-util": "^5.38.1",
+    "react-fast-compare": "^3.2.2",
     "react-is": "^18.2.0",
     "runes2": "^1.1.2",
     "staged-components": "^1.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ dependencies:
   rc-util:
     specifier: ^5.38.1
     version: 5.38.1(react-dom@18.2.0)(react@18.2.0)
+  react-fast-compare:
+    specifier: ^3.2.2
+    version: 3.2.2
   react-is:
     specifier: ^18.2.0
     version: 18.2.0
@@ -15189,6 +15192,7 @@ packages:
       react: 16.14.0
       scheduler: 0.19.1
     dev: true
+    bundledDependencies: false
 
   /react-dom@18.2.0(react@18.2.0):
     resolution: {integrity: sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==}
@@ -15211,7 +15215,6 @@ packages:
 
   /react-fast-compare@3.2.2:
     resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
-    dev: true
 
   /react-helmet@6.1.0(react@18.2.0):
     resolution: {integrity: sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==}
@@ -15418,6 +15421,7 @@ packages:
       object-assign: 4.1.1
       prop-types: 15.8.1
     dev: true
+    bundledDependencies: false
 
   /react@18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}

--- a/src/components/picker-view/wheel.tsx
+++ b/src/components/picker-view/wheel.tsx
@@ -10,7 +10,7 @@ import {
 import { rubberbandIfOutOfBounds } from '../../utils/rubberband'
 import { bound } from '../../utils/bound'
 import { PickerColumnItem, PickerValue } from './index'
-import isEqual from 'lodash/isEqual'
+import isEqual from 'react-fast-compare'
 import { useIsomorphicLayoutEffect } from 'ahooks'
 import { measureCSSLength } from '../../utils/measure-css-length'
 import { supportsPassive } from '../../utils/supports-passive'


### PR DESCRIPTION
## 打包体积比较（越小越好）

```
    lodash/isEqual: Bundle size is 16.4 kB -> 6.4 kB (gzip)
react-fast-compare: Bundle size is 2.34 kB -> 925 B (gzip)
```

数据来源 <https://bundlejs.com/>

## 性能比较（ops/sec越多越好）

![图片](https://github.com/ant-design/ant-design-mobile/assets/5836790/0a77226c-c29e-4be6-ae49-2b1bcb145317)

数据来源 <https://www.npmjs.com/package/react-fast-compare>

相比 lodash/isEqual, react-fast-compare 在体积和性能上都更有优势。