### PR TITLE
refactor: @rc-component/mini-decimal -> big.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,12 +17,12 @@
   },
   "dependencies": {
     "@floating-ui/dom": "^1.4.2",
-    "@rc-component/mini-decimal": "^1.1.0",
     "@react-spring/web": "~9.6.1",
     "@use-gesture/react": "10.3.0",
     "ahooks": "^3.7.6",
     "antd-mobile-icons": "^0.3.0",
     "antd-mobile-v5-count": "^1.0.1",
+    "big.js": "^6.2.1",
     "classnames": "^2.3.2",
     "dayjs": "^1.11.7",
     "lodash": "^4.17.21",

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -4,7 +4,7 @@ import { NativeProps, withNativeProps } from '../../utils/native-props'
 import classNames from 'classnames'
 import Ticks from './ticks'
 import Marks, { SliderMarks } from './marks'
-import getMiniDecimal, { toFixed } from '@rc-component/mini-decimal'
+import Big from 'big.js'
 import Thumb from './thumb'
 import { mergeProps } from '../../utils/with-default-props'
 import { nearest } from '../../utils/nearest'
@@ -54,10 +54,10 @@ export const Slider: FC<SliderProps> = p => {
     return (props.range ? value : [props.min, value]) as any
   }
   function alignValue(value: number, decimalLen: number) {
-    const decimal = getMiniDecimal(value)
-    const fixedStr = toFixed(decimal.toString(), '.', decimalLen)
+    const decimal = Big(value)
+    const fixedStr = decimal.toFixed(decimalLen)
 
-    return getMiniDecimal(fixedStr).toNumber()
+    return Big(fixedStr).toNumber()
   }
 
   function reverseValue(value: [number, number]): SliderValue {
@@ -114,11 +114,7 @@ export const Slider: FC<SliderProps> = p => {
         .sort((a, b) => a - b)
     } else if (ticks) {
       const points: number[] = []
-      for (
-        let i = getMiniDecimal(min);
-        i.lessEquals(getMiniDecimal(max));
-        i = i.add(step)
-      ) {
+      for (let i = Big(min); i.lte(Big(max)); i = i.add(step)) {
         points.push(i.toNumber())
       }
       return points
@@ -138,8 +134,8 @@ export const Slider: FC<SliderProps> = p => {
     } else {
       // 使用 MiniDecimal 避免精度问题
       const cell = Math.round((newPosition - min) / step)
-      const nextVal = getMiniDecimal(cell).multi(step)
-      value = getMiniDecimal(min).add(nextVal.toString()).toNumber()
+      const nextVal = Big(cell).mul(step)
+      value = Big(min).add(nextVal).toNumber()
     }
     return value
   }


### PR DESCRIPTION
在应用中使用到 big.js 的可能性很高，如果 ADM 也是用 big.js 则有很大概率能够减小最终产物的体积。big.js 已经迭代了非常多的版本，相对来说更加可靠。而 @rc-component/mini-decimal 相对维护的并不是很活跃，也缺乏文档。