### PR TITLE
fix: createErrorBlock will lost the style cause treeshaking

### DIFF
--- a/src/components/error-block/create-error-block.tsx
+++ b/src/components/error-block/create-error-block.tsx
@@ -5,6 +5,7 @@ import { mergeProps } from '../../utils/with-default-props'
 import { NativeProps, withNativeProps } from '../../utils/native-props'
 import { useConfig } from '../config-provider'
 import type { ErrorBlockStatus, ImageRecord } from '.'
+import './error-block.less'
 
 const classPrefix = `adm-error-block`
 

--- a/src/components/error-block/index.ts
+++ b/src/components/error-block/index.ts
@@ -1,4 +1,3 @@
-import './error-block.less'
 import type { ReactNode } from 'react'
 import { ErrorBlock } from './error-block'
 


### PR DESCRIPTION
Reproduce:

```shell
mkdir test-app
pnpm pnpm dlx create-umi@latest
cd test-app
```

```tsx
// copy to ./src/pages/index.tsx
import { defaultImage } from 'antd-mobile/es/components/error-block/images';
import { createErrorBlock } from 'antd-mobile';

export const CustomErrorBlock = createErrorBlock({
  default: defaultImage,
  empty: 'https://example.img',
});


export default function HomePage() {
  return (
    <div>
      <CustomErrorBlock
        title="test"
      />
    </div>
  );
}

```
```shell
pnpm build
```
 `.adm-error-block` is not found in dist css
but pnpm dev is correct




