### PR TITLE
refactor: semantic font size variables

### DIFF
--- a/src/components/action-sheet/action-sheet.less
+++ b/src/components/action-sheet/action-sheet.less
@@ -12,7 +12,7 @@
     display: flex;
     justify-content: center;
     color: var(--adm-color-weak);
-    font-size: var(--adm-font-size-7);
+    font-size: var(--adm-font-size-large);
     padding: 18px 12px;
     border-bottom: 1px solid var(--adm-color-border);
   }
@@ -40,10 +40,10 @@
     }
     &-name {
       color: var(--adm-color-text);
-      font-size: var(--adm-font-size-10);
+      font-size: var(--adm-font-size-huge);
     }
     &-description {
-      font-size: var(--adm-font-size-6);
+      font-size: var(--adm-font-size-main);
       color: var(--adm-color-weak);
       padding-top: 4px;
     }

--- a/src/components/badge/badge.less
+++ b/src/components/badge/badge.less
@@ -20,7 +20,7 @@
     box-sizing: border-box;
     min-width: 8px;
     padding: 1px 4px;
-    font-size: var(--adm-font-size-1);
+    font-size: var(--adm-font-size-tiny);
     line-height: 12px;
     white-space: nowrap;
     font-weight: normal;

--- a/src/components/button/button.less
+++ b/src/components/button/button.less
@@ -21,7 +21,7 @@
   height: auto;
   padding: 7px 12px;
   margin: 0;
-  font-size: var(--adm-font-size-9);
+  font-size: var(--adm-font-size-huge);
   line-height: 1.4;
   text-align: center;
   border: var(--border-width) var(--border-style) var(--border-color);
@@ -117,12 +117,12 @@
   &&-small {
     padding-top: 3px;
     padding-bottom: 3px;
-    font-size: var(--adm-font-size-7);
+    font-size: var(--adm-font-size-large);
   }
   &&-large {
     padding-top: 11px;
     padding-bottom: 11px;
-    font-size: var(--adm-font-size-10);
+    font-size: var(--adm-font-size-huge);
   }
   &&-shape-rounded {
     --border-radius: 1000px;

--- a/src/components/calendar-picker-view/calendar-picker-view.less
+++ b/src/components/calendar-picker-view/calendar-picker-view.less
@@ -3,7 +3,7 @@
 .adm-calendar-picker-popup {
   & &-title {
     flex: auto;
-    font-size: var(--adm-font-size-10);
+    font-size: var(--adm-font-size-huge);
   }
 
   & &-header {
@@ -115,13 +115,13 @@
     & &-date {
       flex: none;
       line-height: 22px;
-      font-size: var(--adm-font-size-8);
+      font-size: var(--adm-font-size-large);
     }
 
     & &-top,
     & &-bottom {
       flex: none;
-      font-size: var(--adm-font-size-1);
+      font-size: var(--adm-font-size-tiny);
       height: 14px;
       line-height: 14px;
       color: var(--adm-color-weak);
@@ -136,7 +136,7 @@
     border-bottom: solid 1px var(--adm-color-border);
     height: 45px;
     box-sizing: border-box;
-    font-size: var(--adm-font-size-6);
+    font-size: var(--adm-font-size-main);
     padding: 0 8px;
 
     & &-cell {

--- a/src/components/calendar/calendar.less
+++ b/src/components/calendar/calendar.less
@@ -19,7 +19,7 @@
       }
     }
     .adm-calendar-title {
-      font-size: var(--adm-font-size-10);
+      font-size: var(--adm-font-size-huge);
       flex: auto;
       text-align: center;
     }
@@ -82,11 +82,11 @@
     justify-content: flex-end;
     & &-top {
       flex: none;
-      font-size: var(--adm-font-size-10);
+      font-size: var(--adm-font-size-huge);
     }
     & &-bottom {
       flex: none;
-      font-size: var(--adm-font-size-4);
+      font-size: var(--adm-font-size-small);
       height: 12px;
       line-height: 12px;
       color: var(--adm-color-weak);
@@ -101,7 +101,7 @@
     border-bottom: solid 1px var(--adm-color-border);
     height: 45px;
     box-sizing: border-box;
-    font-size: var(--adm-font-size-7);
+    font-size: var(--adm-font-size-large);
     padding: 0 8px;
     & &-cell {
       flex: 1;

--- a/src/components/capsule-tabs/capsule-tabs.less
+++ b/src/components/capsule-tabs/capsule-tabs.less
@@ -33,7 +33,7 @@
     margin: 0 auto;
     border-radius: 20px;
     cursor: pointer;
-    font-size: var(--adm-font-size-7);
+    font-size: var(--adm-font-size-large);
     text-align: center;
     white-space: nowrap;
     background-color: var(--adm-color-fill-content);

--- a/src/components/card/card.less
+++ b/src/components/card/card.less
@@ -15,7 +15,7 @@
       border-bottom: solid 0.5px var(--adm-color-border);
     }
     &-title {
-      font-size: var(--adm-font-size-7);
+      font-size: var(--adm-font-size-large);
       line-height: 1.4;
       font-weight: bold;
     }

--- a/src/components/cascader-view/cascader-view.less
+++ b/src/components/cascader-view/cascader-view.less
@@ -3,7 +3,7 @@
 
   &-tabs {
     &.adm-tabs {
-      --title-font-size: var(--adm-font-size-6);
+      --title-font-size: var(--adm-font-size-main);
       --content-padding: none;
     }
   }
@@ -28,7 +28,7 @@
   }
 
   &-item {
-    font-size: var(--adm-font-size-6);
+    font-size: var(--adm-font-size-main);
 
     &-active {
       color: var(--adm-color-primary);

--- a/src/components/cascader/cascader.less
+++ b/src/components/cascader/cascader.less
@@ -15,13 +15,13 @@
   align-items: center;
   padding: 6px 8px;
   &-button {
-    font-size: var(--adm-font-size-7);
+    font-size: var(--adm-font-size-large);
     display: inline-block;
     padding: 4px 4px;
   }
   &-title {
     padding: 4px 4px;
-    font-size: var(--adm-font-size-7);
+    font-size: var(--adm-font-size-large);
     color: var(--adm-color-text);
     text-align: center;
     flex: 1;

--- a/src/components/check-list/check-list.less
+++ b/src/components/check-list/check-list.less
@@ -1,6 +1,6 @@
 .adm-check-list-item {
   &-extra {
-    font-size: var(--adm-font-size-10);
+    font-size: var(--adm-font-size-huge);
     line-height: 1;
     color: var(--adm-color-primary);
   }

--- a/src/components/checkbox/checkbox.less
+++ b/src/components/checkbox/checkbox.less
@@ -2,7 +2,7 @@
 
 .@{class-prefix-checkbox} {
   --icon-size: 22px;
-  --font-size: var(--adm-font-size-9);
+  --font-size: var(--adm-font-size-huge);
   --gap: 8px;
   display: inline-flex;
   vertical-align: text-bottom;

--- a/src/components/dialog/dialog.less
+++ b/src/components/dialog/dialog.less
@@ -12,7 +12,7 @@
 .@{class-prefix-dialog}-body {
   width: 100%;
   max-height: 70vh;
-  font-size: var(--adm-font-size-6);
+  font-size: var(--adm-font-size-main);
   overflow: hidden;
 
   display: flex;
@@ -41,7 +41,7 @@
   margin-bottom: 8px;
   padding: 0 12px;
   font-weight: bold;
-  font-size: var(--adm-font-size-10);
+  font-size: var(--adm-font-size-huge);
   line-height: 25px;
   text-align: center;
 }
@@ -50,7 +50,7 @@
   max-height: 70vh;
   overflow-x: hidden;
   overflow-y: auto;
-  font-size: var(--adm-font-size-7);
+  font-size: var(--adm-font-size-large);
   line-height: 1.4;
   color: var(--adm-color-text);
   &-empty {
@@ -69,7 +69,7 @@
     }
     > .adm-dialog-button {
       padding: 10px;
-      font-size: var(--adm-font-size-10);
+      font-size: var(--adm-font-size-huge);
       line-height: 25px;
       border-radius: 0;
       &-bold {

--- a/src/components/empty/empty.less
+++ b/src/components/empty/empty.less
@@ -19,7 +19,7 @@
 
   &-description {
     margin-top: 8px;
-    font-size: var(--adm-font-size-6);
+    font-size: var(--adm-font-size-main);
     color: var(--adm-color-light);
   }
 }

--- a/src/components/error-block/error-block.less
+++ b/src/components/error-block/error-block.less
@@ -25,12 +25,12 @@
   }
 
   &-description {
-    font-size: var(--adm-font-size-4);
+    font-size: var(--adm-font-size-small);
     color: var(--adm-color-weak);
     line-height: 1.4;
     margin-top: 12px;
     &-title {
-      font-size: var(--adm-font-size-7);
+      font-size: var(--adm-font-size-large);
     }
     &-subtitle {
       margin-top: 8px;

--- a/src/components/error-block/error-block.patch.less
+++ b/src/components/error-block/error-block.patch.less
@@ -7,9 +7,9 @@
   }
 
   &-description {
-    font-size: var(--adm-font-size-4);
+    font-size: var(--adm-font-size-small);
     &-title {
-      font-size: var(--adm-font-size-7);
+      font-size: var(--adm-font-size-large);
     }
   }
 

--- a/src/components/form/form-item.less
+++ b/src/components/form/form-item.less
@@ -76,7 +76,7 @@
 
   &&-vertical {
     .adm-form-item-label {
-      font-size: var(--adm-font-size-7);
+      font-size: var(--adm-font-size-large);
       margin-bottom: 4px;
     }
   }

--- a/src/components/image-uploader/image-uploader.less
+++ b/src/components/image-uploader/image-uploader.less
@@ -67,7 +67,7 @@
     &-mask-message {
       display: inline-block;
       padding: 6px 4px;
-      font-size: var(--adm-font-size-4);
+      font-size: var(--adm-font-size-small);
     }
 
     &-image {

--- a/src/components/image-viewer/image-viewer.less
+++ b/src/components/image-viewer/image-viewer.less
@@ -62,6 +62,6 @@
     top: 12px;
     transform: translateX(-50%);
     color: var(--adm-color-border);
-    font-size: var(--adm-font-size-6);
+    font-size: var(--adm-font-size-main);
   }
 }

--- a/src/components/index-bar/index-bar.less
+++ b/src/components/index-bar/index-bar.less
@@ -39,7 +39,7 @@
     z-index: 910;
     overflow: visible;
     color: var(--adm-color-weak);
-    font-size: var(--adm-font-size-4);
+    font-size: var(--adm-font-size-small);
     user-select: none;
     touch-action: none;
 

--- a/src/components/input/input.less
+++ b/src/components/input/input.less
@@ -1,7 +1,7 @@
 @class-prefix-input: ~'adm-input';
 
 .@{class-prefix-input} {
-  --font-size: var(--adm-font-size-9);
+  --font-size: var(--adm-font-size-huge);
   --color: var(--adm-color-text);
   --placeholder-color: var(--adm-color-light);
   --text-align: left;
@@ -105,6 +105,6 @@
   cursor: pointer;
   .antd-mobile-icon {
     display: block;
-    font-size: var(--adm-font-size-7);
+    font-size: var(--adm-font-size-large);
   }
 }

--- a/src/components/jumbo-tabs/jumbo-tabs.less
+++ b/src/components/jumbo-tabs/jumbo-tabs.less
@@ -38,7 +38,7 @@
     margin: 0 auto;
     padding: 12px 0;
     cursor: pointer;
-    font-size: var(--adm-font-size-9);
+    font-size: var(--adm-font-size-huge);
     white-space: nowrap;
     &-title {
       line-height: 24px;

--- a/src/components/list/list.less
+++ b/src/components/list/list.less
@@ -1,5 +1,5 @@
 .adm-list {
-  --header-font-size: var(--adm-font-size-7);
+  --header-font-size: var(--adm-font-size-large);
   --prefix-width: 'auto';
   --prefix-padding-right: 12px;
   --align-items: center;
@@ -9,7 +9,7 @@
   --border-bottom: solid 1px var(--adm-color-border);
   --padding-left: 12px;
   --padding-right: 12px;
-  --font-size: var(--adm-font-size-9);
+  --font-size: var(--adm-font-size-huge);
   --extra-max-width: 70%;
 
   &-header {
@@ -71,7 +71,7 @@
     &-extra {
       flex: none;
       padding-left: 12px;
-      font-size: var(--adm-font-size-7);
+      font-size: var(--adm-font-size-large);
       color: var(--adm-color-weak);
       max-width: var(--extra-max-width);
     }

--- a/src/components/modal/modal.less
+++ b/src/components/modal/modal.less
@@ -12,7 +12,7 @@
 .@{class-prefix-modal}-body {
   width: 100%;
   max-height: 70vh;
-  font-size: var(--adm-font-size-6);
+  font-size: var(--adm-font-size-main);
   overflow: hidden;
 
   display: flex;
@@ -42,7 +42,7 @@
   margin-bottom: 8px;
   padding: 0 12px;
   font-weight: bold;
-  font-size: var(--adm-font-size-10);
+  font-size: var(--adm-font-size-huge);
   line-height: 25px;
   text-align: center;
 }
@@ -51,7 +51,7 @@
   max-height: 70vh;
   overflow-x: hidden;
   overflow-y: auto;
-  font-size: var(--adm-font-size-7);
+  font-size: var(--adm-font-size-large);
   line-height: 1.4;
   color: var(--adm-color-text);
 }
@@ -67,7 +67,7 @@
     --gap-vertical: 20px;
   }
   .adm-modal-button {
-    font-size: var(--adm-font-size-10);
+    font-size: var(--adm-font-size-huge);
     line-height: 25px;
     &:not(.adm-modal-button-primary) {
       padding-top: 0;

--- a/src/components/nav-bar/nav-bar.less
+++ b/src/components/nav-bar/nav-bar.less
@@ -34,7 +34,7 @@
   }
 
   &-left {
-    font-size: var(--adm-font-size-7);
+    font-size: var(--adm-font-size-large);
     display: flex;
     justify-content: flex-start;
     align-items: center;
@@ -43,7 +43,7 @@
   &-title {
     justify-content: center;
     white-space: nowrap;
-    font-size: var(--adm-font-size-10);
+    font-size: var(--adm-font-size-huge);
     padding: 0 12px;
   }
 

--- a/src/components/notice-bar/notice-bar.less
+++ b/src/components/notice-bar/notice-bar.less
@@ -4,8 +4,8 @@
   --background-color: var(--adm-color-weak);
   --border-color: var(--adm-color-weak);
   --text-color: var(--adm-color-text-light-solid);
-  --font-size: var(--adm-font-size-7);
-  --icon-font-size: var(--adm-font-size-10);
+  --font-size: var(--adm-font-size-large);
+  --icon-font-size: var(--adm-font-size-huge);
   --height: 40px;
 
   height: var(--height);
@@ -82,7 +82,7 @@
   }
 
   &-close-icon {
-    font-size: var(--adm-font-size-10);
+    font-size: var(--adm-font-size-huge);
   }
 
   &-wrap {

--- a/src/components/passcode-input/passcode-input.less
+++ b/src/components/passcode-input/passcode-input.less
@@ -21,7 +21,7 @@
     align-items: center;
     justify-content: center;
     box-sizing: border-box;
-    font-size: var(--adm-font-size-10);
+    font-size: var(--adm-font-size-huge);
     width: var(--cell-size);
     height: var(--cell-size);
     background: var(--adm-color-background);

--- a/src/components/picker-view/picker-view.less
+++ b/src/components/picker-view/picker-view.less
@@ -3,7 +3,7 @@
 .@{class-prefix-picker-view} {
   --height: 240px;
   --item-height: 34px;
-  --item-font-size: var(--adm-font-size-8);
+  --item-font-size: var(--adm-font-size-large);
   height: var(--height);
   width: 100%;
   display: flex;

--- a/src/components/picker/picker.less
+++ b/src/components/picker/picker.less
@@ -1,9 +1,9 @@
 @class-prefix-picker: ~'adm-picker';
 
 .@{class-prefix-picker} {
-  --header-button-font-size: var(--adm-font-size-7);
-  --title-font-size: var(--adm-font-size-7);
-  --item-font-size: var(--adm-font-size-8);
+  --header-button-font-size: var(--adm-font-size-large);
+  --title-font-size: var(--adm-font-size-large);
+  --item-font-size: var(--adm-font-size-large);
   --item-height: 34px;
 
   width: 100%;

--- a/src/components/popover/popover.less
+++ b/src/components/popover/popover.less
@@ -41,7 +41,7 @@
     background-clip: padding-box;
     border-radius: 8px;
     box-shadow: 0 0 30px 0 rgba(51, 51, 51, 0.2);
-    font-size: var(--adm-font-size-7);
+    font-size: var(--adm-font-size-large);
     width: max-content;
     min-width: 32px;
     max-width: calc(100vw - 24px);

--- a/src/components/radio/radio.less
+++ b/src/components/radio/radio.less
@@ -2,7 +2,7 @@
 
 .@{class-prefix-radio} {
   --icon-size: 22px;
-  --font-size: var(--adm-font-size-9);
+  --font-size: var(--adm-font-size-huge);
   --gap: 8px;
   display: inline-flex;
   vertical-align: text-bottom;

--- a/src/components/result-page/result-page.less
+++ b/src/components/result-page/result-page.less
@@ -31,7 +31,7 @@
   }
 
   &-title {
-    font-size: var(--adm-font-size-10);
+    font-size: var(--adm-font-size-huge);
     color: var(--adm-color-text-light-solid);
     line-height: 1.4;
     text-align: center;
@@ -40,7 +40,7 @@
   &-description {
     margin-top: 8px;
     margin-bottom: 24px;
-    font-size: var(--adm-font-size-6);
+    font-size: var(--adm-font-size-main);
     color: rgba(255, 255, 255, 0.6);
     line-height: 1.4;
     text-align: center;
@@ -57,7 +57,7 @@
     justify-content: space-between;
     margin-bottom: 5px;
     color: var(--adm-color-text-light-solid);
-    font-size: var(--adm-font-size-6);
+    font-size: var(--adm-font-size-main);
 
     &-bold {
       font-weight: 600;

--- a/src/components/result/result.less
+++ b/src/components/result/result.less
@@ -18,7 +18,7 @@
 
   &-title {
     color: var(--adm-color-text);
-    font-size: var(--adm-font-size-10);
+    font-size: var(--adm-font-size-huge);
     line-height: 1.4;
     text-align: center;
   }

--- a/src/components/search-bar/search-bar.less
+++ b/src/components/search-bar/search-bar.less
@@ -24,7 +24,7 @@
     .adm-search-bar-input-box-icon {
       flex: none;
       color: var(--adm-color-light);
-      font-size: var(--adm-font-size-8);
+      font-size: var(--adm-font-size-large);
     }
     .adm-search-bar-input {
       flex: auto;
@@ -33,7 +33,7 @@
       box-sizing: border-box;
       &.adm-input {
         --placeholder-color: var(---placeholder-color);
-        --font-size: var(--adm-font-size-7);
+        --font-size: var(--adm-font-size-large);
       }
       .adm-input-element {
         line-height: 19px;

--- a/src/components/selector/selector.less
+++ b/src/components/selector/selector.less
@@ -15,7 +15,7 @@
   ---gap-vertical: var(--gap-vertical, var(--gap));
 
   overflow: hidden;
-  font-size: var(--adm-font-size-7);
+  font-size: var(--adm-font-size-large);
   line-height: 1.4;
 
   .adm-space.adm-space {

--- a/src/components/slider/slider.less
+++ b/src/components/slider/slider.less
@@ -82,7 +82,7 @@
     position: relative;
     width: 100%;
     overflow: visible;
-    font-size: var(--adm-font-size-3);
+    font-size: var(--adm-font-size-small);
     height: 11px;
     margin-top: 10px;
   }

--- a/src/components/stepper/stepper.less
+++ b/src/components/stepper/stepper.less
@@ -10,7 +10,7 @@
   --border: none;
   --border-inner: solid 2px transparent;
   --active-border: var(--border);
-  --button-font-size: var(--adm-font-size-7);
+  --button-font-size: var(--adm-font-size-large);
   --button-text-color: var(--adm-color-primary);
   --button-background-color: var(--adm-color-fill-content);
   --button-width: var(--height);

--- a/src/components/steps/steps.less
+++ b/src/components/steps/steps.less
@@ -60,7 +60,7 @@
 
 .@{class-prefix-steps} {
   --title-font-size: var(--adm-font-size-main);
-  --description-font-size: var(--adm-font-size-4);
+  --description-font-size: var(--adm-font-size-small);
   --indicator-margin-right: 0;
   --icon-size: 18px;
 

--- a/src/components/switch/switch.less
+++ b/src/components/switch/switch.less
@@ -76,7 +76,7 @@
     height: 100%;
     color: var(--adm-color-weak);
     transition: margin 200ms;
-    font-size: var(--adm-font-size-7);
+    font-size: var(--adm-font-size-large);
   }
 
   /* 选中状态 */

--- a/src/components/tab-bar/tab-bar.less
+++ b/src/components/tab-bar/tab-bar.less
@@ -31,7 +31,7 @@
   }
 
   &-item-title {
-    font-size: var(--adm-font-size-2);
+    font-size: var(--adm-font-size-tiny);
     line-height: 15px;
     &-with-icon {
       margin-top: 2px;

--- a/src/components/tabs/tabs.less
+++ b/src/components/tabs/tabs.less
@@ -1,7 +1,7 @@
 @class-prefix-tabs: ~'adm-tabs';
 
 .@{class-prefix-tabs} {
-  --title-font-size: var(--adm-font-size-9);
+  --title-font-size: var(--adm-font-size-huge);
   --content-padding: 12px;
   --active-line-height: 2px;
   --active-line-border-radius: var(--active-line-height);

--- a/src/components/tag/tag.less
+++ b/src/components/tag/tag.less
@@ -3,7 +3,7 @@
 .@{class-prefix-tag} {
   --border-radius: var(--adm-tag-border-radius, 2px);
   padding: 2px 4px;
-  font-size: var(--adm-font-size-3);
+  font-size: var(--adm-font-size-small);
   line-height: 1;
   font-weight: normal;
   background: var(--background-color);

--- a/src/components/text-area/text-area.less
+++ b/src/components/text-area/text-area.less
@@ -1,5 +1,5 @@
 .adm-text-area {
-  --font-size: var(--adm-font-size-9);
+  --font-size: var(--adm-font-size-huge);
   --color: var(--adm-color-text);
   --placeholder-color: var(--adm-color-light);
   --disabled-color: var(--adm-color-weak);
@@ -72,6 +72,6 @@
 .adm-text-area-count {
   text-align: var(--count-text-align);
   color: var(--adm-color-weak);
-  font-size: var(--adm-font-size-9);
+  font-size: var(--adm-font-size-huge);
   padding-top: 8px;
 }

--- a/src/components/toast/toast.less
+++ b/src/components/toast/toast.less
@@ -23,7 +23,7 @@
     background-color: rgba(0, 0, 0, 0.7);
     border-radius: 8px;
     pointer-events: all;
-    font-size: var(--adm-font-size-7);
+    font-size: var(--adm-font-size-large);
     line-height: 1.5;
     box-sizing: border-box;
     text-align: initial;

--- a/src/components/virtual-input/virtual-input.less
+++ b/src/components/virtual-input/virtual-input.less
@@ -1,7 +1,7 @@
 @class-prefix-virtual-input: ~'adm-virtual-input';
 
 .@{class-prefix-virtual-input} {
-  --font-size: var(--adm-font-size-9);
+  --font-size: var(--adm-font-size-huge);
   --color: var(--adm-color-text);
   --placeholder-color: var(--adm-color-light);
   --disabled-color: var(--adm-color-weak);
@@ -102,6 +102,6 @@
   cursor: pointer;
   .antd-mobile-icon {
     display: block;
-    font-size: var(--adm-font-size-6);
+    font-size: var(--adm-font-size-main);
   }
 }

--- a/src/global/theme-default.less
+++ b/src/global/theme-default.less
@@ -4,15 +4,25 @@
   --adm-radius-m: 8px;
   --adm-radius-l: 12px;
 
+  // deprecated, use --adm-font-size-tiny
   --adm-font-size-1: 9px;
+  // deprecated, use --adm-font-size-tiny
   --adm-font-size-2: 10px;
+  // deprecated, use --adm-font-size-small
   --adm-font-size-3: 11px;
+  // deprecated, use --adm-font-size-small
   --adm-font-size-4: 12px;
+  // deprecated, use --adm-font-size-main
   --adm-font-size-5: 13px;
+  // deprecated, use --adm-font-size-main
   --adm-font-size-6: 14px;
+  // deprecated, use --adm-font-size-large
   --adm-font-size-7: 15px;
+  // deprecated, use --adm-font-size-large
   --adm-font-size-8: 16px;
+  // deprecated, use --adm-font-size-huge
   --adm-font-size-9: 17px;
+  // deprecated, use --adm-font-size-huge
   --adm-font-size-10: 18px;
 
   // variables should be exposed to users:
@@ -43,7 +53,11 @@
   --adm-color-text-dark-solid: #000000;
   --adm-color-fill-content: var(--adm-color-box);
 
+  --adm-font-size-tiny: var(--adm-font-size-1);
+  --adm-font-size-small: var(--adm-font-size-3);
   --adm-font-size-main: var(--adm-font-size-5);
+  --adm-font-size-large: var(--adm-font-size-8);
+  --adm-font-size-huge: var(--adm-font-size-10);
 
   --adm-font-family: -apple-system, blinkmacsystemfont, 'Helvetica Neue',
     helvetica, segoe ui, arial, roboto, 'PingFang SC', 'miui',


### PR DESCRIPTION
将原本的 10 个非语义化的字体大小变量，合并为 5 个语义化的字体大小变量。

```css
:root {
  --adm-font-size-1: 9px;
  --adm-font-size-2: 10px;
  // 合并为
  --adm-font-size-tiny: var(--adm-font-size-1);

  --adm-font-size-3: 11px;
  --adm-font-size-4: 12px;
  // 合并为
  --adm-font-size-small: var(--adm-font-size-3);

  --adm-font-size-5: 13px;
  --adm-font-size-6: 14px;
  // 合并为
  --adm-font-size-main: var(--adm-font-size-5);

  --adm-font-size-7: 15px;
  --adm-font-size-8: 16px;
  // 合并为
  --adm-font-size-large: var(--adm-font-size-8);

  --adm-font-size-9: 17px;
  --adm-font-size-10: 18px;
  // 合并为
  --adm-font-size-huge: var(--adm-font-size-10);
}
```