### PR TITLE
fix: button patch danger color

### DIFF
--- a/src/components/button/button.patch.less
+++ b/src/components/button/button.patch.less
@@ -54,11 +54,11 @@
     }
   }
   &-danger {
-    background-color: #00b578;
-    border-color: #00b578;
+    background-color: #ff3141;
+    border-color: #ff3141;
     &.@{class-prefix-button}-fill-outline,
     &.@{class-prefix-button}-fill-none {
-      color: #00b578;
+      color: #ff3141;
     }
   }
   &-warning {


### PR DESCRIPTION
src/components/button/button.patch.less

&-danger {
    background-color: #00b578;
    border-color: #00b578;
    &.@{class-prefix-button}-fill-outline,
    &.@{class-prefix-button}-fill-none {
      color: #00b578;
    }
 }

修改为：

&-danger {
    background-color: #ff3141;
    border-color: #ff3141;
    &.@{class-prefix-button}-fill-outline,
    &.@{class-prefix-button}-fill-none {
      color: #ff3141;
    }
 }