### PR TITLE
修复`calendar-picker-view`中存在的月份第一行可能全部为空元素的问题

### DIFF
--- a/src/components/calendar-picker-view/calendar-picker-view.tsx
+++ b/src/components/calendar-picker-view/calendar-picker-view.tsx
@@ -153,6 +153,11 @@ export const CalendarPickerView = forwardRef<
         year,
         month: month + 1,
       }
+      let emptyCount =
+        props.weekStartsOn === 'Monday'
+          ? monthIterator.date(1).isoWeekday() - 1
+          : monthIterator.date(1).isoWeekday()
+      emptyCount = emptyCount % 7
 
       cells.push(
         <div key={`${year}-${month}`}>
@@ -166,11 +171,7 @@ export const CalendarPickerView = forwardRef<
           </div>
           <div className={`${classPrefix}-cells`}>
             {/* 空格填充 */}
-            {Array(
-              props.weekStartsOn === 'Monday'
-                ? monthIterator.date(1).isoWeekday() - 1
-                : monthIterator.date(1).isoWeekday()
-            )
+            {Array(emptyCount)
               .fill(null)
               .map((_, index) => (
                 <div key={index} className={`${classPrefix}-cell`}></div>

--- a/src/components/calendar-picker-view/tests/__snapshots__/calendar-picker-view.test.tsx.snap
+++ b/src/components/calendar-picker-view/tests/__snapshots__/calendar-picker-view.test.tsx.snap
@@ -6430,27 +6430,6 @@ exports[`Calendar jump to a day 2`] = `
         >
           <div
             class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
           >
             <div
               class="adm-calendar-picker-view-cell-top"

--- a/src/components/config-provider/tests/__snapshots__/config-provider.test.tsx.snap
+++ b/src/components/config-provider/tests/__snapshots__/config-provider.test.tsx.snap
@@ -1749,27 +1749,6 @@ exports[`ConfigProvider should display the text as da-DK 1`] = `
         >
           <div
             class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
           >
             <div
               class="adm-calendar-picker-view-cell-top"
@@ -6391,27 +6370,6 @@ exports[`ConfigProvider should display the text as en 1`] = `
         <div
           class="adm-calendar-picker-view-cells"
         >
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
           <div
             class="adm-calendar-picker-view-cell"
           >
@@ -11037,27 +10995,6 @@ exports[`ConfigProvider should display the text as es 1`] = `
         >
           <div
             class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
           >
             <div
               class="adm-calendar-picker-view-cell-top"
@@ -15679,27 +15616,6 @@ exports[`ConfigProvider should display the text as fa-IR 1`] = `
         <div
           class="adm-calendar-picker-view-cells"
         >
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
           <div
             class="adm-calendar-picker-view-cell"
           >
@@ -20325,27 +20241,6 @@ exports[`ConfigProvider should display the text as fr-FR 1`] = `
         >
           <div
             class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
           >
             <div
               class="adm-calendar-picker-view-cell-top"
@@ -24967,27 +24862,6 @@ exports[`ConfigProvider should display the text as hu 1`] = `
         <div
           class="adm-calendar-picker-view-cells"
         >
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
           <div
             class="adm-calendar-picker-view-cell"
           >
@@ -29613,27 +29487,6 @@ exports[`ConfigProvider should display the text as id-ID 1`] = `
         >
           <div
             class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
           >
             <div
               class="adm-calendar-picker-view-cell-top"
@@ -34255,27 +34108,6 @@ exports[`ConfigProvider should display the text as it-IT 1`] = `
         <div
           class="adm-calendar-picker-view-cells"
         >
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
           <div
             class="adm-calendar-picker-view-cell"
           >
@@ -38901,27 +38733,6 @@ exports[`ConfigProvider should display the text as ja-JP 1`] = `
         >
           <div
             class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
           >
             <div
               class="adm-calendar-picker-view-cell-top"
@@ -43543,27 +43354,6 @@ exports[`ConfigProvider should display the text as kk-KZ 1`] = `
         <div
           class="adm-calendar-picker-view-cells"
         >
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
           <div
             class="adm-calendar-picker-view-cell"
           >
@@ -48189,27 +47979,6 @@ exports[`ConfigProvider should display the text as ko-KR 1`] = `
         >
           <div
             class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
           >
             <div
               class="adm-calendar-picker-view-cell-top"
@@ -52831,27 +52600,6 @@ exports[`ConfigProvider should display the text as nb-NO 1`] = `
         <div
           class="adm-calendar-picker-view-cells"
         >
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
           <div
             class="adm-calendar-picker-view-cell"
           >
@@ -57477,27 +57225,6 @@ exports[`ConfigProvider should display the text as nl-NL 1`] = `
         >
           <div
             class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
           >
             <div
               class="adm-calendar-picker-view-cell-top"
@@ -62119,27 +61846,6 @@ exports[`ConfigProvider should display the text as ru 1`] = `
         <div
           class="adm-calendar-picker-view-cells"
         >
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
           <div
             class="adm-calendar-picker-view-cell"
           >
@@ -66765,27 +66471,6 @@ exports[`ConfigProvider should display the text as th-TH 1`] = `
         >
           <div
             class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
           >
             <div
               class="adm-calendar-picker-view-cell-top"
@@ -71407,27 +71092,6 @@ exports[`ConfigProvider should display the text as tr-TR 1`] = `
         <div
           class="adm-calendar-picker-view-cells"
         >
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
           <div
             class="adm-calendar-picker-view-cell"
           >
@@ -76053,27 +75717,6 @@ exports[`ConfigProvider should display the text as zh-CH 1`] = `
         >
           <div
             class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
           >
             <div
               class="adm-calendar-picker-view-cell-top"
@@ -80697,27 +80340,6 @@ exports[`ConfigProvider should display the text as zh-HK 1`] = `
         >
           <div
             class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
           >
             <div
               class="adm-calendar-picker-view-cell-top"
@@ -85339,27 +84961,6 @@ exports[`ConfigProvider should display the text as zh-TW 1`] = `
         <div
           class="adm-calendar-picker-view-cells"
         >
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
-          <div
-            class="adm-calendar-picker-view-cell"
-          />
           <div
             class="adm-calendar-picker-view-cell"
           >


### PR DESCRIPTION
问题如下图，也可以[点击这里](https://mobile.ant.design/~demos/calendar-picker-demo1/)在线查看问题。打开页面之后，先点击“选择单个日期”，在查看2023年10月即可：
![微信截图_20240309161820](https://github.com/ant-design/ant-design-mobile/assets/16334363/f7f760f9-b68c-4c58-8f47-3bae3843272b)

