### PR TITLE
feat(utils): add touchstart event to PropagationEvent

### DIFF
--- a/src/utils/with-stop-propagation.tsx
+++ b/src/utils/with-stop-propagation.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
 import type { ReactElement } from 'react'
-export type PropagationEvent = 'click'
+export type PropagationEvent = 'click' | 'touchstart'
 
 const eventToPropRecord: Record<PropagationEvent, string> = {
   'click': 'onClick',
+  'touchstart': 'onTouchStart'
 }
 
 export function withStopPropagation(


### PR DESCRIPTION
PropagationEvent 增加 touchstart 事件。

我遇到的业务场景: 
- `SwipeAction` 设置 `closeOnAction={false}`
-  其中某个 action 会拉起 Picker
-  期望 Picker 里面选择项目的时候不要 close 掉 Swiper

