### PR TITLE
优化仅 zh-CN 语言应用的打包体积

### DIFF
--- a/src/locales/zh-CN.test.ts
+++ b/src/locales/zh-CN.test.ts
@@ -1,0 +1,18 @@
+import { base } from './base'
+import zhCN from './zh-CN'
+
+test('zh-CN', () => {
+  function compareKeys(a: any, b: any): boolean {
+    return !Object.keys(a).some(key => {
+      if (typeof b[key] === 'string') {
+        return false
+      } else if (b[key]) {
+        return !compareKeys(a[key], b[key])
+      } else {
+        return true
+      }
+    })
+  }
+
+  expect(compareKeys(base, zhCN)).toBeTruthy()
+})

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -1,9 +1,8 @@
-import { mergeLocale } from '../utils/merge-locale'
-import { base } from './base'
+import { Locale } from './base'
 
 const typeTemplate = '${label}不是一个有效的${type}'
 
-const zhCN = mergeLocale(base, {
+const zhCN: Locale = {
   locale: 'zh-CH',
   common: {
     confirm: '确定',
@@ -140,6 +139,6 @@ const zhCN = mergeLocale(base, {
   Selector: {
     name: '选择组',
   },
-})
+}
 
 export default zhCN


### PR DESCRIPTION
有很多应用只支持 zh-CN，而由于 mergeLocale 的存在，导致 base （英文）也会被打包进去，徒增 3KB 的体积。本项目的维护者几乎都是 zh-CN 语言使用者，zh-CN 语言的完整性是有保证的，因此并不需要 mergeLocale 兜底，因此在 zh-CN 语言中去掉了 mergeLocale。