### PR TITLE
fix: input enterKeyHint

### DIFF
--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -160,6 +160,7 @@ export const Input = forwardRef<InputRef, InputProps>((p, ref) => {
         max={props.max}
         min={props.min}
         autoComplete={props.autoComplete}
+        enterKeyHint={props.enterKeyHint}
         autoFocus={props.autoFocus}
         pattern={props.pattern}
         inputMode={props.inputMode}


### PR DESCRIPTION
input 的enterKeyHint 和autoFocus同时使用时，在ios中只能autoFocus，enterKeyHint无效
fix https://github.com/ant-design/ant-design-mobile/issues/6605