### PR TITLE
fix: dropdown separate title and content when scrolling

### DIFF
--- a/src/components/dropdown/dropdown.less
+++ b/src/components/dropdown/dropdown.less
@@ -78,7 +78,7 @@
     left: 0;
 
     .@{class-prefix-dropdown}-popup-mask {
-      position: absolute;
+      position: fixed;
     }
 
     .@{class-prefix-dropdown}-popup-body {


### PR DESCRIPTION
fix https://github.com/ant-design/ant-design-mobile/issues/6606