### PR TITLE
feat(deps): add react-dom peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,7 +172,8 @@
     "webpack-stream": "^7.0.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
在 https://bundlephobia.com/package/antd-mobile 上，bundle 分析会提示 react-dom 没有找到

![图片](https://github.com/ant-design/ant-design-mobile/assets/5836790/d7b18b77-af12-40fc-80c3-0758b6972289)

理论上任何会被 bundle 的依赖都应该在 dependencies 或者 peerDependencies 里。参考 antd 的 peerDependencies 就是有 react-dom 的，所以我在 antd-mobile 里也加上了。这样更加严谨一些，也能让 bundlephobia.com 之类的工具分析得更准确一些。