### PR TITLE
fix: collapse component expands blank issue #6619

### DIFF
--- a/src/components/collapse/collapse.tsx
+++ b/src/components/collapse/collapse.tsx
@@ -1,15 +1,15 @@
-import React, { isValidElement, useRef } from 'react'
-import type { FC, ReactNode, ReactElement } from 'react'
-import { NativeProps, withNativeProps } from '../../utils/native-props'
-import List from '../list'
+import { animated, useSpring } from '@react-spring/web'
+import { useMount } from 'ahooks'
 import { DownOutline } from 'antd-mobile-icons'
 import classNames from 'classnames'
-import { useSpring, animated } from '@react-spring/web'
-import { usePropsValue } from '../../utils/use-props-value'
-import { useMount } from 'ahooks'
+import type { FC, ReactElement, ReactNode } from 'react'
+import React, { isValidElement, useRef } from 'react'
+import { NativeProps, withNativeProps } from '../../utils/native-props'
 import { useShouldRender } from '../../utils/should-render'
-import { useIsomorphicUpdateLayoutEffect } from '../../utils/use-isomorphic-update-layout-effect'
 import { traverseReactNode } from '../../utils/traverse-react-node'
+import { useIsomorphicUpdateLayoutEffect } from '../../utils/use-isomorphic-update-layout-effect'
+import { usePropsValue } from '../../utils/use-props-value'
+import List from '../list'
 
 const classPrefix = `adm-collapse`
 
@@ -65,18 +65,28 @@ const CollapsePanelContent: FC<{
   useIsomorphicUpdateLayoutEffect(() => {
     const inner = innerRef.current
     if (!inner) return
+    let observer: MutationObserver | null = null
+    const handleMutations = () => {
+      api.start({ height: inner.offsetHeight })
+      if (observer) {
+        observer.disconnect()
+      }
+      observer = new MutationObserver(handleMutations)
+      observer.observe(innerRef.current as HTMLDivElement, {
+        childList: true,
+        subtree: true,
+      })
+    }
     if (visible) {
-      api.start({
-        height: inner.offsetHeight,
-      })
+      handleMutations()
     } else {
-      api.start({
-        height: inner.offsetHeight,
-        immediate: true,
-      })
-      api.start({
-        height: 0,
-      })
+      api.start({ height: inner.offsetHeight, immediate: true })
+      api.start({ height: 0 })
+    }
+    return () => {
+      if (observer) {
+        observer.disconnect()
+      }
     }
   }, [visible])
 

--- a/src/components/collapse/demos/demo1.tsx
+++ b/src/components/collapse/demos/demo1.tsx
@@ -1,41 +1,21 @@
+import { Collapse, Ellipsis } from 'antd-mobile'
 import React from 'react'
-import { Collapse } from 'antd-mobile'
-import { DemoBlock, lorem } from 'demos'
 
-export default () => {
+const content = `这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本`
+
+// 初次展开Collapse.Panel时，会有空白处
+export default function App() {
   return (
-    <>
-      <DemoBlock title='基础用法' padding='0'>
-        <Collapse defaultActiveKey={['1']}>
-          <Collapse.Panel key='1' title='第一项'>
-            {mockContents[0]}
-          </Collapse.Panel>
-          <Collapse.Panel key='2' title='第二项'>
-            {mockContents[1]}
-          </Collapse.Panel>
-          <Collapse.Panel key='3' title='第三项'>
-            {mockContents[2]}
-          </Collapse.Panel>
-        </Collapse>
-      </DemoBlock>
-
-      <DemoBlock title='手风琴模式' padding='0'>
-        <Collapse accordion>
-          <Collapse.Panel key='1' title='第一项'>
-            手风琴模式只能同时展开一个
-          </Collapse.Panel>
-          <Collapse.Panel key='2' title='第二项'>
-            手风琴模式只能同时展开一个
-          </Collapse.Panel>
-          <Collapse.Panel key='3' title='第三项'>
-            手风琴模式只能同时展开一个
-          </Collapse.Panel>
-        </Collapse>
-      </DemoBlock>
-    </>
+    <Collapse bordered={false}>
+      <Collapse.Panel title='panel' key='1'>
+        <Ellipsis
+          direction='end'
+          rows={3}
+          expandText='展开'
+          collapseText='收起'
+          content={content}
+        />
+      </Collapse.Panel>
+    </Collapse>
   )
 }
-
-const mockContents = Array(5)
-  .fill(null)
-  .map(() => lorem.generateParagraphs(1))

--- a/src/components/collapse/demos/demo1.tsx
+++ b/src/components/collapse/demos/demo1.tsx
@@ -1,21 +1,41 @@
-import { Collapse, Ellipsis } from 'antd-mobile'
+import { Collapse } from 'antd-mobile'
+import { DemoBlock, lorem } from 'demos'
 import React from 'react'
 
-const content = `这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本这是一段文本`
-
-// 初次展开Collapse.Panel时，会有空白处
-export default function App() {
+export default () => {
   return (
-    <Collapse bordered={false}>
-      <Collapse.Panel title='panel' key='1'>
-        <Ellipsis
-          direction='end'
-          rows={3}
-          expandText='展开'
-          collapseText='收起'
-          content={content}
-        />
-      </Collapse.Panel>
-    </Collapse>
+    <>
+      <DemoBlock title='基础用法' padding='0'>
+        <Collapse defaultActiveKey={['1']}>
+          <Collapse.Panel key='1' title='第一项'>
+            {mockContents[0]}
+          </Collapse.Panel>
+          <Collapse.Panel key='2' title='第二项'>
+            {mockContents[1]}
+          </Collapse.Panel>
+          <Collapse.Panel key='3' title='第三项'>
+            {mockContents[2]}
+          </Collapse.Panel>
+        </Collapse>
+      </DemoBlock>
+
+      <DemoBlock title='手风琴模式' padding='0'>
+        <Collapse accordion>
+          <Collapse.Panel key='1' title='第一项'>
+            手风琴模式只能同时展开一个
+          </Collapse.Panel>
+          <Collapse.Panel key='2' title='第二项'>
+            手风琴模式只能同时展开一个
+          </Collapse.Panel>
+          <Collapse.Panel key='3' title='第三项'>
+            手风琴模式只能同时展开一个
+          </Collapse.Panel>
+        </Collapse>
+      </DemoBlock>
+    </>
   )
 }
+
+const mockContents = Array(5)
+  .fill(null)
+  .map(() => lorem.generateParagraphs(1))


### PR DESCRIPTION
Using MutationObserver to change the order in which height change animations are executed, I think the height animations should be triggered after DOM rendering is complete.

Currently, most modern browsers have implemented the MutationObserver API:

- Chrome: Supported from version 18 onwards
- Firefox: Supported from version 14 onwards
- Safari: Supported from version 6.1 onwards
- Opera: Supported from version 15 onwards
- Edge: Supported from version 79 onwards
- Internet Explorer: Never supported

resolve https://github.com/ant-design/ant-design-mobile/issues/6619