### PR TITLE
docs: remove `--save` flag and fix typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 </div>
 
 ```bash
-$ npm install --save antd-mobile
+$ npm install antd-mobile
 # or
 $ yarn add antd-mobile
 # or
@@ -39,7 +39,7 @@ You can also play with antd-mobile just in browser with [Codesandbox](https://co
 
 If you found bugs or would like to request some new features, please consider opening an [issue](https://github.com/ant-design/ant-design-mobile/issues/new).
 
-If you have some question about how to use ant-mobile, you can start a [discussion thread](https://github.com/ant-design/ant-design-mobile/discussions).
+If you have some questions about how to use ant-mobile, you can start a [discussion thread](https://github.com/ant-design/ant-design-mobile/discussions).
 
 ---
 


### PR DESCRIPTION
### What does this PR do?

1. Fix typo
2. Remove the redundant `--save` flag from npm install command

![npm version](https://github.com/ant-design/ant-design-mobile/assets/45116321/cfcf583e-51c4-4095-8e2f-30a0793d70e0)

### Why is this important?

Removing the `--save` flag makes the documentation cleaner and prevents potential confusion for users who might think the flag is still necessary. This change helps keep the documentation up-to-date with the current npm behavior.

### Changes made:

- Removed `--save` flag from the `npm install` command in the README.md file.

### Related issues:

- None

### Additional notes:

- Tested the updated command to ensure it works as expected with the latest npm version.