### PR TITLE
修复segmented组件滑块移动时超出边界

### DIFF
--- a/src/components/segmented/segmented.less
+++ b/src/components/segmented/segmented.less
@@ -81,7 +81,7 @@
     top: 0;
     left: 0;
     width: 0;
-    height: 100%;
+    height: calc(100% - 8px);
     padding: 4px 0;
   }
 


### PR DESCRIPTION
before:
<img width="343" alt="Snipaste_2024-10-29_11-46-30" src="https://github.com/user-attachments/assets/d2b532f8-e22b-4bfe-b822-9d646964b8a0">
after:
![image](https://github.com/user-attachments/assets/b28ce8a4-79b5-4b46-8f3e-61b805f8e557)

fix #6768
