### PR TITLE
fix: unable to jump page

### DIFF
--- a/docs/components/components/Main/MainSection/index.tsx
+++ b/docs/components/components/Main/MainSection/index.tsx
@@ -2,6 +2,7 @@ import { Button } from 'antd-mobile'
 import React, { useEffect, useState } from 'react'
 import Lottie from 'react-lottie'
 import { useTrans } from '../../../../hooks/useTrans'
+import { openUrl } from '../../../../utils'
 import styles from './index.local.less'
 
 export default (props: { isWidthScreen: boolean }) => {
@@ -39,7 +40,11 @@ export default (props: { isWidthScreen: boolean }) => {
             color='primary'
             shape='rounded'
             className={styles.buttonLeft}
-            href={trans('/guide/quick-start', '/zh/guide/quick-start')}
+            onClick={() =>
+              openUrl({
+                href: trans('/guide/quick-start', '/zh/guide/quick-start'),
+              })
+            }
           >
             {trans('Get Start', '开始使用')}
           </Button>
@@ -47,7 +52,11 @@ export default (props: { isWidthScreen: boolean }) => {
             color='primary'
             shape='rounded'
             className={styles.buttonRight}
-            href={trans('/components', '/zh/components')}
+            onClick={() =>
+              openUrl({
+                href: trans('/components', '/zh/components'),
+              })
+            }
           >
             {trans('Preview Online', '在线体验')}
           </Button>

--- a/docs/components/components/Main/index.tsx
+++ b/docs/components/components/Main/index.tsx
@@ -4,6 +4,7 @@ import { Button, Card } from 'antd-mobile'
 import React, { useEffect, useRef, useState } from 'react'
 import Lottie from 'react-lottie'
 import { useTrans } from '../../../hooks/useTrans'
+import { openUrl } from '../../../utils'
 import MainSection from './MainSection'
 import {
   getGuides,
@@ -99,10 +100,12 @@ export default () => {
                   </div>
                   <Button
                     className={styles.productResourceCardButton}
-                    type='primary'
-                    shape='round'
-                    target={resource.target}
-                    href={resource.buttonLink}
+                    onClick={() =>
+                      openUrl({
+                        href: resource.buttonLink,
+                        target: resource.target,
+                      })
+                    }
                   >
                     {resource.buttonText}
                   </Button>

--- a/docs/utils/index.ts
+++ b/docs/utils/index.ts
@@ -1,0 +1,15 @@
+export const openUrl = ({
+  href,
+  target,
+}: {
+  href: string
+  target?: string
+}) => {
+  switch (target) {
+    case '_blank':
+      window.open(href, target)
+      break
+    default:
+      window.location.href = href
+  }
+}


### PR DESCRIPTION
[https://mobile.ant.design/zh](https://mobile.ant.design/zh)
官网的依赖从 antd 更换到 antdm 后, 相关属性不一致.
目前页面是无法进行跳转, 先做相关处理使页面正常跳转
![image](https://github.com/user-attachments/assets/b190c27c-65a1-4ace-aa99-184b5b24a57d)
![image](https://github.com/user-attachments/assets/1abcbad2-6094-40e3-860d-c5490bbd4c45)
