### PR TITLE
fix(Popover): autoUpdate not working when defaultVisible is false

### DIFF
--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -1,40 +1,40 @@
+import {
+  arrow,
+  autoUpdate,
+  computePosition,
+  flip,
+  hide,
+  limitShift,
+  offset,
+  shift,
+} from '@floating-ui/dom'
+import { useClickAway, useIsomorphicLayoutEffect } from 'ahooks'
+import classNames from 'classnames'
+import type { ReactElement, ReactNode } from 'react'
 import React, {
   forwardRef,
+  useEffect,
   useImperativeHandle,
   useRef,
   useState,
-  useEffect,
 } from 'react'
-import type { ReactNode, ReactElement } from 'react'
-import classNames from 'classnames'
+import { convertPx } from '../../utils/convert-px'
+import { NativeProps, withNativeProps } from '../../utils/native-props'
+import {
+  GetContainer,
+  renderToContainer,
+} from '../../utils/render-to-container'
+import { useShouldRender } from '../../utils/should-render'
 import { usePropsValue } from '../../utils/use-props-value'
 import { mergeProps } from '../../utils/with-default-props'
-import { NativeProps, withNativeProps } from '../../utils/native-props'
 import {
   PropagationEvent,
   withStopPropagation,
 } from '../../utils/with-stop-propagation'
 import { Arrow } from './arrow'
-import {
-  GetContainer,
-  renderToContainer,
-} from '../../utils/render-to-container'
-import {
-  arrow,
-  computePosition,
-  flip,
-  offset,
-  autoUpdate,
-  hide,
-  shift,
-  limitShift,
-} from '@floating-ui/dom'
-import { Wrapper } from './wrapper'
-import { useShouldRender } from '../../utils/should-render'
-import { useClickAway, useIsomorphicLayoutEffect } from 'ahooks'
 import { DeprecatedPlacement, Placement } from './index'
 import { normalizePlacement } from './normalize-placement'
-import { convertPx } from '../../utils/convert-px'
+import { Wrapper } from './wrapper'
 
 const classPrefix = `adm-popover`
 
@@ -187,11 +187,11 @@ export const Popover = forwardRef<PopoverRef, PopoverProps>((p, ref) => {
 
   useEffect(() => {
     const floatingElement = floatingRef.current
-    if (!targetElement || !floatingElement) return
+    if (!targetElement || !floatingElement || !visible) return
     return autoUpdate(targetElement, floatingElement, update, {
       elementResize: typeof ResizeObserver !== 'undefined',
     })
-  }, [targetElement])
+  }, [targetElement, visible])
 
   useClickAway(
     () => {


### PR DESCRIPTION
autoUpdate 在 visible 变化时触发，visible 为 false 关闭 autoUpdate，visible 为 true 开启 autoUpdate。一方面可以优化运行时性能，另一方面可以解决默认 visible = false 时，元素未创建，导致 autoUpdate 不生效的问题。

Fix #6794 