### PR TITLE
fix(Ellipsis): Handle some post-update issues

### DIFF
--- a/src/components/ellipsis/demos/demo1.tsx
+++ b/src/components/ellipsis/demos/demo1.tsx
@@ -1,4 +1,6 @@
-import { Ellipsis } from 'antd-mobile'
+import { Ellipsis, Space } from 'antd-mobile'
+import { DownOutline, UpOutline } from 'antd-mobile-icons'
+import { DemoBlock } from 'demos'
 import React from 'react'
 
 const content =
@@ -7,15 +9,7 @@ const content =
 export default () => {
   return (
     <>
-      <div style={{ width: '10em' }}>
-        <Ellipsis
-          rows={2}
-          content={
-            '这是一段超长文本一段这是一段超长文本一段这是一段超长文本一段'
-          }
-        />
-      </div>
-      {/* <DemoBlock title='尾部省略'>
+      <DemoBlock title='尾部省略'>
         <Ellipsis direction='end' content={content} />
       </DemoBlock>
 
@@ -84,7 +78,7 @@ export default () => {
             </>
           }
         />
-      </DemoBlock> */}
+      </DemoBlock>
     </>
   )
 }

--- a/src/components/ellipsis/demos/demo1.tsx
+++ b/src/components/ellipsis/demos/demo1.tsx
@@ -1,6 +1,4 @@
-import { Ellipsis, Space } from 'antd-mobile'
-import { DownOutline, UpOutline } from 'antd-mobile-icons'
-import { DemoBlock } from 'demos'
+import { Ellipsis } from 'antd-mobile'
 import React from 'react'
 
 const content =
@@ -9,7 +7,15 @@ const content =
 export default () => {
   return (
     <>
-      <DemoBlock title='尾部省略'>
+      <div style={{ width: '10em' }}>
+        <Ellipsis
+          rows={2}
+          content={
+            '这是一段超长文本一段这是一段超长文本一段这是一段超长文本一段'
+          }
+        />
+      </div>
+      {/* <DemoBlock title='尾部省略'>
         <Ellipsis direction='end' content={content} />
       </DemoBlock>
 
@@ -78,7 +84,7 @@ export default () => {
             </>
           }
         />
-      </DemoBlock>
+      </DemoBlock> */}
     </>
   )
 }

--- a/src/components/ellipsis/tests/ellipsis.test.tsx
+++ b/src/components/ellipsis/tests/ellipsis.test.tsx
@@ -17,7 +17,8 @@ describe('Ellipsis', () => {
           const that = this as HTMLElement
           const charLen = (that.textContent || '').length || 1
           const rows = Math.ceil(charLen / 30)
-          return rows * lineHeight
+          const styleLineHeight = parseFloat(that.style.lineHeight)
+          return Math.round(rows * (styleLineHeight || lineHeight))
         },
       },
     })
@@ -131,5 +132,31 @@ describe('Ellipsis', () => {
     expect(await findByText('expand')).toBeVisible()
     fireEvent.click(getByText('expand'))
     expect(getByText('collapse')).toBeInTheDocument()
+  })
+
+  test('non-integer line height', () => {
+    const rows = 2
+    const lineHeight = '16.4px'
+
+    const { getByTestId } = render(
+      <React.Fragment>
+        <Ellipsis
+          rows={rows}
+          style={{ lineHeight }}
+          content={content}
+          data-testid='ellipsis'
+        />
+        <div style={{ lineHeight }} data-testid='maxheight'>
+          {content}
+        </div>
+      </React.Fragment>
+    )
+
+    const { offsetHeight } = getByTestId('ellipsis') || {}
+    const { offsetHeight: maxheight } = getByTestId('maxheight') || {}
+    const rowsHeight = Math.round(parseFloat(lineHeight) * rows)
+    const expectHeight = Math.min(rowsHeight, maxheight)
+
+    expect(offsetHeight).toBe(expectHeight)
   })
 })

--- a/src/components/ellipsis/useMeasure.tsx
+++ b/src/components/ellipsis/useMeasure.tsx
@@ -66,7 +66,7 @@ export default function useMeasure(
       const fullMeasureHeight = fullMeasureRef.current?.offsetHeight || 0
       const singleRowMeasureHeight =
         singleRowMeasureRef.current?.offsetHeight || 0
-      const rowMeasureHeight = singleRowMeasureHeight * rows
+      const rowMeasureHeight = singleRowMeasureHeight * (rows + 0.5)
 
       if (fullMeasureHeight <= rowMeasureHeight) {
         setStatus(MEASURE_STATUS.STABLE_NO_ELLIPSIS)

--- a/src/components/ellipsis/useMeasure.tsx
+++ b/src/components/ellipsis/useMeasure.tsx
@@ -47,12 +47,6 @@ export default function useMeasure(
 
   const startMeasure = useEvent(() => {
     setStatus(MEASURE_STATUS.PREPARE)
-    setWalkingIndexes([
-      0,
-      direction === 'middle'
-        ? Math.ceil(contentChars.length / 2)
-        : contentChars.length,
-    ])
   })
 
   // Initialize
@@ -72,6 +66,12 @@ export default function useMeasure(
         setStatus(MEASURE_STATUS.STABLE_NO_ELLIPSIS)
       } else {
         setMaxHeight(rowMeasureHeight)
+        setWalkingIndexes([
+          0,
+          direction === 'middle'
+            ? Math.ceil(contentChars.length / 2)
+            : contentChars.length,
+        ])
         setStatus(MEASURE_STATUS.MEASURE_WALKING)
       }
     }

--- a/src/components/ellipsis/useMeasure.tsx
+++ b/src/components/ellipsis/useMeasure.tsx
@@ -47,7 +47,7 @@ export default function useMeasure(
   const midMeasureRef = React.useRef<HTMLDivElement>(null)
 
   const startMeasure = useEvent(() => {
-    // 使用react-dom render挂载的App, requestAnimationFrame触发回调时状态更新不同步
+    // use batch update to avoid async update trigger 2 render
     unstable_batchedUpdates(() => {
       setStatus(MEASURE_STATUS.PREPARE)
       setWalkingIndexes([

--- a/src/components/ellipsis/useMeasure.tsx
+++ b/src/components/ellipsis/useMeasure.tsx
@@ -46,6 +46,12 @@ export default function useMeasure(
   const midMeasureRef = React.useRef<HTMLDivElement>(null)
 
   const startMeasure = useEvent(() => {
+    setWalkingIndexes([
+      0,
+      direction === 'middle'
+        ? Math.ceil(contentChars.length / 2)
+        : contentChars.length,
+    ])
     setStatus(MEASURE_STATUS.PREPARE)
   })
 
@@ -66,12 +72,6 @@ export default function useMeasure(
         setStatus(MEASURE_STATUS.STABLE_NO_ELLIPSIS)
       } else {
         setMaxHeight(rowMeasureHeight)
-        setWalkingIndexes([
-          0,
-          direction === 'middle'
-            ? Math.ceil(contentChars.length / 2)
-            : contentChars.length,
-        ])
         setStatus(MEASURE_STATUS.MEASURE_WALKING)
       }
     }

--- a/src/components/ellipsis/useMeasure.tsx
+++ b/src/components/ellipsis/useMeasure.tsx
@@ -1,5 +1,6 @@
 import { useEvent } from 'rc-util'
 import React from 'react'
+import { unstable_batchedUpdates } from 'react-dom'
 import runes from 'runes2'
 
 const enum MEASURE_STATUS {
@@ -46,13 +47,16 @@ export default function useMeasure(
   const midMeasureRef = React.useRef<HTMLDivElement>(null)
 
   const startMeasure = useEvent(() => {
-    setWalkingIndexes([
-      0,
-      direction === 'middle'
-        ? Math.ceil(contentChars.length / 2)
-        : contentChars.length,
-    ])
-    setStatus(MEASURE_STATUS.PREPARE)
+    // 使用react-dom render挂载的App, requestAnimationFrame触发回调时状态更新不同步
+    unstable_batchedUpdates(() => {
+      setStatus(MEASURE_STATUS.PREPARE)
+      setWalkingIndexes([
+        0,
+        direction === 'middle'
+          ? Math.ceil(contentChars.length / 2)
+          : contentChars.length,
+      ])
+    })
   })
 
   // Initialize


### PR DESCRIPTION
fix #6792

**关于第一个文本省略字数错误的问题**
我分析了一下，其实是setWalkingIndexes设置的值最后被赋值导致

第一次调用正常计算，然后第二次由useResizeEffect触发，先setStatus然后setWalkingIndexes，进入useLayoutEffect计算PREPARE时，此时walkingIndexes的值还是上一次的值，然后进入MEASURE_WALKING，执行了一次diff就等于0，然后renderContent，这时setWalkingIndexes初始化设置的值生效了，因为state是STABLE_ELLIPSIS，然后初始化的值变成渲染了一半的文本，所以文本省略看起来算的有问题，实则被覆盖了。
![image](https://github.com/user-attachments/assets/7a3b2556-3661-47e6-b52a-e5f2d9414911)

最后定位发现，使用react-dom render挂载的App, requestAnimationFrame触发回调时状态更新不同步。

现在做法是把setWalkingIndexes放在setStatus(MEASURE_WALKING)前面，这样就不会有这个问题了，而且其实只有MEASURE_WALKING时才需要walkingIndexes的值。

**引申优化问题**
这里其实还有一个重复计算的问题，当fullMeasureRef大于rowMeasureHeight时才会计算，但是这个fullMeasureRef永远都是渲染content所有内容的高度，导致issue中debug截屏看到的一直是59>40。所以即使文本超出被截断了，下一次进入判断的时候也会重新命中，然后计算截断。

之前组件的实现就没有这个问题，因为下一次判断时container的内容就是已经处理过的，然后在取值container.offsetHeight，就会<=maxHeight，从而跳过判断。

我根据之前的思路再结合现在的实现，在计算前先获取containerRef的高度，然后取最小值，这样就解决了截断情况下fullMeasureRef一直大于rowMeasureHeight的情况，正常的跳过了。
![image](https://github.com/user-attachments/assets/06814433-6b7c-4a2d-8872-d74269562b44)

但是引发了一个新的问题，跳过后state变成了STABLE_NO_ELLIPSIS，然后又渲染了content，导致元素触发ResizeObserver重新计算，结果就是state一直在STABLE_ELLIPSIS与STABLE_NO_ELLIPSIS反复横跳死循环了。

目前能想到两个解法
1. 在ellipsis中存储一个initResizeRef，让第一次useResizeEffect时不调用forceResize。避免组件初次渲染100%重复计算一次
2. 这个组件实现调整一下，参考之前的实现存储计算结果，让fullMeasureRef<=rowMeasureHeight时，不是单纯的改成STABLE_NO_ELLIPSIS渲染content
