### PR TITLE
docs: config provider searchBar param name

### DIFF
--- a/src/components/config-provider/index.en.md
+++ b/src/components/config-provider/index.en.md
@@ -30,7 +30,7 @@ Configure locale messages and custom icons globally.
 | noticeBar | NoticeBar config | `{ icon?: ReactNode, closeIcon?: ReactNode }` | - |
 | popup | Popup config | `{ closeIcon?: ReactNode }` | - |
 | result | Result config | `{ successIcon?: ReactNode, errorIcon?: ReactNode, infoIcon?: ReactNode, waitingIcon?: ReactNode, warningIcon?: ReactNode }` | - |
-| searchBar | SearchBar config | `{ icon?: ReactNode }` | - |
+| searchBar | SearchBar config | `{ searchIcon?: ReactNode }` | - |
 | toast | Toast config | `{ successIcon?: ReactNode, failIcon?: ReactNode, loadingIcon?: ReactNode }` | - |
 
 [zh-CN]: https://github.com/ant-design/ant-design-mobile/blob/master/src/locales/zh-CN.ts

--- a/src/components/config-provider/index.zh.md
+++ b/src/components/config-provider/index.zh.md
@@ -30,7 +30,7 @@
 | noticeBar | NoticeBar 配置 | `{ icon?: ReactNode, closeIcon?: ReactNode }` | - |
 | popup | Popup 配置 | `{ closeIcon?: ReactNode }` | - |
 | result | Result 配置 | `{ successIcon?: ReactNode, errorIcon?: ReactNode, infoIcon?: ReactNode, waitingIcon?: ReactNode, warningIcon?: ReactNode }` | - |
-| searchBar | SearchBar 配置 | `{ icon?: ReactNode }` | - |
+| searchBar | SearchBar 配置 | `{ searchIcon?: ReactNode }` | - |
 | toast | Toast 配置 | `{ successIcon?: ReactNode, failIcon?: ReactNode, loadingIcon?: ReactNode }` | - |
 
 [zh-CN]: https://github.com/ant-design/ant-design-mobile/blob/master/src/locales/zh-CN.ts


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/f45a8703-c256-4eca-9d11-75c805209514)
![image](https://github.com/user-attachments/assets/cd24df80-d371-479c-9b82-d7bbef44efa4)

修正文档的参数名, 文档显示为 `icon`, 实际参数 `searchIcon`