### PR TITLE
[Bugfix]Popover.Menu   在深色模式下，  背景颜色错误

### DIFF
--- a/src/components/popover/popover.less
+++ b/src/components/popover/popover.less
@@ -3,7 +3,7 @@
 .@{class-prefix-popover} {
   --z-index: var(--adm-popover-z-index, 1030);
 
-  --background: #ffffff;
+  --background: var(--adm-color-background);
   --arrow-size: 8px;
   --content-padding: 8px 12px;
 


### PR DESCRIPTION
[Bugfix]Popover.Menu   在深色模式下，  背景颜色错误