### PR TITLE
ci: add pkg.pr.new

### DIFF
--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -1,0 +1,43 @@
+name: Publish Any Commit
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check
+        uses: actions/checkout@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install pnpm
+        id: pnpm-install
+        uses: pnpm/action-setup@v4
+        with:
+          version: 7
+          run_install: false
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: |
+          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm build
+
+      - run: pnpmx pkg-pr-new publish './lib' --no-template


### PR DESCRIPTION
copied https://github.com/ant-design/ant-design/blob/master/.github/workflows/pkg.pr.new.yml

之前提交了 [React 19 兼容 PR](https://github.com/ant-design/ant-design-mobile/pull/6860) 已经被合并掉了。

但是没轮到发版日期，所以可以考虑添加 [pkg.pr.new](http://pkg.pr.new/) 方便用户尝鲜体验 或 提早在发布正式版之前发现问题。