### PR TITLE
Fix the semantic error in the calendar description

### DIFF
--- a/src/components/calendar-picker-view/calendar-picker-view.tsx
+++ b/src/components/calendar-picker-view/calendar-picker-view.tsx
@@ -284,6 +284,10 @@ export const CalendarPickerView = forwardRef<
                   }
 
                   if (props.selectionMode === 'range') {
+                    if (isBegin && isEnd) {
+                      return contentWrapper(locale.Calendar.startAndEnd)
+                    }
+
                     if (isBegin) {
                       return contentWrapper(locale.Calendar.start)
                     }

--- a/src/locales/ar-SA.ts
+++ b/src/locales/ar-SA.ts
@@ -16,6 +16,7 @@ const arSA = mergeLocale(base, {
     'confirm': 'تأكيد',
     'start': 'يبدأ',
     'end': 'ينهي',
+    'startAndEnd': 'يبدأ/ينهي',
     'today': 'اليوم',
     'markItems': ['واحد', 'اثنين', 'ثلاثة', 'أربعة', 'خمسة', 'ستة', 'يوم'],
     'yearAndMonth': '${year} سنة ${month} شهر',

--- a/src/locales/base.ts
+++ b/src/locales/base.ts
@@ -13,6 +13,7 @@ export const base = {
     confirm: 'Confirm',
     start: 'start',
     end: 'end',
+    startAndEnd: 'start/end',
     today: 'today',
     markItems: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
     yearAndMonth: '${year}/${month}',

--- a/src/locales/cnr-ME.ts
+++ b/src/locales/cnr-ME.ts
@@ -16,6 +16,7 @@ const cnrME = mergeLocale(base, {
     confirm: 'Potvrdi',
     start: 'početak',
     end: 'kraj',
+    startAndEnd: 'početak/kraj',
     today: 'danas',
     markItems: ['Pon', 'Uto', 'Sre', 'Čet', 'Pet', 'Sub', 'Ned'],
     yearAndMonth: '${year}/${month}',

--- a/src/locales/de-DE.ts
+++ b/src/locales/de-DE.ts
@@ -16,6 +16,7 @@ const deDE = mergeLocale(base, {
     'confirm': 'Bestätigen',
     'start': 'Starten',
     'end': 'Beenden',
+    'startAndEnd': 'Starten/Beenden',
     'today': 'Heute',
     'markItems': ['I', 'II', 'III', 'IV', 'V', 'Sechs', 'Tag'],
     'yearAndMonth': '${year}Jahr${month}Monat',

--- a/src/locales/hr-HR.ts
+++ b/src/locales/hr-HR.ts
@@ -16,6 +16,7 @@ const hrHR = mergeLocale(base, {
     confirm: 'Potvrdi',
     start: 'početak',
     end: 'kraj',
+    startAndEnd: 'početak/kraj',
     today: 'danas',
     markItems: ['Pon', 'Uto', 'Sri', 'Čet', 'Pet', 'Sub', 'Ned'],
     yearAndMonth: '${year}/${month}',

--- a/src/locales/in-ID.ts
+++ b/src/locales/in-ID.ts
@@ -16,6 +16,7 @@ const inID = mergeLocale(base, {
     confirm: 'OK',
     start: 'Mulai',
     end: 'Selesai',
+    startAndEnd: 'Mulai/Selesai',
     today: 'Hari Ini',
     markItems: ['Senin', 'Selasa', 'Rabu', 'Kamis', 'Jumat', 'Sabtu', 'Minggu'],
     yearAndMonth: '${year} Tahun ${month} Bulan',

--- a/src/locales/ms-MY.ts
+++ b/src/locales/ms-MY.ts
@@ -16,6 +16,7 @@ const msMY = mergeLocale(base, {
     'confirm': 'Ok',
     'start': 'Mula',
     'end': 'Tamat',
+    'startAndEnd': 'Mula/Tamat',
     'today': 'Hari ini',
     'markItems': ['Satu', 'Dua', 'Tiga', 'Empat', 'Lima', 'Enam', 'Hari'],
     'yearAndMonth': 'Tahun${year} bulan ${month}',

--- a/src/locales/ru-RU.ts
+++ b/src/locales/ru-RU.ts
@@ -16,6 +16,7 @@ const ruRU = mergeLocale(base, {
     confirm: 'Подтвердить',
     start: 'начало',
     end: 'конец',
+    startAndEnd: 'начало/конец',
     today: 'сегодня',
     markItems: ['Пн', 'Вт', 'Ср', 'Чт', 'Пт', 'Сб', 'Вс'],
     yearAndMonth: '${year}/${month}',

--- a/src/locales/sr-RS.ts
+++ b/src/locales/sr-RS.ts
@@ -16,6 +16,7 @@ const srRS = mergeLocale(base, {
     confirm: 'Потврди',
     start: 'почетак',
     end: 'крај',
+    startAndEnd: 'почетак/крај',
     today: 'данас',
     markItems: ['Пон', 'Уто', 'Сре', 'Чет', 'Пет', 'Суб', 'Нед'],
     yearAndMonth: '${year}/${month}',

--- a/src/locales/th-TH.ts
+++ b/src/locales/th-TH.ts
@@ -16,6 +16,7 @@ const thTH = mergeLocale(base, {
     confirm: 'ยืนยัน',
     start: 'เริ่ม',
     end: 'เสร็จ',
+    startAndEnd: 'เริ่ม/เสร็จ',
     today: 'วันนี้',
     markItems: [
       'วันจันทร์',

--- a/src/locales/vi-VN.ts
+++ b/src/locales/vi-VN.ts
@@ -16,6 +16,7 @@ const viVN = mergeLocale(base, {
     'confirm': 'Xác nhận',
     'start': 'Bắt đầu',
     'end': 'Kết thúc',
+    'startAndEnd': 'Bắt đầu/Kết thúc',
     'today': 'Hôm nay',
     'markItems': ['Một', 'Hai', 'Ba', 'Bốn', 'Năm', 'Sáu', 'Ngày'],
     'yearAndMonth': 'Tháng ${month} năm ${year}',

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -15,6 +15,7 @@ const zhCN: Locale = {
     confirm: '确认',
     start: '开始',
     end: '结束',
+    startAndEnd: '开始/结束',
     today: '今日',
     markItems: ['一', '二', '三', '四', '五', '六', '日'],
     yearAndMonth: '${year}年${month}月',


### PR DESCRIPTION
原逻辑日期范围选择中, 第一次选中"开始"设置的是 [date1, date1] 而不是 [date1, 空值].
此时文案显示为 "开始", 第二次选中其他日期文案为 "结束", 设置第二个值 [date1, date2].

为了在不修改原逻辑, 而造成 breakchange.
所以将第一次选中的文案改为 "开始/结束", 作为语义修复的 Bug fix 来调整.

![871a8f5a5b853aed1e33792bc1a32119](https://github.com/user-attachments/assets/82e7b0d8-7ef5-49c5-b3ad-6fa0a8426e6a)

刚好可以解决该 issue 的问题 #6804

