### PR TITLE
feat(Ellipsis): add onEllipsis callback to Ellipsis component 

### DIFF
--- a/src/components/ellipsis/demos/demo1.tsx
+++ b/src/components/ellipsis/demos/demo1.tsx
@@ -31,6 +31,9 @@ export default () => {
           content={content}
           expandText='展开'
           collapseText='收起'
+          onEllipsis={ellipsis => {
+            Toast.show(`${ellipsis ? '展开' : '收起'}了`)
+          }}
         />
       </DemoBlock>
 

--- a/src/components/ellipsis/ellipsis.tsx
+++ b/src/components/ellipsis/ellipsis.tsx
@@ -20,6 +20,10 @@ export type EllipsisProps = {
   stopPropagationForActionButtons?: PropagationEvent[]
   onContentClick?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
   defaultExpanded?: boolean
+  onEllipsis?: (
+    ellipsis: boolean,
+    e: React.MouseEvent<HTMLAnchorElement, MouseEvent>
+  ) => void
 } & NativeProps
 
 const defaultProps = {

--- a/src/components/ellipsis/index.en.md
+++ b/src/components/ellipsis/index.en.md
@@ -26,6 +26,7 @@ When the display space is not enough, hide some content and replace it with "...
 | rows | The number to display lines | `number` | `1` |
 | stopPropagationForActionButtons | Prevent the event bubbling caused by the expand operation and the collapse operation | `PropagationEvent[]` | `[]` |
 | defaultExpanded | Whether to expand by default | `boolean` | `false` |
+| onEllipsis | Callback when expand or collapse | `(ellipsis: boolean, e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void` | `''` |
 
 ## FAQ
 

--- a/src/components/ellipsis/index.zh.md
+++ b/src/components/ellipsis/index.zh.md
@@ -26,6 +26,7 @@
 | rows | 展示几行 | `number` | `1` |
 | stopPropagationForActionButtons | 阻止展开操作，收起操作引发的事件冒泡 | `PropagationEvent[]` | `[]` |
 | defaultExpanded | 是否默认展开 | `boolean` | `false` |
+| onEllipsis | 展开或收起的回调 | `(ellipsis: boolean, e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void` | `''` |
 
 ## FAQ
 

--- a/src/components/ellipsis/tests/ellipsis.test.tsx
+++ b/src/components/ellipsis/tests/ellipsis.test.tsx
@@ -103,6 +103,26 @@ describe('Ellipsis', () => {
     expect(ellipsis).toHaveTextContent('...')
   })
 
+  test('toggle should be work', () => {
+    const toggle = jest.fn()
+    const { getByText } = render(
+      <Ellipsis
+        content={content}
+        defaultExpanded
+        expandText='expand'
+        collapseText='collapse'
+        onEllipsis={ellipsis => {
+          toggle(ellipsis)
+        }}
+      />
+    )
+    fireEvent.click(getByText('collapse'))
+    expect(toggle).toBeCalledWith(false)
+
+    fireEvent.click(getByText('expand'))
+    expect(toggle).toBeCalledWith(true)
+  })
+
   test('content not exceeded', () => {
     const { getByTestId } = render(
       <Ellipsis content='abc' data-testid='ellipsis' />


### PR DESCRIPTION
- 解决该 issue 的问题 https://github.com/ant-design/ant-design-mobile/issues/6570
- fork to https://github.com/ant-design/ant-design-mobile/pull/6576
- change api use onEllipsis



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - Ellipsis 组件新增 onEllipsis 回调属性，支持在内容展开或收起时触发回调，并返回当前状态及鼠标事件。
- **文档**
  - 更新了中英文文档，增加 onEllipsis 属性说明及用法示例。
- **测试**
  - 增加了 onEllipsis 回调相关的测试用例，验证展开与收起时回调的正确性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->