### PR TITLE
feat(Ellipsis): add onEllipsis callback to Ellipsis component

### DIFF
--- a/src/components/ellipsis/demos/demo1.tsx
+++ b/src/components/ellipsis/demos/demo1.tsx
@@ -31,7 +31,7 @@ export default () => {
           content={content}
           expandText='展开'
           collapseText='收起'
-          onEllipsis={ellipsis => {
+          onExpand={ellipsis => {
             Toast.show(`${ellipsis ? '展开' : '收起'}了`)
           }}
         />

--- a/src/components/ellipsis/demos/demo1.tsx
+++ b/src/components/ellipsis/demos/demo1.tsx
@@ -1,4 +1,4 @@
-import { Ellipsis, Space } from 'antd-mobile'
+import { Ellipsis, Space, Toast } from 'antd-mobile'
 import { DownOutline, UpOutline } from 'antd-mobile-icons'
 import { DemoBlock } from 'demos'
 import React from 'react'

--- a/src/components/ellipsis/demos/demo1.tsx
+++ b/src/components/ellipsis/demos/demo1.tsx
@@ -31,6 +31,9 @@ export default () => {
           content={content}
           expandText='展开'
           collapseText='收起'
+          onEllipsis={ellipsis => {
+            Toast.show(`${ellipsis ? '展开' : '收起'}了`)
+          }}
         />
       </DemoBlock>
 

--- a/src/components/ellipsis/ellipsis.tsx
+++ b/src/components/ellipsis/ellipsis.tsx
@@ -20,9 +20,11 @@ export type EllipsisProps = {
   stopPropagationForActionButtons?: PropagationEvent[]
   onContentClick?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
   defaultExpanded?: boolean
-  onEllipsis?: (
+  onExpand?: (
     ellipsis: boolean,
-    e: React.MouseEvent<HTMLAnchorElement, MouseEvent>
+    info: {
+      event: React.MouseEvent<HTMLAnchorElement, MouseEvent>
+    }
   ) => void
 } & NativeProps
 
@@ -63,7 +65,9 @@ export const Ellipsis: FC<EllipsisProps> = p => {
         <a
           onClick={e => {
             setExpanded(true)
-            props.onEllipsis?.(true, e)
+            props.onExpand?.(true, {
+              event: e,
+            })
           }}
         >
           {expandText}
@@ -77,7 +81,9 @@ export const Ellipsis: FC<EllipsisProps> = p => {
         <a
           onClick={e => {
             setExpanded(false)
-            props.onEllipsis?.(false, e)
+            props.onExpand?.(false, {
+              event: e,
+            })
           }}
         >
           {collapseText}

--- a/src/components/ellipsis/ellipsis.tsx
+++ b/src/components/ellipsis/ellipsis.tsx
@@ -20,6 +20,10 @@ export type EllipsisProps = {
   stopPropagationForActionButtons?: PropagationEvent[]
   onContentClick?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
   defaultExpanded?: boolean
+  onEllipsis?: (
+    ellipsis: boolean,
+    e: React.MouseEvent<HTMLAnchorElement, MouseEvent>
+  ) => void
 } & NativeProps
 
 const defaultProps = {

--- a/src/components/ellipsis/ellipsis.tsx
+++ b/src/components/ellipsis/ellipsis.tsx
@@ -21,7 +21,7 @@ export type EllipsisProps = {
   onContentClick?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
   defaultExpanded?: boolean
   onExpand?: (
-    ellipsis: boolean,
+    expanded: boolean,
     info: {
       event: React.MouseEvent<HTMLAnchorElement, MouseEvent>
     }

--- a/src/components/ellipsis/ellipsis.tsx
+++ b/src/components/ellipsis/ellipsis.tsx
@@ -61,8 +61,9 @@ export const Ellipsis: FC<EllipsisProps> = p => {
     ? withStopPropagation(
         stopPropagationForActionButtons,
         <a
-          onClick={() => {
+          onClick={e => {
             setExpanded(true)
+            props.onEllipsis?.(true, e)
           }}
         >
           {expandText}
@@ -74,8 +75,9 @@ export const Ellipsis: FC<EllipsisProps> = p => {
     ? withStopPropagation(
         stopPropagationForActionButtons,
         <a
-          onClick={() => {
+          onClick={e => {
             setExpanded(false)
+            props.onEllipsis?.(false, e)
           }}
         >
           {collapseText}

--- a/src/components/ellipsis/index.en.md
+++ b/src/components/ellipsis/index.en.md
@@ -26,7 +26,7 @@ When the display space is not enough, hide some content and replace it with "...
 | rows | The number to display lines | `number` | `1` |
 | stopPropagationForActionButtons | Prevent the event bubbling caused by the expand operation and the collapse operation | `PropagationEvent[]` | `[]` |
 | defaultExpanded | Whether to expand by default | `boolean` | `false` |
-| onEllipsis | Callback when expand or collapse | `(ellipsis: boolean, e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void` | `-` |
+| onExpand | Callback when expand or collapse | `(ellipsis: boolean, info: { event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void}` | - |
 
 ## FAQ
 

--- a/src/components/ellipsis/index.en.md
+++ b/src/components/ellipsis/index.en.md
@@ -26,7 +26,7 @@ When the display space is not enough, hide some content and replace it with "...
 | rows | The number to display lines | `number` | `1` |
 | stopPropagationForActionButtons | Prevent the event bubbling caused by the expand operation and the collapse operation | `PropagationEvent[]` | `[]` |
 | defaultExpanded | Whether to expand by default | `boolean` | `false` |
-| onEllipsis | Callback when expand or collapse | `(ellipsis: boolean, e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void` | `''` |
+| onEllipsis | Callback when expand or collapse | `(ellipsis: boolean, e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void` | `-` |
 
 ## FAQ
 

--- a/src/components/ellipsis/index.en.md
+++ b/src/components/ellipsis/index.en.md
@@ -26,6 +26,7 @@ When the display space is not enough, hide some content and replace it with "...
 | rows | The number to display lines | `number` | `1` |
 | stopPropagationForActionButtons | Prevent the event bubbling caused by the expand operation and the collapse operation | `PropagationEvent[]` | `[]` |
 | defaultExpanded | Whether to expand by default | `boolean` | `false` |
+| onEllipsis | Callback when expand or collapse | `(ellipsis: boolean, e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void` | `''` |
 
 ## FAQ
 

--- a/src/components/ellipsis/index.en.md
+++ b/src/components/ellipsis/index.en.md
@@ -16,17 +16,17 @@ When the display space is not enough, hide some content and replace it with "...
 
 ### Props
 
-| Name | Description | Type | Default |
-| --- | --- | --- | --- |
-| collapseText | Collapse operation text | `React.ReactNode` | `''` |
-| content | The text content | `string` | - |
-| direction | Position omitted | `'start' \| 'end' \| 'middle'` | `'end'` |
-| expandText | Expand operation text | `React.ReactNode` | `''` |
-| onContentClick | Trigger when clicked text content | `(e: React.MouseEvent) => void` | - |
-| rows | The number to display lines | `number` | `1` |
-| stopPropagationForActionButtons | Prevent the event bubbling caused by the expand operation and the collapse operation | `PropagationEvent[]` | `[]` |
-| defaultExpanded | Whether to expand by default | `boolean` | `false` |
-| onExpand | Callback when expand or collapse | `(ellipsis: boolean, info: { event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void}` | - |
+| Name | Description | Type | Default | Version |
+| --- | --- | --- | --- | --- |
+| collapseText | Collapse operation text | `React.ReactNode` | `''` |  |
+| content | The text content | `string` | - |  |
+| direction | Position omitted | `'start' \| 'end' \| 'middle'` | `'end'` |  |
+| expandText | Expand operation text | `React.ReactNode` | `''` |  |
+| onContentClick | Trigger when clicked text content | `(e: React.MouseEvent) => void` | - |  |
+| rows | The number to display lines | `number` | `1` |  |
+| stopPropagationForActionButtons | Prevent the event bubbling caused by the expand operation and the collapse operation | `PropagationEvent[]` | `[]` |  |
+| defaultExpanded | Whether to expand by default | `boolean` | `false` |  |
+| onExpand | Callback when expand or collapse | `(expanded: boolean, info: { event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void}` | - | 5.41.0 |
 
 ## FAQ
 

--- a/src/components/ellipsis/index.zh.md
+++ b/src/components/ellipsis/index.zh.md
@@ -26,6 +26,7 @@
 | rows | 展示几行 | `number` | `1` |
 | stopPropagationForActionButtons | 阻止展开操作，收起操作引发的事件冒泡 | `PropagationEvent[]` | `[]` |
 | defaultExpanded | 是否默认展开 | `boolean` | `false` |
+| onEllipsis | 展开或收起的回调 | `(ellipsis: boolean, e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void` | `''` |
 
 ## FAQ
 

--- a/src/components/ellipsis/index.zh.md
+++ b/src/components/ellipsis/index.zh.md
@@ -26,7 +26,7 @@
 | rows | 展示几行 | `number` | `1` |
 | stopPropagationForActionButtons | 阻止展开操作，收起操作引发的事件冒泡 | `PropagationEvent[]` | `[]` |
 | defaultExpanded | 是否默认展开 | `boolean` | `false` |
-| onEllipsis | 展开或收起的回调 | `(ellipsis: boolean, e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void` | `-` |
+| onExpand | 展开或收起的回调 | `(ellipsis: boolean, info: { event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void` | - |
 
 ## FAQ
 

--- a/src/components/ellipsis/index.zh.md
+++ b/src/components/ellipsis/index.zh.md
@@ -16,17 +16,17 @@
 
 ### 属性
 
-| 属性 | 说明 | 类型 | 默认值 |
-| --- | --- | --- | --- |
-| collapseText | 收起操作的文案 | `React.ReactNode` | `''` |
-| content | 文本内容 | `string` | - |
-| direction | 省略位置 | `'start' \| 'end' \| 'middle'` | `'end'` |
-| expandText | 展开操作的文案 | `React.ReactNode` | `''` |
-| onContentClick | 点击文本内容时触发 | `(e: React.MouseEvent) => void` | - |
-| rows | 展示几行 | `number` | `1` |
-| stopPropagationForActionButtons | 阻止展开操作，收起操作引发的事件冒泡 | `PropagationEvent[]` | `[]` |
-| defaultExpanded | 是否默认展开 | `boolean` | `false` |
-| onExpand | 展开或收起的回调 | `(ellipsis: boolean, info: { event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void` | - |
+| 属性 | 说明 | 类型 | 默认值 | 版本 |
+| --- | --- | --- | --- | --- |
+| collapseText | 收起操作的文案 | `React.ReactNode` | `''` |  |
+| content | 文本内容 | `string` | - |  |
+| direction | 省略位置 | `'start' \| 'end' \| 'middle'` | `'end'` |  |
+| expandText | 展开操作的文案 | `React.ReactNode` | `''` |  |
+| onContentClick | 点击文本内容时触发 | `(e: React.MouseEvent) => void` | - |  |
+| rows | 展示几行 | `number` | `1` |  |
+| stopPropagationForActionButtons | 阻止展开操作，收起操作引发的事件冒泡 | `PropagationEvent[]` | `[]` |  |
+| defaultExpanded | 是否默认展开 | `boolean` | `false` |  |
+| onExpand | 展开或收起的回调 | `(expanded: boolean, info: { event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void` | - | 5.41.0 |
 
 ## FAQ
 

--- a/src/components/ellipsis/index.zh.md
+++ b/src/components/ellipsis/index.zh.md
@@ -26,7 +26,7 @@
 | rows | 展示几行 | `number` | `1` |
 | stopPropagationForActionButtons | 阻止展开操作，收起操作引发的事件冒泡 | `PropagationEvent[]` | `[]` |
 | defaultExpanded | 是否默认展开 | `boolean` | `false` |
-| onEllipsis | 展开或收起的回调 | `(ellipsis: boolean, e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void` | `''` |
+| onEllipsis | 展开或收起的回调 | `(ellipsis: boolean, e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void` | `-` |
 
 ## FAQ
 

--- a/src/components/ellipsis/tests/ellipsis.test.tsx
+++ b/src/components/ellipsis/tests/ellipsis.test.tsx
@@ -111,7 +111,7 @@ describe('Ellipsis', () => {
         defaultExpanded
         expandText='expand'
         collapseText='collapse'
-        onEllipsis={ellipsis => {
+        onExpand={ellipsis => {
           toggle(ellipsis)
         }}
       />

--- a/src/components/ellipsis/tests/ellipsis.test.tsx
+++ b/src/components/ellipsis/tests/ellipsis.test.tsx
@@ -103,6 +103,26 @@ describe('Ellipsis', () => {
     expect(ellipsis).toHaveTextContent('...')
   })
 
+  test('check onEllipsis should be work', () => {
+    const toggle = jest.fn()
+    const { getByText } = render(
+      <Ellipsis
+        content={content}
+        defaultExpanded
+        expandText='expand'
+        collapseText='collapse'
+        onEllipsis={ellipsis => {
+          toggle(ellipsis)
+        }}
+      />
+    )
+    fireEvent.click(getByText('collapse'))
+    expect(toggle).toBeCalledWith(false)
+
+    fireEvent.click(getByText('expand'))
+    expect(toggle).toBeCalledWith(true)
+  })
+
   test('content not exceeded', () => {
     const { getByTestId } = render(
       <Ellipsis content='abc' data-testid='ellipsis' />


### PR DESCRIPTION
- 解决该 issue 的问题 https://github.com/ant-design/ant-design-mobile/issues/6570
- fork to https://github.com/ant-design/ant-design-mobile/pull/6576
- change api use onEllipsis

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - Ellipsis 组件新增 onExpand 回调属性，支持在内容展开或收起时触发回调，并返回当前状态和事件对象。
  - 在示例中新增 onExpand 回调，触发时显示对应的展开或收起提示。
- **文档**
  - 更新中英文文档，增加 onExpand 属性说明及用法示例，文档中新增版本信息列。
- **测试**
  - 新增 onExpand 回调相关的单元测试，验证其在展开和收起时能正确触发。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->