### PR TITLE
chore: ci remove bun

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -57,9 +57,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 16
-      - uses: oven-sh/setup-bun@v2
-      - run: bun install
+      - uses: pnpm/action-setup@v4
+      - run: pnpm install
       - name: install react 19
-        run: bun run bun-install-react-19
+        run: pnpm run pnpm-install-react-19
       - name: run tests
-        run: bun run test src/utils/tests/unstable.test.ts
+        run: pnpm run test src/utils/tests/unstable.test.ts

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           version: 7
           run_install: false
-      - run: pnpm install
+      - run: pnpm install --ignore-peer-dependencies
       - name: install react 19
         run: pnpm run pnpm-install-react-19
       - name: run tests

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           version: 7
           run_install: false
-      - run: pnpm install --ignore-peer-dependencies
+      - run: pnpm install --ignore-scripts --strict-peer-dependencies=false
       - name: install react 19
         run: pnpm run pnpm-install-react-19
       - name: run tests

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -58,6 +58,9 @@ jobs:
         with:
           node-version: 16
       - uses: pnpm/action-setup@v4
+        with:
+          version: 7
+          run_install: false
       - run: pnpm install
       - name: install react 19
         run: pnpm run pnpm-install-react-19

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -63,6 +63,6 @@ jobs:
           run_install: false
       - run: pnpm install --ignore-scripts --strict-peer-dependencies=false
       - name: install react 19
-        run: pnpm run pnpm-install-react-19
+        run: pnpm run ci-install-react-19
       - name: run tests
         run: pnpm run test src/utils/tests/unstable.test.ts

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           version: 7
           run_install: false
-      - run: pnpm install
+      - run: pnpm install --ignore-peer-dependencies
       - name: build site
         id: site
         run: pnpm run build-doc

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -23,11 +23,11 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 16
-      - uses: oven-sh/setup-bun@v2
-      - run: bun install
+      - uses: pnpm/action-setup@v4
+      - run: pnpm install
       - name: build site
         id: site
-        run: bun run build-doc
+        run: pnpm run build-doc
         env:
           NODE_OPTIONS: --max_old_space_size=4096
       - run: |

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           version: 7
           run_install: false
-      - run: pnpm install --ignore-peer-dependencies
+      - run: pnpm install --ignore-scripts --strict-peer-dependencies=false
       - name: build site
         id: site
         run: pnpm run build-doc

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           node-version: 16
       - uses: pnpm/action-setup@v4
+        with:
+          version: 7
+          run_install: false
       - run: pnpm install
       - name: build site
         id: site

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "14.2.1",
     "@types/big.js": "^6.1.6",
-    "@types/jest": "^28.1.8",
     "@types/jest-axe": "3.5.4",
     "@types/lodash": "^4.14.194",
     "@types/node": "^18.15.13",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "size-limit:ci": "size-limit --json",
     "start": "dumi dev",
     "test": "jest",
-    "bun-install-react-19": "bun remove react react-dom && bun add --no-save react@19 react-dom@19",
+    "pnpm-install-react-19": "pnpm remove react react-dom && pnpm add --no-save react@19 react-dom@19",
     "test-with-coverage": "jest --coverage"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "14.2.1",
     "@types/big.js": "^6.1.6",
+    "@types/jest": "^28.1.8",
     "@types/jest-axe": "3.5.4",
     "@types/lodash": "^4.14.194",
     "@types/node": "^18.15.13",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "size-limit:ci": "size-limit --json",
     "start": "dumi dev",
     "test": "jest",
-    "pnpm-install-react-19": "pnpm remove react react-dom && pnpm add --no-save react@19 react-dom@19",
+    "ci-install-react-19": "pnpm i react@19 react-dom@19",
     "test-with-coverage": "jest --coverage"
   },
   "lint-staged": {


### PR DESCRIPTION
感觉 bun 这货也太容易出幺蛾子了

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - 持续集成流程从 Bun 包管理器切换为 pnpm，包括依赖安装、React 19 安装和测试、文档构建等相关命令的更新。
  - 脚本由 "bun-install-react-19" 替换为 "ci-install-react-19"，以适配 pnpm 包管理器。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->