### PR TITLE
docs: add disableBodyScroll prop in Popup document

### DIFF
--- a/src/components/popup/index.en.md
+++ b/src/components/popup/index.en.md
@@ -26,6 +26,7 @@ It is suitable for displaying pop-up windows, information prompts, selection inp
 | closeOnMaskClick | Whether to close after clicking the mask layer | `boolean` | `false` |
 | closeIcon | Custom close button icon | `ReactNode` | `<CloseOutline/>` |
 | destroyOnClose | Destroy `dom` when not visible | `boolean` | `false` |
+| disableBodyScroll | Mask Whether to disable body scrolling | `boolean` | `true` |
 | forceRender | Render content forcely | `boolean` | `false` |
 | getContainer | To get the specified mounted `HTML` node, the default is `body`, if `null` returned, it would be rendered to the current node | `HTMLElement \| () => HTMLElement \| null` | `() => document.body` |
 | mask | Whether to display Mask | `boolean` | `true` |

--- a/src/components/popup/index.zh.md
+++ b/src/components/popup/index.zh.md
@@ -26,6 +26,7 @@
 | closeOnMaskClick | 点击背景蒙层后是否关闭 | `boolean` | `false` |
 | closeIcon | 自定义关闭按钮图标 | `ReactNode` | `<CloseOutline/>` |
 | destroyOnClose | 不可见时是否销毁 `DOM` 结构 | `boolean` | `false` |
+| disableBodyScroll | 背景蒙层是否禁用 body 滚动 | `boolean` | `true` |
 | forceRender | 强制渲染内容 | `boolean` | `false` |
 | getContainer | 指定挂载的 `HTML` 节点，默认为 `body`，如果为 `null` 的话，会渲染到当前节点 | `HTMLElement \| () => HTMLElement \| null` | `() => document.body` |
 | mask | 是否展示蒙层 | `boolean` | `true` |


### PR DESCRIPTION
添加popup组件缺少的disableBodyScroll参数的文档注释

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 在 Popup 组件文档中新增了 `disableBodyScroll` 属性说明，该属性用于控制遮罩激活时是否禁用页面滚动，默认值为 `true`。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->