### PR TITLE
fix: 优化处理自定义渲染内容

### DIFF
--- a/src/components/image-viewer/image-viewer.tsx
+++ b/src/components/image-viewer/image-viewer.tsx
@@ -28,6 +28,7 @@ export type ImageViewerProps = {
   afterClose?: () => void
   renderFooter?: (image: string) => ReactNode
   imageRender?: (image: string, { index }: { index: number }) => ReactNode
+  partialCustomRender?: boolean
   classNames?: {
     mask?: string
     body?: string
@@ -38,6 +39,7 @@ const defaultProps = {
   maxZoom: 3,
   getContainer: null,
   visible: false,
+  partialCustomRender: true, // 是否部分自定义渲染（true: 自定义但保留图片拖动，false: 完全自定义，不处理拖拽）
 }
 
 export const ImageViewer: FC<ImageViewerProps> = p => {
@@ -64,6 +66,7 @@ export const ImageViewer: FC<ImageViewerProps> = p => {
             onTap={props.onClose}
             maxZoom={props.maxZoom}
             imageRender={props.imageRender}
+            partialCustomRender={props.partialCustomRender}
           />
         )}
       </div>
@@ -89,6 +92,7 @@ export type MultiImageViewerProps = Omit<
   onIndexChange?: (index: number) => void
   renderFooter?: (image: string, index: number) => ReactNode
   imageRender?: (image: string, { index }: { index: number }) => ReactNode
+  partialCustomRender?: boolean
 }
 
 const multiDefaultProps = {
@@ -144,6 +148,7 @@ export const MultiImageViewer = forwardRef<
             onTap={props.onClose}
             maxZoom={props.maxZoom}
             imageRender={props.imageRender}
+            partialCustomRender={props.partialCustomRender}
           />
         )}
       </div>

--- a/src/components/image-viewer/index.en.md
+++ b/src/components/image-viewer/index.en.md
@@ -22,6 +22,7 @@ You need to click on the picture to view the details and use it with the thumbna
 | onClose | Triggered when it is closed | `() => void` | - |  |
 | renderFooter | Render extra content on footer | `(image: string) => ReactNode` | - |  |
 | imageRender | Custom rendering content | `(image: string, { index }: { index: number }) => ReactNode` | - | 5.39.0 |
+| partialCustomRender | Whether to partially customize rendering (`true`: customize but keep image dragging, `false`: fully customize, do not handle dragging) | `boolean` | `true` |  |
 | visible | Whether to show or hide | `boolean` | `false` |  |
 
 ## ImageViewer.Multi
@@ -36,6 +37,7 @@ On the basis of `ImageViewer`, the following props have been added:
 | onIndexChange | Triggered when the picture is switched | `(index: number) => void` | - |  |
 | renderFooter | Render extra content on footer | `(image: string, index: number) => ReactNode` | - |  |
 | imageRender | Custom rendering content | `(image: string, { index }: { index: number }) => ReactNode` | - |  |
+| partialCustomRender | Whether to partially customize rendering (`true`: customize but keep image dragging, `false`: fully customize, do not handle dragging) | `boolean` | `true` |  |
 
 At the same time, the `image` prop is removed.
 

--- a/src/components/image-viewer/index.zh.md
+++ b/src/components/image-viewer/index.zh.md
@@ -22,6 +22,7 @@
 | onClose | 关闭时触发 | `() => void` | - |  |
 | renderFooter | 渲染底部额外内容 | `(image: string) => ReactNode` | - |  |
 | imageRender | 自定义渲染内容 | `(image: string, { index }: { index: number }) => ReactNode` | - | 5.39.0 |
+| partialCustomRender | 是否部分自定义渲染（`true`: 自定义但保留图片拖动，`false`: 完全自定义，不处理拖拽） | `boolean` | `true` |  |
 | visible | 是否显示 | `boolean` | `false` |  |
 
 ## ImageViewer.Multi
@@ -34,6 +35,96 @@
 | onIndexChange | 切换图片时触发 | `(index: number) => void` | - |  |
 | renderFooter | 渲染底部额外内容 | `(image: string, index: number) => ReactNode` | - |  |
 | imageRender | 自定义渲染内容 | `(image: string, { index }: { index: number }) => ReactNode` | - |  |
+| partialCustomRender | 是否部分自定义渲染（`true`: 自定义但保留图片拖动，`false`: 完全自定义，不处理拖拽） | `boolean` | `true` |  |
+
+其他属性同 `ImageViewer`，但是去掉了 `image` 属性。
+
+### Ref
+
+| 属性    | 说明           | 类型                                          |
+| ------- | -------------- | --------------------------------------------- |
+| swipeTo | 切换到指定索引 | `(index: number, immediate: boolean) => void` |
+
+## 指令式
+
+相比于上文中组件式的使用方式，指令式更加方便也更加常用，在大多数情况下，都推荐使用这种方式：
+
+```ts | pure
+const handler = ImageViewer.show(props)
+const handlerMulti = ImageViewer.Multi.show(props)
+```
+
+可以通过调用 `ImageViewer` 上的 `show` 方法直接进入图片查看。其中 `props` 参数的类型同上表，但不支持传入 `visible` 属性。当查看器被关闭后，组件实例会自动销毁。
+
+`show` 方法的返回值为一个组件控制器，包含以下属性：
+
+| 属性  | 说明           | 类型         |
+| ----- | -------------- | ------------ |
+| close | 关闭图片查看器 | `() => void` |
+
+如果你想关闭全部通过指令式创建出来的 ImageViewer，可以调用 `ImageViewer.clear()`。
+
+## FAQ
+
+### 为什么我更新了 `defaultIndex` 的值，但是 ImageViewer.Multi 显示的图片并没有切换？
+
+ImageViewer.Multi 是一个[非受控](https://reactjs.org/docs/glossary.html#controlled-vs-uncontrolled-components)的组件，`defaultIndex` 只会在组件加载的时候读取一次，在此之后，如果你修改了 `defaultIndex` 的值，并不会对组件有任何的影响。因此，下面这种写法并不能起到切换图片的效果：
+
+```jsx
+<Button
+  onClick={() => {
+    setIndex(i => i + 1)
+  }}
+>
+  Next
+</Button>
+
+<ImageViewer.Multi
+  images={images}
+  defaultIndex={index}
+/>
+```
+
+你可以使用 ref 来对 ImageViewer.Multi 进行手动的操作，也可以考虑使用 `ImageViewer.show()`。
+
+# ImageViewer 图片查看器
+
+通过放大查看图片全貌。
+
+## 何时使用
+
+需要点开图片查看细节，配合缩略图使用。
+
+## 示例
+
+<code src="./demos/demo1.tsx"></code>
+
+## ImageViewer
+
+| 属性 | 说明 | 类型 | 默认值 | 版本 |
+| --- | --- | --- | --- | --- |
+| afterClose | 完全关闭后触发 | `() => void` | - |  |
+| classNames | 语义化 class | `{ mask?:string,body?:string }` | - | 5.33.1 |
+| getContainer | 指定挂载的 HTML 节点，默认为 `null` 渲染到当前节点 | `HTMLElement \| () => HTMLElement \| null` | `null` |  |
+| image | 图片资源的 `url` | `string` | - |  |
+| maxZoom | 最大缩放比例 | `number \| 'auto'` | `3` |  |
+| onClose | 关闭时触发 | `() => void` | - |  |
+| renderFooter | 渲染底部额外内容 | `(image: string) => ReactNode` | - |  |
+| imageRender | 自定义渲染内容 | `(image: string, { index }: { index: number }) => ReactNode` | - | 5.39.0 |
+| partialCustomRender | 是否部分自定义渲染（`true`: 自定义但保留图片拖动，`false`: 完全自定义，不处理拖拽） | `boolean` | `true` |  |
+| visible | 是否显示 | `boolean` | `false` |  |
+
+## ImageViewer.Multi
+
+| 属性 | 说明 | 类型 | 默认值 | 版本 |
+| --- | --- | --- | --- | --- |
+| classNames | 语义化 class | `{ mask?:string,body?:string }` | - | 5.33.1 |
+| defaultIndex | 默认显示第几张图片 | `number` | `0` |  |
+| images | 图片资源的 url 列表 | `string[]` | - |  |
+| onIndexChange | 切换图片时触发 | `(index: number) => void` | - |  |
+| renderFooter | 渲染底部额外内容 | `(image: string, index: number) => ReactNode` | - |  |
+| imageRender | 自定义渲染内容 | `(image: string, { index }: { index: number }) => ReactNode` | - |  |
+| partialCustomRender | 是否部分自定义渲染（`true`: 自定义但保留图片拖动，`false`: 完全自定义，不处理拖拽） | `boolean` | `true` |  |
 
 其他属性同 `ImageViewer`，但是去掉了 `image` 属性。
 

--- a/src/components/image-viewer/slides.tsx
+++ b/src/components/image-viewer/slides.tsx
@@ -19,6 +19,7 @@ export type SlidesType = {
   defaultIndex: number
   onIndexChange?: (index: number) => void
   imageRender?: (image: string, { index }: { index: number }) => ReactNode
+  partialCustomRender?: boolean
 }
 export type SlidesRef = {
   swipeTo: (index: number, immediate?: boolean) => void
@@ -102,6 +103,7 @@ export const Slides = forwardRef<SlidesRef, SlidesType>((props, ref) => {
             onTap={props.onTap}
             maxZoom={props.maxZoom}
             imageRender={props.imageRender}
+            partialCustomRender={props.partialCustomRender}
             index={index}
             onZoomChange={zoom => {
               if (zoom !== 1) {


### PR DESCRIPTION
问题：
在自定渲染内容的时候，放大的时候，点击或者移动会缩小，或者切换
新增和优化
修改了下，图片预览在自定义的时候，保留图片拖动问题，
新增了是否完全使用自定义或使用自定义但保留拖动问题
` const domRender = (dom: React.ReactElement): React.ReactElement => {
    // 完全放开自定义render，不需要需要将ref应用到img上
    if (!partialCustomRender) return dom

    // 自定义但是保留图片拖动
    let refApplied = false
    function recursiveClone(element: React.ReactElement): React.ReactElement {
      if (!React.isValidElement(element)) return element

      if (['img', 'video'].includes(element.type) && !refApplied) {
        refApplied = true
        return React.cloneElement(element, { ref: imgRef })
      }

      const children = element?.props?.children
      if (children) {
        const newChildren = React.Children.map(children, child =>
          React.isValidElement(child) ? recursiveClone(child) : child
        )
        return React.cloneElement(element, undefined, newChildren)
      }
      return element
    }
    return recursiveClone(dom)
  }`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 为 ImageViewer 和 ImageViewer.Multi 组件新增了可选属性 `partialCustomRender`，用于控制自定义渲染的程度，默认值为 `true`。当为 `true` 时，支持部分自定义且保留拖拽功能；为 `false` 时，允许完全自定义但不支持拖拽。
* **文档**
  * 更新了中英文文档，详细说明了 `partialCustomRender` 属性的用法和行为。
  * 中文文档新增了多图查看器的 `Ref` 方法、指令式用法说明及常见问题解答。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->