### PR TITLE
fix: iso date base date string

### DIFF
--- a/src/components/date-picker/date-picker-week-utils.ts
+++ b/src/components/date-picker/date-picker-week-utils.ts
@@ -135,7 +135,8 @@ export function convertStringArrayToDate<
   const yearString = value[0] ?? '1900'
   const weekString = value[1] ?? '1'
   const weekdayString = value[2] ?? '1'
-  const day = dayjs(`${parseInt(yearString as string)}-01-01`)
+  // See https://github.com/ant-design/ant-design-mobile/issues/6905
+  const day = dayjs(`${parseInt(yearString as string)}-01-04`)
     .isoWeek(parseInt(weekString as string))
     .isoWeekday(parseInt(weekdayString as string))
     .hour(0)

--- a/src/components/date-picker/tests/date-picker.test.tsx
+++ b/src/components/date-picker/tests/date-picker.test.tsx
@@ -207,16 +207,39 @@ describe('DatePicker', () => {
     expect(res.tillNow).toBeTruthy()
   })
 
-  test('convertStringArrayToDate of week should correct', () => {
-    // jest mock today is `2024-12-30`
-    jest.useFakeTimers({
-      now: new Date('2024-12-30'),
+  describe('convertStringArrayToDate of week should correct', () => {
+    it('2024-1-1 -> 2024-01-01', () => {
+      // jest mock today is `2024-12-30`
+      jest.useFakeTimers({
+        now: new Date('2024-12-30'),
+      })
+
+      const date = convertStringArrayToDate(['2024', '1', '1'])
+      expect(date.getFullYear()).toBe(2024)
+      expect(date.getMonth()).toBe(0)
+      expect(date.getDate()).toBe(1)
     })
 
-    const date = convertStringArrayToDate(['2024', '1', '1'])
-    expect(date.getFullYear()).toBe(2024)
-    expect(date.getMonth()).toBe(0)
-    expect(date.getDate()).toBe(1)
+    it('2023-1-1 -> 2023-01-02', () => {
+      const date = convertStringArrayToDate(['2023', '1', '1'])
+      expect(date.getFullYear()).toBe(2023)
+      expect(date.getMonth()).toBe(0)
+      expect(date.getDate()).toBe(2)
+    })
+
+    it('2020-1-1 -> 2019-12-30', () => {
+      const date = convertStringArrayToDate(['2020', '1', '1'])
+      expect(date.getFullYear()).toBe(2019)
+      expect(date.getMonth()).toBe(11)
+      expect(date.getDate()).toBe(30)
+    })
+
+    it('2023-27-1 -> 2023-07-03', () => {
+      const date = convertStringArrayToDate(['2023', '27', '1'])
+      expect(date.getFullYear()).toBe(2023)
+      expect(date.getMonth()).toBe(6)
+      expect(date.getDate()).toBe(3)
+    })
   })
 
   test('renderLabel should be work', async () => {


### PR DESCRIPTION
- 解决该 issue 的问题 #6905 
- iso date base date string

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **修复**
  - 修复 iso 年 周 日 基础时间错误导致的年误差

 ## ISO 周的定义(查询资料)
- 每一年的第 1 个 ISO 周：是 包含该年 1 月 4 日的那一周。
- ISO 周是以 周一开始 的。
- 所以 1月1日 可能还属于上一年的 ISO 年。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->