### PR TITLE
fix: Fixed the issue that the asynchronous setting of enterKeyHint fails when textarea is in autoFocus

### DIFF
--- a/src/components/text-area/text-area.tsx
+++ b/src/components/text-area/text-area.tsx
@@ -201,6 +201,7 @@ export const TextArea = forwardRef<TextAreaRef, TextAreaProps>(
           onBlur={props.onBlur}
           onClick={props.onClick}
           onKeyDown={handleKeydown}
+          enterKeyHint={props.enterKeyHint}
         />
         {count}
 


### PR DESCRIPTION
fix: Fixed the issue that the asynchronous setting of enterKeyHint fails when textarea is in autoFocus

当TextArea设置autoFocus时，通过useLayoutEffect设置的enterKeyHint属性在当次不会生效，需要重新触发焦点才能生效；

和豆酱沟通后提交pr，增加默认enterKeyHint设置；