### PR TITLE
fix: 修正数字键盘在安卓 talkback 下可读不可点的问题

### DIFF
--- a/src/components/number-keyboard/index.zh.md
+++ b/src/components/number-keyboard/index.zh.md
@@ -12,7 +12,9 @@
 
 ## 示例
 
-tips: 建议在移动端打开 demo 预览效果更佳，因为组件使用的 touch 事件在 web 端看不到效果
+~~tips: 建议在移动端打开 demo 预览效果更佳，因为组件使用的 touch 事件在 web 端看不到效果~~
+
+已修改事件机制支持 PC web 预览
 
 <code src="./demos/demo1.tsx"></code>
 

--- a/src/components/number-keyboard/index.zh.md
+++ b/src/components/number-keyboard/index.zh.md
@@ -12,9 +12,7 @@
 
 ## 示例
 
-~~tips: 建议在移动端打开 demo 预览效果更佳，因为组件使用的 touch 事件在 web 端看不到效果~~
-
-已修改事件机制支持 PC web 预览
+tips: 仅移动端下删除按钮支持长按快删（通过 touchStart/touchEnd 实现）。
 
 <code src="./demos/demo1.tsx"></code>
 

--- a/src/components/number-keyboard/tests/number-keyboard.test.tsx
+++ b/src/components/number-keyboard/tests/number-keyboard.test.tsx
@@ -1,12 +1,13 @@
 import React, { useState } from 'react'
 import { fireEvent, render, screen, testA11y, waitFor } from 'testing'
 import NumberKeyboard from '..'
+import { getDefaultConfig } from '../../config-provider'
 
 const classPrefix = 'adm-number-keyboard'
+const { locale } = getDefaultConfig()
 
 function mockClick(el: HTMLElement) {
-  fireEvent.touchStart(el, { touches: [{}] })
-  fireEvent.touchEnd(el, { touches: [{}] })
+  fireEvent.click(el)
 }
 
 describe('NumberKeyboard', () => {
@@ -65,7 +66,7 @@ describe('NumberKeyboard', () => {
       />
     )
 
-    mockClick(screen.getByTitle('BACKSPACE'))
+    mockClick(screen.getByTitle(locale.Input.clear))
     expect(onDelete).toBeCalled()
 
     mockClick(screen.getByText('-'))
@@ -86,7 +87,7 @@ describe('NumberKeyboard', () => {
       />
     )
     const confirm = screen.getByText('confirm')
-    const del = screen.getByTitle('清除')
+    const del = screen.getByTitle(locale.Input.clear)
     expect(confirm).toBeInTheDocument()
     expect(confirm).toHaveClass(
       `${classPrefix}-key-extra ${classPrefix}-key-ok`
@@ -137,7 +138,7 @@ describe('NumberKeyboard', () => {
     jest.useFakeTimers()
     const onDelete = jest.fn()
     render(<NumberKeyboard visible onDelete={onDelete} />)
-    const del = screen.getByTitle('BACKSPACE')
+    const del = screen.getByTitle(locale.Input.clear)
     fireEvent.touchStart(del, { touches: [{}] })
     jest.runOnlyPendingTimers()
     expect(onDelete).toBeCalledTimes(1)
@@ -190,11 +191,10 @@ describe('NumberKeyboard', () => {
 
     // We do not fire touchend event to mock ISO missing touchend event
     // Press other key
-    fireEvent.touchStart(
+    mockClick(
       document.body.querySelector(
         '.adm-number-keyboard-key-number'
-      ) as HTMLDivElement,
-      { touches: [{}] }
+      ) as HTMLDivElement
     )
 
     jest.advanceTimersByTime(10000)

--- a/src/components/number-keyboard/tests/number-keyboard.test.tsx
+++ b/src/components/number-keyboard/tests/number-keyboard.test.tsx
@@ -177,16 +177,20 @@ describe('NumberKeyboard', () => {
     const { container } = render(<NumberKeyboard visible onDelete={onDelete} />)
 
     // Fire touchstart event
-    fireEvent.touchStart(
-      document.body.querySelector(
-        '.adm-number-keyboard-key-sign'
-      ) as HTMLDivElement,
-      { touches: [{}] }
-    )
+    fireEvent.touchStart(screen.getByTitle(locale.Input.clear), {
+      touches: [{}],
+    })
     onDelete.mockReset()
 
     jest.advanceTimersByTime(10000)
     expect(onDelete).toHaveBeenCalled()
+
+    // release
+    fireEvent.touchEnd(screen.getByTitle(locale.Input.clear), { touches: [{}] })
+    const callTimes = onDelete.mock.calls.length
+    jest.advanceTimersByTime(10000)
+    expect(onDelete.mock.calls.length).toBe(callTimes)
+
     onDelete.mockReset()
 
     // We do not fire touchend event to mock ISO missing touchend event

--- a/src/components/number-keyboard/tests/number-keyboard.test.tsx
+++ b/src/components/number-keyboard/tests/number-keyboard.test.tsx
@@ -204,4 +204,39 @@ describe('NumberKeyboard', () => {
     jest.advanceTimersByTime(10000)
     expect(onDelete).not.toHaveBeenCalled()
   })
+
+  test('long press backspace and release with confirmText', () => {
+    const onDelete = jest.fn()
+    const { container } = render(
+      <NumberKeyboard visible confirmText='确定' onDelete={onDelete} />
+    )
+
+    // Fire touchstart event
+    fireEvent.touchStart(screen.getByTitle(locale.Input.clear), {
+      touches: [{}],
+    })
+    onDelete.mockReset()
+
+    jest.advanceTimersByTime(10000)
+    expect(onDelete).toHaveBeenCalled()
+
+    // release
+    fireEvent.touchEnd(screen.getByTitle(locale.Input.clear), { touches: [{}] })
+    const callTimes = onDelete.mock.calls.length
+    jest.advanceTimersByTime(10000)
+    expect(onDelete.mock.calls.length).toBe(callTimes)
+
+    onDelete.mockReset()
+
+    // We do not fire touchend event to mock ISO missing touchend event
+    // Press other key
+    mockClick(
+      document.body.querySelector(
+        '.adm-number-keyboard-key-number'
+      ) as HTMLDivElement
+    )
+
+    jest.advanceTimersByTime(10000)
+    expect(onDelete).not.toHaveBeenCalled()
+  })
 })

--- a/src/components/passcode-input/tests/passcode-input.test.tsx
+++ b/src/components/passcode-input/tests/passcode-input.test.tsx
@@ -11,8 +11,7 @@ function getCells() {
 }
 
 function mockClick(el: HTMLElement) {
-  fireEvent.touchStart(el, { touches: [{}] })
-  fireEvent.touchEnd(el, { touches: [{}] })
+  fireEvent.click(el)
 }
 
 describe('PasscodeInput', () => {

--- a/src/components/virtual-input/tests/virtual-input.test.tsx
+++ b/src/components/virtual-input/tests/virtual-input.test.tsx
@@ -1,9 +1,11 @@
 import React, { createRef } from 'react'
 import { act, fireEvent, render, screen, waitFor } from 'testing'
+import { getDefaultConfig } from '../../config-provider'
 import NumberKeyboard from '../../number-keyboard'
 import { VirtualInput, VirtualInputRef } from '../virtual-input'
 
 const classPrefix = 'adm-virtual-input'
+const { locale } = getDefaultConfig()
 const TWO_DIGIT_NUMBER_REGEX = /^(([1-9]\d{0,11})|0)(\.\d{0,2}?)?$/
 
 function getSiblingElements(element: Element | null) {
@@ -183,15 +185,15 @@ describe('VirtualInput', () => {
         document.querySelector(`.${KeyBoardClassPrefix}-popup`)
       ).toBeVisible()
     })
-    fireEvent.touchEnd(screen.getByText('0'))
+    fireEvent.click(screen.getByText('0'))
     expect(document.querySelector(`.${classPrefix}-content`)).toHaveTextContent(
       '0'
     )
-    fireEvent.touchEnd(screen.getByText('1'))
+    fireEvent.click(screen.getByText('1'))
     expect(document.querySelector(`.${classPrefix}-content`)).toHaveTextContent(
       '01'
     )
-    fireEvent.touchEnd(screen.getByTitle('BACKSPACE'))
+    fireEvent.click(screen.getByTitle(locale.Input.clear))
     expect(
       document.querySelector(`.${classPrefix}-content`)
     ).not.toHaveTextContent('01')
@@ -239,7 +241,7 @@ describe('VirtualInput', () => {
     })
 
     // click '5' by keyboard，content should be '12345'
-    fireEvent.touchEnd(screen.getByText('5'))
+    fireEvent.click(screen.getByText('5'))
     expect(document.querySelector(`.${classPrefix}-content`)).toHaveTextContent(
       '12345'
     )
@@ -257,7 +259,7 @@ describe('VirtualInput', () => {
       expect(getCaretPosition(caretContainer)).toBe(3)
 
       // click '9' by keyboard, content should be '123945', caret position should be 4
-      fireEvent.touchEnd(screen.getByText('9'))
+      fireEvent.click(screen.getByText('9'))
       await waitFor(() => {
         expect(
           document.querySelector(`.${KeyBoardClassPrefix}-popup`)
@@ -269,7 +271,7 @@ describe('VirtualInput', () => {
       expect(getCaretPosition(caretContainer)).toBe(4)
 
       // click delete by keyboard, content should be '12345', caret position should be 3
-      fireEvent.touchEnd(screen.getByTitle('清除'))
+      fireEvent.click(screen.getByTitle(locale.Input.clear))
       await waitFor(() => {
         expect(
           document.querySelector(`.${KeyBoardClassPrefix}-popup`)
@@ -306,9 +308,9 @@ describe('VirtualInput', () => {
     })
 
     // click '1', '2', '3' by keyboard，content should be '123'
-    fireEvent.touchEnd(screen.getByText('1'))
-    fireEvent.touchEnd(screen.getByText('2'))
-    fireEvent.touchEnd(screen.getByText('3'))
+    fireEvent.click(screen.getByText('1'))
+    fireEvent.click(screen.getByText('2'))
+    fireEvent.click(screen.getByText('3'))
     expect(document.querySelector(`.${classPrefix}-content`)).toHaveTextContent(
       '123'
     )
@@ -327,7 +329,7 @@ describe('VirtualInput', () => {
     expect(getCaretPosition(caretContainer)).toBe(0)
 
     // click '9' by keyboard, content should be '9123', caret position should be 1
-    fireEvent.touchEnd(screen.getByText('9'))
+    fireEvent.click(screen.getByText('9'))
     await waitFor(() => {
       expect(
         document.querySelector(`.${KeyBoardClassPrefix}-popup`)
@@ -339,7 +341,7 @@ describe('VirtualInput', () => {
     expect(getCaretPosition(caretContainer)).toBe(1)
 
     // click delete by keyboard, content should be '123', caret position should be 1
-    fireEvent.touchEnd(screen.getByTitle('清除'))
+    fireEvent.click(screen.getByTitle(locale.Input.clear))
     await waitFor(() => {
       expect(
         document.querySelector(`.${KeyBoardClassPrefix}-popup`)
@@ -397,9 +399,9 @@ describe('VirtualInput', () => {
     })
 
     // click '1', '2', '3' by keyboard，content should be '123'
-    fireEvent.touchEnd(screen.getByTitle('1'))
-    fireEvent.touchEnd(screen.getByTitle('0'))
-    fireEvent.touchEnd(screen.getByTitle('3'))
+    fireEvent.click(screen.getByTitle('1'))
+    fireEvent.click(screen.getByTitle('0'))
+    fireEvent.click(screen.getByTitle('3'))
     expect(document.querySelector(`.${classPrefix}-content`)).toHaveTextContent(
       '103'
     )
@@ -411,9 +413,9 @@ describe('VirtualInput', () => {
       expect(getCaretPosition(caretContainer)).toBe(3)
 
       //  输入小数部分
-      fireEvent.touchEnd(screen.getByTitle('.'))
-      fireEvent.touchEnd(screen.getByTitle('4'))
-      fireEvent.touchEnd(screen.getByTitle('5'))
+      fireEvent.click(screen.getByTitle('.'))
+      fireEvent.click(screen.getByTitle('4'))
+      fireEvent.click(screen.getByTitle('5'))
 
       expect(
         document.querySelector(`.${classPrefix}-content`)
@@ -425,7 +427,7 @@ describe('VirtualInput', () => {
         clickSiblingElements(caretContainer, 2, true)
       })
       expect(getCaretPosition(caretContainer)).toBe(2)
-      fireEvent.touchEnd(screen.getByTitle('.'))
+      fireEvent.click(screen.getByTitle('.'))
       expect(
         document.querySelector(`.${classPrefix}-content`)
       ).toHaveTextContent('103.45')
@@ -436,7 +438,7 @@ describe('VirtualInput', () => {
         clickSiblingElements(caretContainer, 0, true)
       })
       expect(getCaretPosition(caretContainer)).toBe(0)
-      fireEvent.touchEnd(screen.getByTitle('.'))
+      fireEvent.click(screen.getByTitle('.'))
       expect(
         document.querySelector(`.${classPrefix}-content`)
       ).toHaveTextContent('103.45')
@@ -448,7 +450,7 @@ describe('VirtualInput', () => {
       })
       expect(getCaretPosition(caretContainer)).toBe(1)
 
-      fireEvent.touchEnd(screen.getByTitle('清除')) // 点删除
+      fireEvent.click(screen.getByTitle(locale.Input.clear)) // 点删除
       await waitFor(() => {
         expect(
           document.querySelector(`.${KeyBoardClassPrefix}-popup`)
@@ -465,7 +467,7 @@ describe('VirtualInput', () => {
       })
       expect(getCaretPosition(caretContainer)).toBe(1)
 
-      fireEvent.touchEnd(screen.getByTitle('清除')) // 点删除
+      fireEvent.click(screen.getByTitle(locale.Input.clear)) // 点删除
       await waitFor(() => {
         expect(
           document.querySelector(`.${KeyBoardClassPrefix}-popup`)
@@ -482,13 +484,13 @@ describe('VirtualInput', () => {
         document.querySelector(`.${classPrefix}-content`)
       ).toHaveTextContent('0')
 
-      fireEvent.touchEnd(screen.getByTitle('9')) // 在 0 时输入 9，则为 9
+      fireEvent.click(screen.getByTitle('9')) // 在 0 时输入 9，则为 9
       expect(
         document.querySelector(`.${classPrefix}-content`)
       ).toHaveTextContent('9')
       expect(getCaretPosition(caretContainer)).toBe(1)
 
-      fireEvent.touchEnd(screen.getByTitle('清除')) // 点删除
+      fireEvent.click(screen.getByTitle(locale.Input.clear)) // 点删除
       expect(
         document.querySelector(`.${classPrefix}-content`)
       ).toHaveTextContent('0')
@@ -533,12 +535,12 @@ describe('VirtualInput', () => {
     expect(targetElement).not.toBeNull()
 
     // click '1', '2', '3' by keyboard，content should be '123'
-    fireEvent.touchEnd(screen.getByTitle('1'))
-    fireEvent.touchEnd(screen.getByTitle('0'))
-    fireEvent.touchEnd(screen.getByTitle('3'))
-    fireEvent.touchEnd(screen.getByTitle('.'))
-    fireEvent.touchEnd(screen.getByTitle('4'))
-    fireEvent.touchEnd(screen.getByTitle('5'))
+    fireEvent.click(screen.getByTitle('1'))
+    fireEvent.click(screen.getByTitle('0'))
+    fireEvent.click(screen.getByTitle('3'))
+    fireEvent.click(screen.getByTitle('.'))
+    fireEvent.click(screen.getByTitle('4'))
+    fireEvent.click(screen.getByTitle('5'))
     expect(targetElement).toHaveTextContent('103.45')
     const caretContainer = input.querySelector(
       `.${classPrefix}-caret-container`
@@ -634,9 +636,9 @@ describe('VirtualInput', () => {
     const targetElement = input.querySelector(`.${classPrefix}-content`)
 
     // click '1', '2', '3' by keyboard，content should be '123'
-    fireEvent.touchEnd(screen.getByText('1'))
-    fireEvent.touchEnd(screen.getByText('2'))
-    fireEvent.touchEnd(screen.getByText('3'))
+    fireEvent.click(screen.getByText('1'))
+    fireEvent.click(screen.getByText('2'))
+    fireEvent.click(screen.getByText('3'))
     expect(targetElement).toHaveTextContent('123')
     const caretContainer = input.querySelector(
       `.${classPrefix}-caret-container`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能优化**
  * 优化数字键盘删除键的长按连续删除体验，提升可访问性，特别是对Android TalkBack的支持。
  * 删除键的提示文字改为本地化文本，增强多语言支持。
  * 数字键盘支持PC端网页预览，改善了触摸事件机制。
  * 明确区分删除键事件处理，提升交互一致性。
  * 文档中明确删除键长按快删功能仅在移动端生效。

* **测试**
  * 测试用例支持多语言，提升对本地化的兼容性。
  * 简化事件模拟方式，统一使用点击事件，使测试更简洁易读。
  * 增强长按删除键相关测试，覆盖确认按钮存在时的行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->