### PR TITLE
fix(Swiper): 优化子元素key处理，避免数组重排时不必要的重新挂载

### DIFF
--- a/src/components/ellipsis/useMeasure.tsx
+++ b/src/components/ellipsis/useMeasure.tsx
@@ -1,3 +1,4 @@
+import { useIsomorphicLayoutEffect } from 'ahooks'
 import { useEvent } from 'rc-util'
 import React from 'react'
 import { unstable_batchedUpdates } from 'react-dom'
@@ -60,12 +61,12 @@ export default function useMeasure(
   })
 
   // Initialize
-  React.useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     startMeasure()
   }, [contentChars, rows])
 
   // Measure element height
-  React.useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (status === MEASURE_STATUS.PREPARE) {
       const fullMeasureHeight = fullMeasureRef.current?.offsetHeight || 0
       const singleRowMeasureHeight =
@@ -82,7 +83,7 @@ export default function useMeasure(
   }, [status])
 
   // Walking measure
-  React.useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (status === MEASURE_STATUS.MEASURE_WALKING) {
       const diff = walkingIndexes[1] - walkingIndexes[0]
       const midHeight = midMeasureRef.current?.offsetHeight || 0

--- a/src/components/ellipsis/useMeasure.tsx
+++ b/src/components/ellipsis/useMeasure.tsx
@@ -1,5 +1,5 @@
-import { useIsomorphicLayoutEffect } from 'ahooks'
 import { useEvent } from 'rc-util'
+import useLayoutEffect from 'rc-util/lib/hooks/useLayoutEffect'
 import React from 'react'
 import { unstable_batchedUpdates } from 'react-dom'
 import runes from 'runes2'
@@ -61,12 +61,12 @@ export default function useMeasure(
   })
 
   // Initialize
-  useIsomorphicLayoutEffect(() => {
+  useLayoutEffect(() => {
     startMeasure()
   }, [contentChars, rows])
 
   // Measure element height
-  useIsomorphicLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (status === MEASURE_STATUS.PREPARE) {
       const fullMeasureHeight = fullMeasureRef.current?.offsetHeight || 0
       const singleRowMeasureHeight =
@@ -83,7 +83,7 @@ export default function useMeasure(
   }, [status])
 
   // Walking measure
-  useIsomorphicLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (status === MEASURE_STATUS.MEASURE_WALKING) {
       const diff = walkingIndexes[1] - walkingIndexes[0]
       const midHeight = midMeasureRef.current?.offsetHeight || 0

--- a/src/components/swiper/swiper.tsx
+++ b/src/components/swiper/swiper.tsx
@@ -5,7 +5,6 @@ import classNames from 'classnames'
 import type { CSSProperties, ReactElement, ReactNode } from 'react'
 import React, {
   forwardRef,
-  useCallback,
   useEffect,
   useImperativeHandle,
   useMemo,
@@ -352,7 +351,7 @@ export const Swiper = forwardRef<SwiperRef, SwiperProps>(
         )
       }
 
-      const renderStableItems = useCallback(() => {
+      const renderStableItems = () => {
         if (renderChildren && total) {
           const offsetCount = 2
           const startIndex = Math.max(current - offsetCount, 0)
@@ -384,16 +383,7 @@ export const Swiper = forwardRef<SwiperRef, SwiperProps>(
         }
 
         return null
-      }, [
-        validChildren,
-        renderChildren,
-        total,
-        current,
-        isVertical,
-        position,
-        mergedTotal,
-        loop,
-      ])
+      }
 
       function renderItems() {
         return renderStableItems()

--- a/src/components/swiper/swiper.tsx
+++ b/src/components/swiper/swiper.tsx
@@ -2,6 +2,7 @@ import { animated, useSpring } from '@react-spring/web'
 import { useDrag } from '@use-gesture/react'
 import { useGetState, useIsomorphicLayoutEffect } from 'ahooks'
 import classNames from 'classnames'
+import toArray from 'rc-util/lib/Children/toArray'
 import type { CSSProperties, ReactElement, ReactNode } from 'react'
 import React, {
   forwardRef,
@@ -105,17 +106,18 @@ export const Swiper = forwardRef<SwiperRef, SwiperProps>(
       if (typeof children === 'function') {
         renderChildren = children
       } else {
-        validChildren = React.Children.map(children, child => {
+        const childrenArray = toArray(children)
+        validChildren = childrenArray.filter(child => {
           if (!React.isValidElement(child)) return null
           if (child.type !== SwiperItem) {
             devWarning(
               'Swiper',
               'The children of `Swiper` must be `Swiper.Item` components.'
             )
-            return null
+            return false
           }
           count++
-          return child
+          return true
         })
       }
 
@@ -377,8 +379,7 @@ export const Swiper = forwardRef<SwiperRef, SwiperProps>(
 
         if (validChildren) {
           return validChildren.map((child, index) => {
-            const key = child?.key ?? index
-            return renderItem(index, child, key)
+            return renderItem(index, child, child?.key ?? index)
           })
         }
 

--- a/src/components/swiper/tests/swiper.test.tsx
+++ b/src/components/swiper/tests/swiper.test.tsx
@@ -1,7 +1,7 @@
-import React, { useRef, useState } from 'react'
-import { render, testA11y, fireEvent, screen, mockDrag } from 'testing'
-import Swiper, { SwiperRef } from '..'
 import { act } from '@testing-library/react'
+import React, { useRef, useState } from 'react'
+import { fireEvent, mockDrag, render, screen, testA11y } from 'testing'
+import Swiper, { SwiperRef } from '..'
 
 const classPrefix = `adm-swiper`
 
@@ -379,5 +379,45 @@ describe('Swiper', () => {
     )
 
     expect(container).toMatchSnapshot()
+  })
+
+  test('should not remount items when reordering', () => {
+    const mountLog: any[] = []
+
+    const TestItem = ({ id }: { id: string }) => {
+      React.useEffect(() => {
+        mountLog.push(id)
+      }, [])
+      return <div data-testid={`item-${id}`}>Item {id}</div>
+    }
+
+    const TestApp = () => {
+      const [items, setItems] = React.useState(['a', 'b', 'c'])
+      return (
+        <>
+          <Swiper>
+            {items.map(id => (
+              <Swiper.Item key={id}>
+                <TestItem id={id} />
+              </Swiper.Item>
+            ))}
+          </Swiper>
+          <button
+            data-testid='change-order'
+            onClick={() => setItems(['c', 'a', 'b'])}
+          >
+            Change Order
+          </button>
+        </>
+      )
+    }
+
+    const { getByTestId } = render(<TestApp />)
+
+    expect(mountLog).toEqual(['a', 'b', 'c'])
+
+    fireEvent.click(getByTestId('change-order'))
+
+    expect(mountLog).toEqual(['a', 'b', 'c'])
   })
 })


### PR DESCRIPTION
Fixes #6877  - 数组重排导致子元素重新挂载的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **重构**
  * 优化了轮播组件中子项的渲染逻辑，提高了渲染的稳定性和性能。
  * 替换了部分内部依赖的 React 钩子实现，保持功能一致。

* **测试**
  * 新增轮播组件在子项顺序变更时不会重新挂载的测试用例，提升了组件稳定性验证。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->