### PR TITLE
feat: date-picker 组件优化日期选择器，支持自定义日期字段顺序

### DIFF
--- a/src/components/date-picker-view/date-picker-view.tsx
+++ b/src/components/date-picker-view/date-picker-view.tsx
@@ -70,13 +70,18 @@ export const DatePickerView: FC<DatePickerViewProps> = p => {
 
   const onChange = useCallback(
     (val: PickerValue[]) => {
-      const date = convertStringArrayToDate(val, props.precision)
+      const date = convertStringArrayToDate(
+        val,
+        props.precision,
+        undefined,
+        value ?? undefined
+      )
       if (date) {
         setValue(date)
         props.onChange?.(date)
       }
     },
-    [props.onChange, props.precision]
+    [props.onChange, props.precision, value]
   )
 
   return withNativeProps(
@@ -90,7 +95,9 @@ export const DatePickerView: FC<DatePickerViewProps> = p => {
           props.precision,
           mergedRenderLabel,
           props.filter,
-          props.tillNow
+          props.tillNow,
+          undefined,
+          value ?? undefined
         )
       }
       loading={props.loading}

--- a/src/components/date-picker/date-picker-date-utils.ts
+++ b/src/components/date-picker/date-picker-date-utils.ts
@@ -127,7 +127,7 @@ export function generateDatePickerColumns(
   if (rank >= precisionRankRecord.minute) defaultColumns.push(MINUTE_COLUMN)
   if (rank >= precisionRankRecord.second) defaultColumns.push(SECOND_COLUMN)
 
-  const finalColumns = columns || defaultColumns
+  const finalColumns = columns?.length ? columns : defaultColumns
 
   const validColumns = finalColumns.filter(columnType => {
     const columnPrecision = columnToPrecisionMap[columnType]

--- a/src/components/date-picker/date-picker-date-utils.ts
+++ b/src/components/date-picker/date-picker-date-utils.ts
@@ -151,98 +151,63 @@ export function generateDatePickerColumns(
     return column
   }
 
+  const columnConfigs = {
+    [YEAR_COLUMN]: {
+      lower: minYear,
+      upper: maxYear,
+      selected: selectedYear,
+      precision: 'year' as DatePrecision,
+    },
+    [MONTH_COLUMN]: {
+      lower: isInMinYear ? minMonth : 1,
+      upper: isInMaxYear ? maxMonth : 12,
+      selected: selectedMonth,
+      precision: 'month' as DatePrecision,
+    },
+    [DAY_COLUMN]: {
+      lower: isInMinMonth ? minDay : 1,
+      upper: isInMaxMonth ? maxDay : firstDayInSelectedMonth.daysInMonth(),
+      selected: selectedDay,
+      precision: 'day' as DatePrecision,
+    },
+    [HOUR_COLUMN]: {
+      lower: isInMinDay ? minHour : 0,
+      upper: isInMaxDay ? maxHour : 23,
+      selected: selectedHour,
+      precision: 'hour' as DatePrecision,
+    },
+    [MINUTE_COLUMN]: {
+      lower: isInMinHour ? minMinute : 0,
+      upper: isInMaxHour ? maxMinute : 59,
+      selected: selectedMinute,
+      precision: 'minute' as DatePrecision,
+    },
+    [SECOND_COLUMN]: {
+      lower: isInMinMinute ? minSecond : 0,
+      upper: isInMaxMinute ? maxSecond : 59,
+      selected: selectedSecond,
+      precision: 'second' as DatePrecision,
+    },
+  }
+
   renderedColumns.forEach(columnType => {
-    switch (columnType) {
-      case YEAR_COLUMN: {
-        const lower = minYear
-        const upper = maxYear
-        const years = generateColumn(lower, upper, 'year', YEAR_COLUMN)
-        ret.push(
-          years.map(v => ({
-            label: renderLabel('year', v, { selected: selectedYear === v }),
-            value: v.toString(),
-          }))
-        )
-        break
-      }
-      case MONTH_COLUMN: {
-        const lowerMonth = isInMinYear ? minMonth : 1
-        const upperMonth = isInMaxYear ? maxMonth : 12
-        const months = generateColumn(
-          lowerMonth,
-          upperMonth,
-          'month',
-          MONTH_COLUMN
-        )
-        ret.push(
-          months.map(v => ({
-            label: renderLabel('month', v, { selected: selectedMonth === v }),
-            value: v.toString(),
-          }))
-        )
-        break
-      }
-      case DAY_COLUMN: {
-        const lowerDay = isInMinMonth ? minDay : 1
-        const upperDay = isInMaxMonth
-          ? maxDay
-          : firstDayInSelectedMonth.daysInMonth()
-        const days = generateColumn(lowerDay, upperDay, 'day', DAY_COLUMN)
-        ret.push(
-          days.map(v => ({
-            label: renderLabel('day', v, { selected: selectedDay === v }),
-            value: v.toString(),
-          }))
-        )
-        break
-      }
-      case HOUR_COLUMN: {
-        const lowerHour = isInMinDay ? minHour : 0
-        const upperHour = isInMaxDay ? maxHour : 23
-        const hours = generateColumn(lowerHour, upperHour, 'hour', HOUR_COLUMN)
-        ret.push(
-          hours.map(v => ({
-            label: renderLabel('hour', v, { selected: selectedHour === v }),
-            value: v.toString(),
-          }))
-        )
-        break
-      }
-      case MINUTE_COLUMN: {
-        const lowerMinute = isInMinHour ? minMinute : 0
-        const upperMinute = isInMaxHour ? maxMinute : 59
-        const minutes = generateColumn(
-          lowerMinute,
-          upperMinute,
-          'minute',
-          MINUTE_COLUMN
-        )
-        ret.push(
-          minutes.map(v => ({
-            label: renderLabel('minute', v, { selected: selectedMinute === v }),
-            value: v.toString(),
-          }))
-        )
-        break
-      }
-      case SECOND_COLUMN: {
-        const lowerSecond = isInMinMinute ? minSecond : 0
-        const upperSecond = isInMaxMinute ? maxSecond : 59
-        const seconds = generateColumn(
-          lowerSecond,
-          upperSecond,
-          'second',
-          SECOND_COLUMN
-        )
-        ret.push(
-          seconds.map(v => ({
-            label: renderLabel('second', v, { selected: selectedSecond === v }),
-            value: v.toString(),
-          }))
-        )
-        break
-      }
-    }
+    const config = columnConfigs[columnType]
+    if (!config) return
+
+    const column = generateColumn(
+      config.lower,
+      config.upper,
+      config.precision,
+      columnType
+    )
+    ret.push(
+      column.map(v => ({
+        label: renderLabel(config.precision, v, {
+          selected: config.selected === v,
+        }),
+        value: v.toString(),
+      }))
+    )
   })
 
   // Till Now

--- a/src/components/date-picker/date-picker-date-utils.ts
+++ b/src/components/date-picker/date-picker-date-utils.ts
@@ -82,9 +82,13 @@ export function generateDatePickerColumns(
   if (rank >= precisionRankRecord.second) defaultColumns.push(SECOND_COLUMN)
 
   const finalColumns = columns?.length ? columns : defaultColumns
+  const renderedColumns = finalColumns.filter(columnType => {
+    const columnPrecision = columnToPrecisionMap[columnType]
+    return rank >= precisionRankRecord[columnPrecision]
+  })
   function getValue(type: DateColumnType): number | null {
-    const index = finalColumns.indexOf(type)
-    if (index !== undefined && index >= 0 && index < selected.length) {
+    const index = renderedColumns.indexOf(type)
+    if (index >= 0 && index < selected.length) {
       const val = parseInt(selected[index], 10)
       return isNaN(val) ? null : val
     }
@@ -136,14 +140,9 @@ export function generateDatePickerColumns(
     return column
   }
 
-  const validColumns = finalColumns.filter(columnType => {
-    const columnPrecision = columnToPrecisionMap[columnType]
-    return rank >= precisionRankRecord[columnPrecision]
-  })
-
-  validColumns.forEach(columnType => {
+  renderedColumns.forEach(columnType => {
     switch (columnType) {
-      case YEAR_COLUMN:
+      case YEAR_COLUMN: {
         const lower = minYear
         const upper = maxYear
         const years = generateColumn(lower, upper, 'year')
@@ -154,8 +153,8 @@ export function generateDatePickerColumns(
           }))
         )
         break
-
-      case MONTH_COLUMN:
+      }
+      case MONTH_COLUMN: {
         const lowerMonth = isInMinYear ? minMonth : 1
         const upperMonth = isInMaxYear ? maxMonth : 12
         const months = generateColumn(lowerMonth, upperMonth, 'month')
@@ -166,8 +165,8 @@ export function generateDatePickerColumns(
           }))
         )
         break
-
-      case DAY_COLUMN:
+      }
+      case DAY_COLUMN: {
         const lowerDay = isInMinMonth ? minDay : 1
         const upperDay = isInMaxMonth
           ? maxDay
@@ -180,8 +179,8 @@ export function generateDatePickerColumns(
           }))
         )
         break
-
-      case HOUR_COLUMN:
+      }
+      case HOUR_COLUMN: {
         const lowerHour = isInMinDay ? minHour : 0
         const upperHour = isInMaxDay ? maxHour : 23
         const hours = generateColumn(lowerHour, upperHour, 'hour')
@@ -192,8 +191,8 @@ export function generateDatePickerColumns(
           }))
         )
         break
-
-      case MINUTE_COLUMN:
+      }
+      case MINUTE_COLUMN: {
         const lowerMinute = isInMinHour ? minMinute : 0
         const upperMinute = isInMaxHour ? maxMinute : 59
         const minutes = generateColumn(lowerMinute, upperMinute, 'minute')
@@ -204,8 +203,8 @@ export function generateDatePickerColumns(
           }))
         )
         break
-
-      case SECOND_COLUMN:
+      }
+      case SECOND_COLUMN: {
         const lowerSecond = isInMinMinute ? minSecond : 0
         const upperSecond = isInMaxMinute ? maxSecond : 59
         const seconds = generateColumn(lowerSecond, upperSecond, 'second')
@@ -216,6 +215,7 @@ export function generateDatePickerColumns(
           }))
         )
         break
+      }
     }
   })
 

--- a/src/components/date-picker/date-picker-date-utils.ts
+++ b/src/components/date-picker/date-picker-date-utils.ts
@@ -74,12 +74,12 @@ export function generateDatePickerColumns(
 
   const rank = precisionRankRecord[precision]
   const defaultColumns: DateColumnType[] = []
-  if (rank >= precisionRankRecord.year) defaultColumns.push(YEAR_COLUMN)
-  if (rank >= precisionRankRecord.month) defaultColumns.push(MONTH_COLUMN)
-  if (rank >= precisionRankRecord.day) defaultColumns.push(DAY_COLUMN)
-  if (rank >= precisionRankRecord.hour) defaultColumns.push(HOUR_COLUMN)
-  if (rank >= precisionRankRecord.minute) defaultColumns.push(MINUTE_COLUMN)
-  if (rank >= precisionRankRecord.second) defaultColumns.push(SECOND_COLUMN)
+  Object.keys(columnToPrecisionMap).forEach(columnType => {
+    const precision = columnToPrecisionMap[columnType as DateColumnType]
+    if (rank >= precisionRankRecord[precision]) {
+      defaultColumns.push(columnType as DateColumnType)
+    }
+  })
 
   const finalColumns = columns?.length ? columns : defaultColumns
   const renderedColumns = finalColumns.filter(columnType => {

--- a/src/components/date-picker/date-picker-date-utils.ts
+++ b/src/components/date-picker/date-picker-date-utils.ts
@@ -46,6 +46,13 @@ const columnToPrecisionMap: Record<DateColumnType, DatePrecision> = {
   [SECOND_COLUMN]: 'second',
 }
 
+function getDefaultColumns(precision: DatePrecision): DateColumnType[] {
+  const rank = precisionRankRecord[precision]
+  return (Object.keys(columnToPrecisionMap) as DateColumnType[]).filter(
+    columnType => rank >= precisionRankRecord[columnToPrecisionMap[columnType]]
+  )
+}
+
 export function generateDatePickerColumns(
   selected: string[],
   min: Date,
@@ -73,14 +80,7 @@ export function generateDatePickerColumns(
   const maxSecond = max.getSeconds()
 
   const rank = precisionRankRecord[precision]
-  const defaultColumns: DateColumnType[] = []
-  Object.keys(columnToPrecisionMap).forEach(columnType => {
-    const precision = columnToPrecisionMap[columnType as DateColumnType]
-    if (rank >= precisionRankRecord[precision]) {
-      defaultColumns.push(columnType as DateColumnType)
-    }
-  })
-
+  const defaultColumns = getDefaultColumns(precision)
   const finalColumns = columns?.length ? columns : defaultColumns
   const renderedColumns = finalColumns.filter(columnType => {
     const columnPrecision = columnToPrecisionMap[columnType]
@@ -102,11 +102,7 @@ export function generateDatePickerColumns(
   const selectedMinute = getValue(MINUTE_COLUMN) ?? 0
   const selectedSecond = getValue(SECOND_COLUMN) ?? 0
   const firstDayInSelectedMonth = dayjs(
-    convertStringArrayToDate(
-      [selectedYear, selectedMonth, '1'],
-      columns ?? defaultColumns,
-      precision
-    )
+    new Date(selectedYear, selectedMonth - 1, 1)
   )
 
   const isInMinYear = selectedYear === minYear
@@ -250,13 +246,7 @@ export function convertStringArrayToDate<
 ): Date {
   let finalColumns = columns
   if (!finalColumns || finalColumns.length === 0) {
-    const rank = precisionRankRecord[precision]
-    finalColumns = (
-      Object.keys(columnToPrecisionMap) as DateColumnType[]
-    ).filter(
-      columnType =>
-        rank >= precisionRankRecord[columnToPrecisionMap[columnType]]
-    )
+    finalColumns = getDefaultColumns(precision)
   }
 
   const now = new Date()

--- a/src/components/date-picker/date-picker-date-utils.ts
+++ b/src/components/date-picker/date-picker-date-utils.ts
@@ -97,29 +97,50 @@ export function generateDatePickerColumns(
     return null
   }
 
+  // Check which columns are rendered
+  const hasYearColumn = renderedColumns.includes(YEAR_COLUMN)
+  const hasMonthColumn = renderedColumns.includes(MONTH_COLUMN)
+  const hasDayColumn = renderedColumns.includes(DAY_COLUMN)
+  const hasHourColumn = renderedColumns.includes(HOUR_COLUMN)
+  const hasMinuteColumn = renderedColumns.includes(MINUTE_COLUMN)
+
   const selectedYear = getValue(YEAR_COLUMN) ?? effectiveBaseline.getFullYear()
   const selectedMonth =
     getValue(MONTH_COLUMN) ?? effectiveBaseline.getMonth() + 1
   const selectedDay = getValue(DAY_COLUMN) ?? effectiveBaseline.getDate()
-  const selectedHour = getValue(HOUR_COLUMN) ?? effectiveBaseline.getHours()
   const selectedMinute =
     getValue(MINUTE_COLUMN) ?? effectiveBaseline.getMinutes()
   const selectedSecond =
     getValue(SECOND_COLUMN) ?? effectiveBaseline.getSeconds()
+
+  // For hour column without day context, check if min.max date is the same
+  const selectedHour =
+    getValue(HOUR_COLUMN) ??
+    (minDay === maxDay ? minHour : effectiveBaseline.getHours())
   const firstDayInSelectedMonth = dayjs(
     new Date(selectedYear, selectedMonth - 1, 1)
   )
 
-  const isInMinYear = selectedYear === minYear
-  const isInMaxYear = selectedYear === maxYear
-  const isInMinMonth = isInMinYear && selectedMonth === minMonth
-  const isInMaxMonth = isInMaxYear && selectedMonth === maxMonth
-  const isInMinDay = isInMinMonth && selectedDay === minDay
-  const isInMaxDay = isInMaxMonth && selectedDay === maxDay
-  const isInMinHour = isInMinDay && selectedHour === minHour
-  const isInMaxHour = isInMaxDay && selectedHour === maxHour
-  const isInMinMinute = isInMinHour && selectedMinute === minMinute
-  const isInMaxMinute = isInMaxHour && selectedMinute === maxMinute
+  // Boundary checks: for columns that are not rendered,
+  // we consider we're in that boundary only if min equals max
+  const isInMinYear = hasYearColumn ? selectedYear === minYear : true
+  const isInMaxYear = hasYearColumn ? selectedYear === maxYear : true
+  const isInMinMonth =
+    isInMinYear && (hasMonthColumn ? selectedMonth === minMonth : true)
+  const isInMaxMonth =
+    isInMaxYear && (hasMonthColumn ? selectedMonth === maxMonth : true)
+  const isInMinDay =
+    isInMinMonth && (hasDayColumn ? selectedDay === minDay : true)
+  const isInMaxDay =
+    isInMaxMonth && (hasDayColumn ? selectedDay === maxDay : true)
+  const isInMinHour =
+    isInMinDay && (hasHourColumn ? selectedHour === minHour : true)
+  const isInMaxHour =
+    isInMaxDay && (hasHourColumn ? selectedHour === maxHour : true)
+  const isInMinMinute =
+    isInMinHour && (hasMinuteColumn ? selectedMinute === minMinute : true)
+  const isInMaxMinute =
+    isInMaxHour && (hasMinuteColumn ? selectedMinute === maxMinute : true)
 
   const generateColumn = (
     from: number,

--- a/src/components/date-picker/date-picker-date-utils.ts
+++ b/src/components/date-picker/date-picker-date-utils.ts
@@ -61,8 +61,10 @@ export function generateDatePickerColumns(
   renderLabel: RenderLabel,
   filter: DatePickerFilter | undefined,
   tillNow?: boolean,
-  columns?: DateColumnType[]
+  columns?: DateColumnType[],
+  baselineDate?: Date
 ) {
+  const effectiveBaseline = baselineDate || new Date()
   const ret: PickerColumn[] = []
 
   const minYear = min.getFullYear()
@@ -95,12 +97,15 @@ export function generateDatePickerColumns(
     return null
   }
 
-  const selectedYear = getValue(YEAR_COLUMN) ?? min.getFullYear()
-  const selectedMonth = getValue(MONTH_COLUMN) ?? 1
-  const selectedDay = getValue(DAY_COLUMN) ?? 1
-  const selectedHour = getValue(HOUR_COLUMN) ?? 0
-  const selectedMinute = getValue(MINUTE_COLUMN) ?? 0
-  const selectedSecond = getValue(SECOND_COLUMN) ?? 0
+  const selectedYear = getValue(YEAR_COLUMN) ?? effectiveBaseline.getFullYear()
+  const selectedMonth =
+    getValue(MONTH_COLUMN) ?? effectiveBaseline.getMonth() + 1
+  const selectedDay = getValue(DAY_COLUMN) ?? effectiveBaseline.getDate()
+  const selectedHour = getValue(HOUR_COLUMN) ?? effectiveBaseline.getHours()
+  const selectedMinute =
+    getValue(MINUTE_COLUMN) ?? effectiveBaseline.getMinutes()
+  const selectedSecond =
+    getValue(SECOND_COLUMN) ?? effectiveBaseline.getSeconds()
   const firstDayInSelectedMonth = dayjs(
     new Date(selectedYear, selectedMonth - 1, 1)
   )
@@ -138,7 +143,8 @@ export function generateDatePickerColumns(
             return convertStringArrayToDate(
               stringArray,
               partialColumns,
-              precision
+              precision,
+              effectiveBaseline
             )
           },
         })
@@ -242,21 +248,32 @@ export function convertStringArrayToDate<
 >(
   value: T[],
   columns: DateColumnType[] | undefined,
-  precision: DatePrecision
+  precision: DatePrecision,
+  baselineDate?: Date
 ): Date {
-  let finalColumns = columns
-  if (!finalColumns || finalColumns.length === 0) {
-    finalColumns = getDefaultColumns(precision)
-  }
+  const effectiveBaseline = baselineDate || new Date()
+  const hasCustomColumns = columns && columns.length > 0
+  const finalColumns = hasCustomColumns ? columns : getDefaultColumns(precision)
 
-  const now = new Date()
   const dateParts = {
-    [YEAR_COLUMN]: now.getFullYear().toString(),
-    [MONTH_COLUMN]: (now.getMonth() + 1).toString(),
-    [DAY_COLUMN]: now.getDate().toString(),
-    [HOUR_COLUMN]: now.getHours().toString(),
-    [MINUTE_COLUMN]: now.getMinutes().toString(),
-    [SECOND_COLUMN]: now.getSeconds().toString(),
+    [YEAR_COLUMN]: hasCustomColumns
+      ? effectiveBaseline.getFullYear().toString()
+      : '1900',
+    [MONTH_COLUMN]: hasCustomColumns
+      ? (effectiveBaseline.getMonth() + 1).toString()
+      : '1',
+    [DAY_COLUMN]: hasCustomColumns
+      ? effectiveBaseline.getDate().toString()
+      : '1',
+    [HOUR_COLUMN]: hasCustomColumns
+      ? effectiveBaseline.getHours().toString()
+      : '0',
+    [MINUTE_COLUMN]: hasCustomColumns
+      ? effectiveBaseline.getMinutes().toString()
+      : '0',
+    [SECOND_COLUMN]: hasCustomColumns
+      ? effectiveBaseline.getSeconds().toString()
+      : '0',
   }
 
   finalColumns.forEach((columnType, index) => {

--- a/src/components/date-picker/date-picker-date-utils.ts
+++ b/src/components/date-picker/date-picker-date-utils.ts
@@ -274,27 +274,67 @@ export function convertStringArrayToDate<
 ): Date {
   const effectiveBaseline = baselineDate || new Date()
   const hasCustomColumns = columns && columns.length > 0
-  const finalColumns = hasCustomColumns ? columns : getDefaultColumns(precision)
+  const rank = precisionRankRecord[precision]
+  const defaultColumns = getDefaultColumns(precision)
+  const finalColumns = hasCustomColumns
+    ? columns.filter(col => {
+        const colPrecision = columnToPrecisionMap[col]
+        return rank >= precisionRankRecord[colPrecision]
+      })
+    : defaultColumns
+
+  const precisionDefaults: Record<
+    DatePrecision,
+    Partial<Record<DateColumnType, string>>
+  > = {
+    year: {
+      [MONTH_COLUMN]: '1',
+      [DAY_COLUMN]: '1',
+      [HOUR_COLUMN]: '0',
+      [MINUTE_COLUMN]: '0',
+      [SECOND_COLUMN]: '0',
+    },
+    month: {
+      [DAY_COLUMN]: '1',
+      [HOUR_COLUMN]: '0',
+      [MINUTE_COLUMN]: '0',
+      [SECOND_COLUMN]: '0',
+    },
+    day: {
+      [HOUR_COLUMN]: '0',
+      [MINUTE_COLUMN]: '0',
+      [SECOND_COLUMN]: '0',
+    },
+    hour: {
+      [MINUTE_COLUMN]: '0',
+      [SECOND_COLUMN]: '0',
+    },
+    minute: {
+      [SECOND_COLUMN]: '0',
+    },
+    second: {},
+  }
+
+  const defaults = precisionDefaults[precision]
 
   const dateParts = {
-    [YEAR_COLUMN]: hasCustomColumns
-      ? effectiveBaseline.getFullYear().toString()
-      : '1900',
-    [MONTH_COLUMN]: hasCustomColumns
+    [YEAR_COLUMN]: effectiveBaseline.getFullYear().toString(),
+    [MONTH_COLUMN]: finalColumns.includes(MONTH_COLUMN)
       ? (effectiveBaseline.getMonth() + 1).toString()
-      : '1',
-    [DAY_COLUMN]: hasCustomColumns
+      : (defaults[MONTH_COLUMN] ??
+        (effectiveBaseline.getMonth() + 1).toString()),
+    [DAY_COLUMN]: finalColumns.includes(DAY_COLUMN)
       ? effectiveBaseline.getDate().toString()
-      : '1',
-    [HOUR_COLUMN]: hasCustomColumns
+      : (defaults[DAY_COLUMN] ?? effectiveBaseline.getDate().toString()),
+    [HOUR_COLUMN]: finalColumns.includes(HOUR_COLUMN)
       ? effectiveBaseline.getHours().toString()
-      : '0',
-    [MINUTE_COLUMN]: hasCustomColumns
+      : (defaults[HOUR_COLUMN] ?? effectiveBaseline.getHours().toString()),
+    [MINUTE_COLUMN]: finalColumns.includes(MINUTE_COLUMN)
       ? effectiveBaseline.getMinutes().toString()
-      : '0',
-    [SECOND_COLUMN]: hasCustomColumns
+      : (defaults[MINUTE_COLUMN] ?? effectiveBaseline.getMinutes().toString()),
+    [SECOND_COLUMN]: finalColumns.includes(SECOND_COLUMN)
       ? effectiveBaseline.getSeconds().toString()
-      : '0',
+      : (defaults[SECOND_COLUMN] ?? effectiveBaseline.getSeconds().toString()),
   }
 
   finalColumns.forEach((columnType, index) => {

--- a/src/components/date-picker/date-picker-utils.ts
+++ b/src/components/date-picker/date-picker-utils.ts
@@ -5,7 +5,7 @@ import type { QuarterPrecision } from './date-picker-quarter-utils'
 import * as quarterUtils from './date-picker-quarter-utils'
 import type { WeekPrecision } from './date-picker-week-utils'
 import * as weekUtils from './date-picker-week-utils'
-import type { PickerDate } from './util'
+import type { DateColumnType, PickerDate } from './util'
 import { TILL_NOW } from './util'
 
 export type Precision = DatePrecision | WeekPrecision | QuarterPrecision
@@ -50,7 +50,8 @@ export const convertStringArrayToDate = <
   T extends string | number | null | undefined,
 >(
   value: T[],
-  precision: Precision
+  precision: Precision,
+  columns?: DateColumnType[]
 ) => {
   // Special case for DATE_NOW
   if (value?.[0] === TILL_NOW) {
@@ -64,7 +65,7 @@ export const convertStringArrayToDate = <
   } else if (precision.includes('quarter')) {
     return quarterUtils.convertStringArrayToDate(value)
   } else {
-    return dateUtils.convertStringArrayToDate(value)
+    return dateUtils.convertStringArrayToDate(value, columns)
   }
 }
 
@@ -75,7 +76,8 @@ export const generateDatePickerColumns = (
   precision: Precision,
   renderLabel: RenderLabel,
   filter: DatePickerFilter | undefined,
-  tillNow?: boolean
+  tillNow?: boolean,
+  columns?: DateColumnType[]
 ) => {
   if (precision.startsWith('week')) {
     return weekUtils.generateDatePickerColumns(
@@ -103,7 +105,8 @@ export const generateDatePickerColumns = (
       precision as DatePrecision,
       renderLabel,
       filter,
-      tillNow
+      tillNow,
+      columns
     )
   }
 }

--- a/src/components/date-picker/date-picker-utils.ts
+++ b/src/components/date-picker/date-picker-utils.ts
@@ -97,7 +97,11 @@ export const convertStringArrayToDate = <
   } else if (precision.includes('quarter')) {
     return quarterUtils.convertStringArrayToDate(value)
   } else {
-    return dateUtils.convertStringArrayToDate(value, columns)
+    return dateUtils.convertStringArrayToDate(
+      value,
+      columns,
+      precision as DatePrecision
+    )
   }
 }
 

--- a/src/components/date-picker/date-picker-utils.ts
+++ b/src/components/date-picker/date-picker-utils.ts
@@ -64,7 +64,18 @@ export const convertDateToStringArray = (
     [MINUTE_COLUMN]: standard[4],
     [SECOND_COLUMN]: standard[5],
   }
-  return columns.map(col => map[col])
+  const order: DateColumnType[] = [
+    YEAR_COLUMN,
+    MONTH_COLUMN,
+    DAY_COLUMN,
+    HOUR_COLUMN,
+    MINUTE_COLUMN,
+    SECOND_COLUMN,
+  ]
+  const max = precisionLengthRecord[datePrecision]
+  return columns
+    .filter(col => order.indexOf(col) > -1 && order.indexOf(col) < max)
+    .map(col => map[col])
 }
 
 export const convertStringArrayToDate = <

--- a/src/components/date-picker/date-picker-utils.ts
+++ b/src/components/date-picker/date-picker-utils.ts
@@ -6,7 +6,15 @@ import * as quarterUtils from './date-picker-quarter-utils'
 import type { WeekPrecision } from './date-picker-week-utils'
 import * as weekUtils from './date-picker-week-utils'
 import type { DateColumnType, PickerDate } from './util'
-import { TILL_NOW } from './util'
+import {
+  DAY_COLUMN,
+  HOUR_COLUMN,
+  MINUTE_COLUMN,
+  MONTH_COLUMN,
+  SECOND_COLUMN,
+  TILL_NOW,
+  YEAR_COLUMN,
+} from './util'
 
 export type Precision = DatePrecision | WeekPrecision | QuarterPrecision
 
@@ -33,17 +41,30 @@ const precisionLengthRecord: Record<DatePrecision, number> = {
 
 export const convertDateToStringArray = (
   date: Date | undefined | null,
-  precision: Precision
+  precision: Precision,
+  columns?: DateColumnType[]
 ) => {
+  if (!date) return []
   if (precision.includes('week')) {
     return weekUtils.convertDateToStringArray(date)
   } else if (precision.includes('quarter')) {
     return quarterUtils.convertDateToStringArray(date)
-  } else {
-    const datePrecision = precision as DatePrecision
-    const stringArray = dateUtils.convertDateToStringArray(date)
-    return stringArray.slice(0, precisionLengthRecord[datePrecision])
   }
+  const datePrecision = precision as DatePrecision
+  const standard = dateUtils.convertDateToStringArray(date)
+
+  if (!columns?.length) {
+    return standard.slice(0, precisionLengthRecord[datePrecision])
+  }
+  const map: Record<DateColumnType, string> = {
+    [YEAR_COLUMN]: standard[0],
+    [MONTH_COLUMN]: standard[1],
+    [DAY_COLUMN]: standard[2],
+    [HOUR_COLUMN]: standard[3],
+    [MINUTE_COLUMN]: standard[4],
+    [SECOND_COLUMN]: standard[5],
+  }
+  return columns.map(col => map[col])
 }
 
 export const convertStringArrayToDate = <

--- a/src/components/date-picker/date-picker-utils.ts
+++ b/src/components/date-picker/date-picker-utils.ts
@@ -83,7 +83,8 @@ export const convertStringArrayToDate = <
 >(
   value: T[],
   precision: Precision,
-  columns?: DateColumnType[]
+  columns?: DateColumnType[],
+  baselineDate?: Date
 ) => {
   // Special case for DATE_NOW
   if (value?.[0] === TILL_NOW) {
@@ -100,7 +101,8 @@ export const convertStringArrayToDate = <
     return dateUtils.convertStringArrayToDate(
       value,
       columns,
-      precision as DatePrecision
+      precision as DatePrecision,
+      baselineDate
     )
   }
 }
@@ -113,7 +115,8 @@ export const generateDatePickerColumns = (
   renderLabel: RenderLabel,
   filter: DatePickerFilter | undefined,
   tillNow?: boolean,
-  columns?: DateColumnType[]
+  columns?: DateColumnType[],
+  baselineDate?: Date
 ) => {
   if (precision.startsWith('week')) {
     return weekUtils.generateDatePickerColumns(
@@ -142,7 +145,8 @@ export const generateDatePickerColumns = (
       renderLabel,
       filter,
       tillNow,
-      columns
+      columns,
+      baselineDate
     )
   }
 }

--- a/src/components/date-picker/date-picker.tsx
+++ b/src/components/date-picker/date-picker.tsx
@@ -1,28 +1,28 @@
-import React, { forwardRef, useCallback, useMemo } from 'react'
-import type { ReactNode } from 'react'
 import { useMemoizedFn } from 'ahooks'
-import Picker from '../picker'
+import type { ReactNode } from 'react'
+import React, { forwardRef, useCallback, useMemo } from 'react'
+import { bound } from '../../utils/bound'
+import { NativeProps, withNativeProps } from '../../utils/native-props'
+import { usePropsValue } from '../../utils/use-props-value'
+import { mergeProps } from '../../utils/with-default-props'
+import type { RenderLabel } from '../date-picker-view/date-picker-view'
+import useRenderLabel from '../date-picker-view/useRenderLabel'
 import type {
+  PickerActions,
+  PickerColumn,
   PickerProps,
   PickerRef,
-  PickerActions,
   PickerValue,
-  PickerColumn,
 } from '../picker'
-import { NativeProps, withNativeProps } from '../../utils/native-props'
-import { mergeProps } from '../../utils/with-default-props'
-import { usePropsValue } from '../../utils/use-props-value'
+import Picker from '../picker'
+import type { DatePickerFilter, Precision } from './date-picker-utils'
 import {
   convertDateToStringArray,
   convertStringArrayToDate,
   generateDatePickerColumns,
 } from './date-picker-utils'
-import type { Precision, DatePickerFilter } from './date-picker-utils'
-import { bound } from '../../utils/bound'
-import useRenderLabel from '../date-picker-view/useRenderLabel'
-import type { RenderLabel } from '../date-picker-view/date-picker-view'
+import type { DateColumnType, PickerDate } from './util'
 import { TILL_NOW } from './util'
-import type { PickerDate } from './util'
 
 export type DatePickerRef = PickerRef
 
@@ -58,6 +58,7 @@ export type DatePickerProps = Pick<
   renderLabel?: RenderLabel
   filter?: DatePickerFilter
   tillNow?: boolean
+  columns?: DateColumnType[]
 } & NativeProps
 
 const thisYear = new Date().getFullYear()
@@ -102,14 +103,18 @@ export const DatePicker = forwardRef<DatePickerRef, DatePickerProps>(
 
     const onConfirm = useCallback(
       (val: PickerValue[]) => {
-        const date = convertStringArrayToDate(val, props.precision)
+        const date = convertStringArrayToDate(
+          val,
+          props.precision,
+          props.columns
+        )
         setValue(date, true)
       },
-      [setValue, props.precision]
+      [setValue, props.precision, props.columns]
     )
 
     const onSelect = useMemoizedFn((val: PickerValue[]) => {
-      const date = convertStringArrayToDate(val, props.precision)
+      const date = convertStringArrayToDate(val, props.precision, props.columns)
       props.onSelect?.(date)
     })
 
@@ -122,9 +127,17 @@ export const DatePicker = forwardRef<DatePickerRef, DatePickerProps>(
           props.precision,
           mergedRenderLabel,
           props.filter,
-          props.tillNow
+          props.tillNow,
+          props.columns
         ),
-      [props.min, props.max, props.precision, mergedRenderLabel, props.tillNow]
+      [
+        props.min,
+        props.max,
+        props.precision,
+        mergedRenderLabel,
+        props.tillNow,
+        props.columns,
+      ]
     )
 
     return withNativeProps(

--- a/src/components/date-picker/date-picker.tsx
+++ b/src/components/date-picker/date-picker.tsx
@@ -98,7 +98,7 @@ export const DatePicker = forwardRef<DatePickerRef, DatePickerProps>(
       date = new Date(
         bound(date.getTime(), props.min.getTime(), props.max.getTime())
       )
-      return convertDateToStringArray(date, props.precision)
+      return convertDateToStringArray(date, props.precision, props.columns)
     }, [value, props.precision, props.min, props.max])
 
     const onConfirm = useCallback(

--- a/src/components/date-picker/date-picker.tsx
+++ b/src/components/date-picker/date-picker.tsx
@@ -99,22 +99,28 @@ export const DatePicker = forwardRef<DatePickerRef, DatePickerProps>(
         bound(date.getTime(), props.min.getTime(), props.max.getTime())
       )
       return convertDateToStringArray(date, props.precision, props.columns)
-    }, [value, props.precision, props.min, props.max])
+    }, [value, props.precision, props.min, props.max, props.columns])
 
     const onConfirm = useCallback(
       (val: PickerValue[]) => {
         const date = convertStringArrayToDate(
           val,
           props.precision,
-          props.columns
+          props.columns,
+          value ?? undefined
         )
         setValue(date, true)
       },
-      [setValue, props.precision, props.columns]
+      [setValue, props.precision, props.columns, value]
     )
 
     const onSelect = useMemoizedFn((val: PickerValue[]) => {
-      const date = convertStringArrayToDate(val, props.precision, props.columns)
+      const date = convertStringArrayToDate(
+        val,
+        props.precision,
+        props.columns,
+        value ?? undefined
+      )
       props.onSelect?.(date)
     })
 
@@ -128,7 +134,8 @@ export const DatePicker = forwardRef<DatePickerRef, DatePickerProps>(
           mergedRenderLabel,
           props.filter,
           props.tillNow,
-          props.columns
+          props.columns,
+          value ?? undefined
         ),
       [
         props.min,
@@ -137,6 +144,7 @@ export const DatePicker = forwardRef<DatePickerRef, DatePickerProps>(
         mergedRenderLabel,
         props.tillNow,
         props.columns,
+        value,
       ]
     )
 

--- a/src/components/date-picker/date-picker.tsx
+++ b/src/components/date-picker/date-picker.tsx
@@ -103,15 +103,22 @@ export const DatePicker = forwardRef<DatePickerRef, DatePickerProps>(
 
     const onConfirm = useCallback(
       (val: PickerValue[]) => {
+        let baseline: Date | undefined = value ?? undefined
+        if (!baseline && props.min && props.max) {
+          const oneDay = 24 * 60 * 60 * 1000
+          if (props.max.getTime() - props.min.getTime() <= oneDay) {
+            baseline = props.min
+          }
+        }
         const date = convertStringArrayToDate(
           val,
           props.precision,
           props.columns,
-          value ?? undefined
+          baseline
         )
         setValue(date, true)
       },
-      [setValue, props.precision, props.columns, value]
+      [setValue, props.precision, props.columns, value, props.min, props.max]
     )
 
     const onSelect = useMemoizedFn((val: PickerValue[]) => {

--- a/src/components/date-picker/demos/demo1.tsx
+++ b/src/components/date-picker/demos/demo1.tsx
@@ -1,7 +1,16 @@
-import React, { useState, useCallback } from 'react'
 import { Button, DatePicker, Space, Toast } from 'antd-mobile'
 import { DemoBlock } from 'demos'
+import React, { useCallback, useState } from 'react'
 import { weekdayToZh } from './weekdayToZh'
+
+// 导入列常量用于自定义列顺序
+import {
+  DAY_COLUMN,
+  HOUR_COLUMN,
+  MINUTE_COLUMN,
+  MONTH_COLUMN,
+  YEAR_COLUMN,
+} from '../date-picker-date-utils'
 
 const now = new Date()
 
@@ -155,6 +164,84 @@ function CustomRender() {
   )
 }
 
+// 自定义列顺序
+function CustomColumnsDemo() {
+  const [visible1, setVisible1] = useState(false)
+  const [visible2, setVisible2] = useState(false)
+  const [visible3, setVisible3] = useState(false)
+
+  return (
+    <Space wrap>
+      <>
+        <Button
+          onClick={() => {
+            setVisible1(true)
+          }}
+        >
+          月-日-年
+        </Button>
+        <DatePicker
+          visible={visible1}
+          onClose={() => {
+            setVisible1(false)
+          }}
+          precision='day'
+          columns={[MONTH_COLUMN, DAY_COLUMN, YEAR_COLUMN]}
+          onConfirm={val => {
+            Toast.show(val.toString())
+          }}
+        />
+      </>
+      <>
+        <Button
+          onClick={() => {
+            setVisible2(true)
+          }}
+        >
+          时-分-日-月-年
+        </Button>
+        <DatePicker
+          visible={visible2}
+          onClose={() => {
+            setVisible2(false)
+          }}
+          precision='minute'
+          columns={[
+            HOUR_COLUMN,
+            MINUTE_COLUMN,
+            DAY_COLUMN,
+            MONTH_COLUMN,
+            YEAR_COLUMN,
+          ]}
+          onConfirm={val => {
+            Toast.show(val.toString())
+          }}
+        />
+      </>
+      <>
+        <Button
+          onClick={() => {
+            setVisible3(true)
+          }}
+        >
+          只选时-分(其他默认当前时间)
+        </Button>
+        <DatePicker
+          visible={visible3}
+          onClose={() => {
+            setVisible3(false)
+          }}
+          precision='minute'
+          columns={[HOUR_COLUMN, MINUTE_COLUMN]}
+          onConfirm={val => {
+            Toast.show(`选择的时间: ${val.toString()}, 年月日使用当前时间`)
+          }}
+        />
+      </>
+    </Space>
+  )
+}
+
 // 周选择器
 function DayOfWeekDemo() {
   const [visible, setVisible] = useState(false)
@@ -287,6 +374,10 @@ export default () => {
 
       <DemoBlock title='自定义每列的渲染内容'>
         <CustomRender />
+      </DemoBlock>
+
+      <DemoBlock title='自定义列顺序'>
+        <CustomColumnsDemo />
       </DemoBlock>
 
       <DemoBlock title='周选择器'>

--- a/src/components/date-picker/demos/demo1.tsx
+++ b/src/components/date-picker/demos/demo1.tsx
@@ -10,7 +10,7 @@ import {
   MINUTE_COLUMN,
   MONTH_COLUMN,
   YEAR_COLUMN,
-} from '../date-picker-date-utils'
+} from '../util'
 
 const now = new Date()
 

--- a/src/components/date-picker/demos/demo1.tsx
+++ b/src/components/date-picker/demos/demo1.tsx
@@ -4,13 +4,8 @@ import React, { useCallback, useState } from 'react'
 import { weekdayToZh } from './weekdayToZh'
 
 // 导入列常量用于自定义列顺序
-import {
-  DAY_COLUMN,
-  HOUR_COLUMN,
-  MINUTE_COLUMN,
-  MONTH_COLUMN,
-  YEAR_COLUMN,
-} from '../util'
+const { DAY_COLUMN, HOUR_COLUMN, MINUTE_COLUMN, MONTH_COLUMN, YEAR_COLUMN } =
+  DatePicker
 
 const now = new Date()
 

--- a/src/components/date-picker/index.ts
+++ b/src/components/date-picker/index.ts
@@ -1,13 +1,28 @@
-import './date-picker.less'
 import { attachPropertiesToComponent } from '../../utils/attach-properties-to-component'
 import { DatePicker } from './date-picker'
-import { TILL_NOW } from './util'
+import './date-picker.less'
 import { prompt } from './prompt'
+import {
+  DAY_COLUMN,
+  HOUR_COLUMN,
+  MINUTE_COLUMN,
+  MONTH_COLUMN,
+  SECOND_COLUMN,
+  TILL_NOW,
+  YEAR_COLUMN,
+} from './util'
 
 export type { DatePickerProps, DatePickerRef } from './date-picker'
 export type { DatePickerFilter } from './date-picker-utils'
+export type { DateColumnType } from './util'
 
 export default attachPropertiesToComponent(DatePicker, {
   prompt,
   DATE_NOW: TILL_NOW,
+  YEAR_COLUMN,
+  MONTH_COLUMN,
+  DAY_COLUMN,
+  HOUR_COLUMN,
+  MINUTE_COLUMN,
+  SECOND_COLUMN,
 })

--- a/src/components/date-picker/tests/date-picker.test.tsx
+++ b/src/components/date-picker/tests/date-picker.test.tsx
@@ -409,6 +409,83 @@ describe('DatePicker', () => {
       expect(fn).toBeCalled()
     })
 
+    test('columns outside precision should not affect confirmed value', async () => {
+      const fn = jest.fn()
+      const { getByText } = render(
+        <DatePicker
+          visible
+          precision='day'
+          columns={[HOUR_COLUMN, YEAR_COLUMN, MONTH_COLUMN, DAY_COLUMN]}
+          defaultValue={new Date('2025-09-02 00:00:00')}
+          onConfirm={fn}
+        />
+      )
+
+      await waitFor(() => {
+        fireEvent.click(getByText('确定'))
+      })
+
+      const result = fn.mock.calls[0][0]
+      expect(result.getFullYear()).toBe(2025)
+      expect(result.getMonth()).toBe(8)
+      expect(result.getDate()).toBe(2)
+      expect(result.getHours()).toBe(0)
+      expect(result.getMinutes()).toBe(0)
+      expect(result.getSeconds()).toBe(0)
+    })
+
+    test('custom day columns should keep lower precision fields at defaults', async () => {
+      jest.useFakeTimers({ now: new Date('2026-04-21 15:30:45') })
+
+      const fn = jest.fn()
+      const { getByText } = render(
+        <DatePicker
+          visible
+          precision='day'
+          columns={[MONTH_COLUMN, DAY_COLUMN, YEAR_COLUMN]}
+          onConfirm={fn}
+        />
+      )
+
+      await waitFor(() => {
+        fireEvent.click(getByText('确定'))
+      })
+
+      const result = fn.mock.calls[0][0]
+      expect(result.getFullYear()).toBe(2026)
+      expect(result.getMonth()).toBe(3)
+      expect(result.getDate()).toBe(21)
+      expect(result.getHours()).toBe(0)
+      expect(result.getMinutes()).toBe(0)
+      expect(result.getSeconds()).toBe(0)
+    })
+
+    test('partial columns confirmed value should respect min and max', async () => {
+      jest.useFakeTimers({ now: new Date('2026-04-17 10:00:00') })
+
+      const min = new Date('2025-09-02 14:00:00')
+      const max = new Date('2025-09-02 16:00:00')
+      const fn = jest.fn()
+      const { getByText } = render(
+        <DatePicker
+          visible
+          precision='minute'
+          columns={[HOUR_COLUMN, MINUTE_COLUMN]}
+          min={min}
+          max={max}
+          onConfirm={fn}
+        />
+      )
+
+      await waitFor(() => {
+        fireEvent.click(getByText('确定'))
+      })
+
+      const result = fn.mock.calls[0][0]
+      expect(result.getTime()).toBeLessThanOrEqual(max.getTime())
+      expect(result.getTime()).toBeGreaterThanOrEqual(min.getTime())
+    })
+
     test('empty columns should use default behavior', async () => {
       const fn = jest.fn()
       const { getByText } = render(

--- a/src/components/date-picker/tests/date-picker.test.tsx
+++ b/src/components/date-picker/tests/date-picker.test.tsx
@@ -486,6 +486,32 @@ describe('DatePicker', () => {
       expect(result.getTime()).toBeGreaterThanOrEqual(min.getTime())
     })
 
+    test('partial columns with exactly one day window should still respect min and max', async () => {
+      jest.useFakeTimers({ now: new Date('2026-04-17 10:00:00') })
+
+      const min = new Date('2025-09-02 14:00:00')
+      const max = new Date('2025-09-03 14:00:00')
+      const fn = jest.fn()
+      const { getByText } = render(
+        <DatePicker
+          visible
+          precision='minute'
+          columns={[HOUR_COLUMN, MINUTE_COLUMN]}
+          min={min}
+          max={max}
+          onConfirm={fn}
+        />
+      )
+
+      await waitFor(() => {
+        fireEvent.click(getByText('确定'))
+      })
+
+      const result = fn.mock.calls[0][0]
+      expect(result.getTime()).toBeLessThanOrEqual(max.getTime())
+      expect(result.getTime()).toBeGreaterThanOrEqual(min.getTime())
+    })
+
     test('empty columns should use default behavior', async () => {
       const fn = jest.fn()
       const { getByText } = render(

--- a/src/components/date-picker/tests/date-picker.test.tsx
+++ b/src/components/date-picker/tests/date-picker.test.tsx
@@ -361,6 +361,32 @@ describe('DatePicker', () => {
       expect(result.getMinutes()).toBe(30)
     })
 
+    test('partial columns should respect min and max', () => {
+      jest.useFakeTimers({ now: new Date('2026-04-17 10:00:00') })
+
+      render(
+        <DatePicker
+          visible
+          precision='minute'
+          columns={[HOUR_COLUMN, MINUTE_COLUMN]}
+          min={new Date('2025-09-02 14:00:00')}
+          max={new Date('2025-09-02 16:00:00')}
+        />
+      )
+
+      const pickerColumns = document.body.querySelectorAll(
+        `.${classPrefix}-view-column`
+      )
+      expect(pickerColumns.length).toBe(2)
+
+      const hourValues = Array.from(
+        pickerColumns[0].querySelectorAll(
+          `.${classPrefix}-view-column-item-label`
+        )
+      ).map(item => item.textContent)
+      expect(hourValues).toEqual(['14', '15', '16'])
+    })
+
     test('columns should respect precision limits', async () => {
       const fn = jest.fn()
       const { getByText } = render(

--- a/src/components/date-picker/tests/date-picker.test.tsx
+++ b/src/components/date-picker/tests/date-picker.test.tsx
@@ -12,7 +12,10 @@ import {
 } from 'testing'
 import DatePicker from '../'
 import Button from '../../button'
-import { convertStringArrayToDate } from '../date-picker-week-utils'
+import {
+  convertStringArrayToDate,
+  generateDatePickerColumns,
+} from '../date-picker-week-utils'
 import {
   DAY_COLUMN,
   HOUR_COLUMN,
@@ -20,10 +23,6 @@ import {
   MONTH_COLUMN,
   YEAR_COLUMN,
 } from '../util'
-import {
-  convertStringArrayToDate,
-  generateDatePickerColumns,
-} from '../date-picker-week-utils'
 
 const classPrefix = `adm-picker`
 

--- a/src/components/date-picker/util.ts
+++ b/src/components/date-picker/util.ts
@@ -3,3 +3,18 @@ export const TILL_NOW = 'TILL_NOW'
 export type PickerDate = Date & {
   tillNow?: boolean
 }
+
+export const YEAR_COLUMN = 'YEAR_COLUMN'
+export const MONTH_COLUMN = 'MONTH_COLUMN'
+export const DAY_COLUMN = 'DAY_COLUMN'
+export const HOUR_COLUMN = 'HOUR_COLUMN'
+export const MINUTE_COLUMN = 'MINUTE_COLUMN'
+export const SECOND_COLUMN = 'SECOND_COLUMN'
+
+export type DateColumnType =
+  | typeof YEAR_COLUMN
+  | typeof MONTH_COLUMN
+  | typeof DAY_COLUMN
+  | typeof HOUR_COLUMN
+  | typeof MINUTE_COLUMN
+  | typeof SECOND_COLUMN

--- a/src/components/date-picker/util.ts
+++ b/src/components/date-picker/util.ts
@@ -4,12 +4,12 @@ export type PickerDate = Date & {
   tillNow?: boolean
 }
 
-export const YEAR_COLUMN = 'YEAR_COLUMN'
-export const MONTH_COLUMN = 'MONTH_COLUMN'
-export const DAY_COLUMN = 'DAY_COLUMN'
-export const HOUR_COLUMN = 'HOUR_COLUMN'
-export const MINUTE_COLUMN = 'MINUTE_COLUMN'
-export const SECOND_COLUMN = 'SECOND_COLUMN'
+export const YEAR_COLUMN = 'YEAR_COLUMN' as const
+export const MONTH_COLUMN = 'MONTH_COLUMN' as const
+export const DAY_COLUMN = 'DAY_COLUMN' as const
+export const HOUR_COLUMN = 'HOUR_COLUMN' as const
+export const MINUTE_COLUMN = 'MINUTE_COLUMN' as const
+export const SECOND_COLUMN = 'SECOND_COLUMN' as const
 
 export type DateColumnType =
   | typeof YEAR_COLUMN

--- a/src/components/ellipsis/useMeasure.tsx
+++ b/src/components/ellipsis/useMeasure.tsx
@@ -1,3 +1,4 @@
+import { useIsomorphicLayoutEffect } from 'ahooks'
 import { useEvent } from 'rc-util'
 import React from 'react'
 import { unstable_batchedUpdates } from 'react-dom'
@@ -60,12 +61,12 @@ export default function useMeasure(
   })
 
   // Initialize
-  React.useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     startMeasure()
   }, [contentChars, rows])
 
   // Measure element height
-  React.useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (status === MEASURE_STATUS.PREPARE) {
       const fullMeasureHeight = fullMeasureRef.current?.offsetHeight || 0
       const singleRowMeasureHeight =
@@ -82,7 +83,7 @@ export default function useMeasure(
   }, [status])
 
   // Walking measure
-  React.useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (status === MEASURE_STATUS.MEASURE_WALKING) {
       const diff = walkingIndexes[1] - walkingIndexes[0]
       const midHeight = midMeasureRef.current?.offsetHeight || 0

--- a/src/components/ellipsis/useMeasure.tsx
+++ b/src/components/ellipsis/useMeasure.tsx
@@ -1,5 +1,5 @@
-import { useIsomorphicLayoutEffect } from 'ahooks'
 import { useEvent } from 'rc-util'
+import useLayoutEffect from 'rc-util/lib/hooks/useLayoutEffect'
 import React from 'react'
 import { unstable_batchedUpdates } from 'react-dom'
 import runes from 'runes2'
@@ -61,12 +61,12 @@ export default function useMeasure(
   })
 
   // Initialize
-  useIsomorphicLayoutEffect(() => {
+  useLayoutEffect(() => {
     startMeasure()
   }, [contentChars, rows])
 
   // Measure element height
-  useIsomorphicLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (status === MEASURE_STATUS.PREPARE) {
       const fullMeasureHeight = fullMeasureRef.current?.offsetHeight || 0
       const singleRowMeasureHeight =
@@ -83,7 +83,7 @@ export default function useMeasure(
   }, [status])
 
   // Walking measure
-  useIsomorphicLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (status === MEASURE_STATUS.MEASURE_WALKING) {
       const diff = walkingIndexes[1] - walkingIndexes[0]
       const midHeight = midMeasureRef.current?.offsetHeight || 0


### PR DESCRIPTION
fix: #6856 支持自定义日期选择器中年、月、日列的显示顺序

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - DatePicker 新增 columns 属性与 DateColumnType，支持自定义列顺序与仅选择部分字段（缺失字段使用当前时间/默认值）；组件导出新增 YEAR/MONTH/DAY/HOUR/MINUTE/SECOND 常量，首列可显示“至今”（tillNow）。

- **文档**
  - 新增示例：自定义列顺序（月-日-年、时-分-日-月-年、仅时-分）。

- **测试**
  - 添加列控制单元测试，覆盖自定义顺序、部分列、精度限制与“至今”行为。

- **注意**
  - 与列相关的日期转换/生成接口新增可选 columns 参数并保留向后兼容。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->