### PR TITLE
fix: error 6945, antd-mobile slide calculation error

### DIFF
--- a/src/components/image-viewer/image-viewer.tsx
+++ b/src/components/image-viewer/image-viewer.tsx
@@ -116,7 +116,16 @@ export const MultiImageViewer = forwardRef<
       slidesRef.current?.swipeTo(index, immediate)
     },
   }))
-
+  const viewportWidth = (function () {
+    try {
+      const host = props.getContainer && props.getContainer();
+      if (host && host.getBoundingClientRect) {
+        const w = host.getBoundingClientRect().width;
+        if (w && w > 0) return w;
+      }
+    } catch (e) {}
+    return typeof window !== 'undefined' ? window.innerWidth : 375;
+  })();
   const onSlideChange = useCallback(
     (newIndex: number) => {
       if (newIndex === index) return
@@ -150,6 +159,7 @@ export const MultiImageViewer = forwardRef<
             onTap={props.onClose}
             maxZoom={props.maxZoom}
             imageRender={props.imageRender}
+            viewportWidth={viewportWidth}
           />
         )}
       </div>

--- a/src/components/image-viewer/slides.tsx
+++ b/src/components/image-viewer/slides.tsx
@@ -23,13 +23,17 @@ export type SlidesType = {
     image: string,
     { ref, index }: { ref: RefObject<HTMLImageElement>; index: number }
   ) => ReactNode
+  viewportWidth: number
 }
 export type SlidesRef = {
   swipeTo: (index: number, immediate?: boolean) => void
 }
 
 export const Slides = forwardRef<SlidesRef, SlidesType>((props, ref) => {
-  const slideWidth = window.innerWidth + convertPx(16)
+  const baseWidth = props.viewportWidth
+
+  const slideWidth = baseWidth + convertPx(16)
+
   const [{ x }, api] = useSpring(() => ({
     x: props.defaultIndex * slideWidth,
     config: { tension: 250, clamp: true },
@@ -51,6 +55,7 @@ export const Slides = forwardRef<SlidesRef, SlidesType>((props, ref) => {
   }))
 
   const dragLockRef = useRef(false)
+
   const bind = useDrag(
     state => {
       if (dragLockRef.current) return


### PR DESCRIPTION
set animation calculation width to container width instead of window width, so that user can customize the layer of the rendering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 幻灯片宽度改为基于容器宽度计算，避免依赖窗口宽度，提升布局准确性。
  - 在无法获取容器时提供回退宽度，增强在嵌入式与多视口场景的稳定性与一致性。
  - 改善图片查看器的响应式表现与滑动体验，在不同分辨率和屏幕密度下显示更可靠。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->