### PR TITLE
fix: 修改光标定位样式，使其在 safari flex 布局下也能显示

### DIFF
--- a/src/components/virtual-input/virtual-input.less
+++ b/src/components/virtual-input/virtual-input.less
@@ -54,17 +54,20 @@
 
   &-caret-container {
     display: inline-block;
-    width: var(--caret-width);
+    width: 0;
+    margin: 0;
+    padding: 0;
+    overflow: visible;
     height: 1.3em;
     vertical-align: top;
     margin-right: 1px;
-    position: absolute;
+    position: relative;
   }
   &-caret {
-    width: 100%;
+    width: var(--caret-width);
     height: 100%;
     background-color: var(--caret-color);
-    position: relative;
+    position: absolute;
     top: 5%;
   }
   &:focus {

--- a/src/components/virtual-input/virtual-input.less
+++ b/src/components/virtual-input/virtual-input.less
@@ -69,6 +69,7 @@
     position: absolute;
     top: 5%;
     left: 0;
+    z-index: 1;
   }
   &:focus {
     outline: none;

--- a/src/components/virtual-input/virtual-input.less
+++ b/src/components/virtual-input/virtual-input.less
@@ -60,7 +60,6 @@
     overflow: visible;
     height: 1.3em;
     vertical-align: top;
-    margin-right: 1px;
     position: relative;
   }
   &-caret {

--- a/src/components/virtual-input/virtual-input.less
+++ b/src/components/virtual-input/virtual-input.less
@@ -64,10 +64,11 @@
   }
   &-caret {
     width: var(--caret-width);
-    height: 100%;
+    height: 95%;
     background-color: var(--caret-color);
     position: absolute;
     top: 5%;
+    left: 0;
   }
   &:focus {
     outline: none;


### PR DESCRIPTION
在 iOS Safari 下，如果外层使用了 flex 布局，那么光标可能显示不出来
<img width="830" height="302" alt="image" src="https://github.com/user-attachments/assets/dfc0111a-c334-495d-be8e-02ed2e4e1faa" />

实际是有占位的，但是渲染不出来（safari 这种鬼问题特别多）
<img width="1018" height="288" alt="image" src="https://github.com/user-attachments/assets/61aa8b80-7207-4e67-a3f3-6ca4d8f7f6bf" />

所以改一下光标的实现方式：
1. 原方案：caret-container 绝对定位即可，不用给其设置 top/left 也不用给其父元素设置 relative，它自然会脱离文档流（不占位）、但位置又保留在「原位」，这个做法有些 tricky，确实遇到上述显示不出来的问题
2. 本 PR 改进方案：caret-container 设置 relative + width 0，caret 设置 absolute + 宽高，方案比较正常，效果与原方案基本一致。（~~但这个 caret-container 无论如何设置，总会有一点点宽度，导致光标移动时数字会「略略抖动」有些瑕疵~~ 是我 sb 了看漏了个 margin-right）
3. 不必了~~更好的方案：放弃 caret-container，而通过给光标所在位置的数字的 span 增加 after 伪类的方式实现光标，但修改较大，后续再提~~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新增功能
  - 无

- 样式
  - 优化虚拟输入框光标容器与光标的布局与尺寸：将容器设为零宽、相对定位并取消裁剪，光标改为绝对定位并独立宽度，提升光标显示稳定性和定位准确性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->