### PR TITLE
feat: 输入框留一点 padding-right，让右对齐时光标不被遮挡

### DIFF
--- a/src/components/virtual-input/virtual-input.less
+++ b/src/components/virtual-input/virtual-input.less
@@ -34,6 +34,7 @@
     overflow-y: hidden;
     overflow-x: scroll;
     letter-spacing: 1px;
+    padding-right: var(--caret-width);
     &::-webkit-scrollbar {
       display: none;
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新增修复
  - 修复虚拟输入框在内容可滚动时被插入符遮挡的问题；为内容区域预留与插入符等宽的右侧空间，提升文本对齐与可见性，在长文本与不同分辨率场景下更稳定。
- 样式
  - 调整虚拟输入框内容容器右侧内边距，优化视觉间距与阅读体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->