### PR TITLE
fix: add missing CSS variables for `Modal` and `Dialog`

### DIFF
--- a/src/components/dialog/dialog.tsx
+++ b/src/components/dialog/dialog.tsx
@@ -1,12 +1,12 @@
-import React from 'react'
-import type { FC, ReactNode } from 'react'
-import { mergeProps } from '../../utils/with-default-props'
 import classNames from 'classnames'
-import { Action, DialogActionButton } from './dialog-action-button'
-import Image from '../image'
-import AutoCenter from '../auto-center'
+import type { FC, ReactNode } from 'react'
+import React from 'react'
 import { NativeProps } from '../../utils/native-props'
+import { mergeProps } from '../../utils/with-default-props'
+import AutoCenter from '../auto-center'
 import CenterPopup, { CenterPopupProps } from '../center-popup'
+import Image from '../image'
+import { Action, DialogActionButton } from './dialog-action-button'
 
 export type DialogProps = Pick<
   CenterPopupProps,
@@ -32,7 +32,13 @@ export type DialogProps = Pick<
   onClose?: () => void
   closeOnAction?: boolean
   closeOnMaskClick?: boolean
-} & NativeProps
+} & NativeProps<
+    | '--background-color'
+    | '--border-radius'
+    | '--max-width'
+    | '--min-width'
+    | '--z-index'
+  >
 
 const defaultProps = {
   actions: [] as Action[],

--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -1,13 +1,13 @@
-import React from 'react'
-import type { FC, ReactNode } from 'react'
-import { mergeProps } from '../../utils/with-default-props'
 import classNames from 'classnames'
-import { Action, ModalActionButton } from './modal-action-button'
+import type { FC, ReactNode } from 'react'
+import React from 'react'
+import { NativeProps } from '../../utils/native-props'
+import { mergeProps } from '../../utils/with-default-props'
+import AutoCenter from '../auto-center'
+import CenterPopup, { CenterPopupProps } from '../center-popup'
 import Image from '../image'
 import Space from '../space'
-import AutoCenter from '../auto-center'
-import { NativeProps } from '../../utils/native-props'
-import CenterPopup, { CenterPopupProps } from '../center-popup'
+import { Action, ModalActionButton } from './modal-action-button'
 
 export type ModalProps = Pick<
   CenterPopupProps,
@@ -34,7 +34,13 @@ export type ModalProps = Pick<
   closeOnAction?: boolean
   closeOnMaskClick?: boolean
   showCloseButton?: boolean
-} & NativeProps
+} & NativeProps<
+    | '--background-color'
+    | '--border-radius'
+    | '--max-width'
+    | '--min-width'
+    | '--z-index'
+  >
 
 const defaultProps = {
   actions: [] as Action[],


### PR DESCRIPTION
`CenterPopup` has extra five CSS Variables.
<img width="1368" height="394" alt="image" src="https://github.com/user-attachments/assets/0588befc-f32a-467d-b2b3-b2d65426a4d2" />

`Modal` and `Dialog` are based on `CenterPopup`, they should have same CSS Variables. However, those five variables aren't included in `NativeProps` at `Modal` ad `Dialog`. User can successfully pass css variables in JS, but throw an type error in TS.

Add missing CSS variables will fix this TS errpr