### PR TITLE
feat: 数字键盘的 confirmText 支持换行展示

### DIFF
--- a/src/components/number-keyboard/demos/demo1.tsx
+++ b/src/components/number-keyboard/demos/demo1.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react'
-import { List, Input, Dialog, NumberKeyboard, Toast, Button } from 'antd-mobile'
+import { Button, Dialog, Input, List, NumberKeyboard, Toast } from 'antd-mobile'
 import { DemoBlock } from 'demos'
+import React, { useState } from 'react'
 
 export default () => {
   const [visible, setVisible] = useState<any>('')
@@ -66,6 +66,9 @@ export default () => {
             {/* 添加 readOnly 阻止原生键盘弹出 */}
             <Input placeholder='请输入内容' value={value} readOnly />
           </List.Item>
+          <List.Item onClick={() => openKeyboard('demo7')}>
+            确认按钮文案支持换行
+          </List.Item>
         </List>
       </DemoBlock>
       <NumberKeyboard
@@ -111,6 +114,14 @@ export default () => {
         onInput={onInput}
         onDelete={onDelete}
         customKey='X'
+      />
+      <NumberKeyboard
+        visible={visible === 'demo3'}
+        onClose={actions.onClose}
+        onInput={actions.onInput}
+        onDelete={actions.onDelete}
+        showCloseButton={false}
+        confirmText={'先签约\n再转入'} // {'\n'} 可以而 '\n' 不行，后者会被转义为 '\\n'
       />
     </>
   )

--- a/src/components/number-keyboard/demos/demo1.tsx
+++ b/src/components/number-keyboard/demos/demo1.tsx
@@ -116,7 +116,7 @@ export default () => {
         customKey='X'
       />
       <NumberKeyboard
-        visible={visible === 'demo3'}
+        visible={visible === 'demo7'}
         onClose={actions.onClose}
         onInput={actions.onInput}
         onDelete={actions.onDelete}

--- a/src/components/number-keyboard/number-keyboard.less
+++ b/src/components/number-keyboard/number-keyboard.less
@@ -120,6 +120,7 @@
       height: 144px;
       font-size: 16px;
       border: none;
+      white-space: pre-line;
     }
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 新功能
  * 数字键盘“确认”按键支持多行文案显示，可保留换行以呈现更长或分段提示，提升交互表达能力。
* 文档
  * 示例页新增演示条目，展示带有多行确认文案与隐藏关闭按钮的键盘用法，便于比较与测试不同交互。
* 样式
  * 优化确认键文本的换行与布局处理，确保包含换行符的文案按预期分行显示并保持视觉一致性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->