### PR TITLE
fix: 解决无障碍输入框读屏两次问题

### DIFF
--- a/src/components/virtual-input/virtual-input.tsx
+++ b/src/components/virtual-input/virtual-input.tsx
@@ -187,7 +187,8 @@ export const VirtualInput = forwardRef<VirtualInputRef, VirtualInputProps>(
         setCaretPosition(value.length)
         mergedProps.cursor?.onMove?.(value.length)
       }
-      mergedProps.onClick?.(e)
+      mergedProps.onClick?.(e);
+      setHasFocus(true)
     }
 
     // 点击单个字符时，根据点击位置置于字符前或后


### PR DESCRIPTION
无障碍模式下虚拟输入框的元素设置了role=textbox，如果同时设置了aria-label，输入框中的元素会读两遍
修改了该问题，兼容没有输入内容可以读出placeholder，有输入内容时仅读屏一次

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发版说明

* **新功能**
  * 点击虚拟输入内容时会触发聚焦状态，提升交互反馈与键盘可访问性。

* **Bug 修复**
  * 优化无障碍标签逻辑：有值时不再将实际值作为 aria-label，空值时使用占位提示作为无障碍标签，改善屏幕阅读器体验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->