### PR TITLE
fix: Space组件在 justify="center" 布局下最后一个元素有布局错误

### DIFF
--- a/src/components/space/space.less
+++ b/src/components/space/space.less
@@ -34,9 +34,6 @@
       margin-bottom: calc(var(--gap-vertical) * -1);
       > .@{class-prefix-space}-item {
         padding-bottom: var(--gap-vertical);
-        &:last-child {
-          padding-bottom: 0;
-        }
       }
     }
   }


### PR DESCRIPTION
fix: #6992 修复 Space 组件在 横向布局时最后一个元素有 margin 导致的布局错误

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 修复了水平布局中最后一项元素的多余间距问题，确保最后一项不显示不必要的右边距，使间距显示更加整洁一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->