### PR TITLE
fix(VirtualInput): should not show outline when call by focus

### DIFF
--- a/src/components/virtual-input/virtual-input.less
+++ b/src/components/virtual-input/virtual-input.less
@@ -34,6 +34,7 @@
     overflow-x: scroll;
     letter-spacing: 1px;
     padding-right: var(--caret-width);
+    outline: none;
     &::-webkit-scrollbar {
       display: none;
     }


### PR DESCRIPTION
直接调用 `focus()` 会出现：

<img width="296" height="95" alt="截屏2025-12-11 11 16 38" src="https://github.com/user-attachments/assets/78c75379-dbd3-4eb4-b7e6-37e1815671db" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 样式优化

* **样式改进**
  * 优化了虚拟输入组件内容区域的视觉显示效果，提升了整体界面呈现。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->