### PR TITLE
fix(tabs): invaild autoscroll prop

### DIFF
--- a/src/components/tabs/index.en.md
+++ b/src/components/tabs/index.en.md
@@ -30,6 +30,7 @@ The current content needs to be divided into groups of the same hierarchical str
 | onChange | Callback when switching panel | `(key: string) => void` | - |
 | stretch | Whether stretch the tab header | `boolean` | `true` |
 | direction | Document layout direction | `'ltr' \| 'rtl'` | `'ltr'` |
+| autoScroll | Whether to enable auto scroll when switching tabs | `boolean` | `true` |
 
 ### CSS Variables
 

--- a/src/components/tabs/index.zh.md
+++ b/src/components/tabs/index.zh.md
@@ -30,6 +30,7 @@
 | onChange | 切换面板的回调 | `(key: string) => void` | - |
 | stretch | 选项卡头部是否拉伸 | `boolean` | `true` |
 | direction | 文档排版方向 | `'ltr' \| 'rtl'` | `'ltr'` |
+| autoScroll | 切换 tab 时是否自动滚动 | `boolean` | `true` |
 
 ### CSS 变量
 

--- a/src/components/tabs/tabs.tsx
+++ b/src/components/tabs/tabs.tsx
@@ -189,7 +189,7 @@ export const Tabs: FC<TabsProps> = p => {
       )
     }
 
-    if (!fromMutation || props.autoScroll !== false) {
+    if (!fromMutation && props.autoScroll !== false) {
       scrollApi.start({
         scrollLeft: nextScrollLeft,
         from: { scrollLeft: containerScrollLeft },


### PR DESCRIPTION
fix https://github.com/ant-design/ant-design-mobile/issues/7007

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 为 Tabs 组件添加了 autoScroll 属性，允许用户在切换选项卡时控制是否启用自动滚动功能，该选项默认处于启用状态。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->