### PR TITLE
feat(swiper): 优化小尺寸幻灯片的定位逻辑

### DIFF
--- a/src/components/ellipsis/useMeasure.tsx
+++ b/src/components/ellipsis/useMeasure.tsx
@@ -1,3 +1,4 @@
+import { useIsomorphicLayoutEffect } from 'ahooks'
 import { useEvent } from 'rc-util'
 import React from 'react'
 import { unstable_batchedUpdates } from 'react-dom'
@@ -60,12 +61,12 @@ export default function useMeasure(
   })
 
   // Initialize
-  React.useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     startMeasure()
   }, [contentChars, rows])
 
   // Measure element height
-  React.useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (status === MEASURE_STATUS.PREPARE) {
       const fullMeasureHeight = fullMeasureRef.current?.offsetHeight || 0
       const singleRowMeasureHeight =
@@ -82,7 +83,7 @@ export default function useMeasure(
   }, [status])
 
   // Walking measure
-  React.useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (status === MEASURE_STATUS.MEASURE_WALKING) {
       const diff = walkingIndexes[1] - walkingIndexes[0]
       const midHeight = midMeasureRef.current?.offsetHeight || 0

--- a/src/components/ellipsis/useMeasure.tsx
+++ b/src/components/ellipsis/useMeasure.tsx
@@ -1,5 +1,5 @@
-import { useIsomorphicLayoutEffect } from 'ahooks'
 import { useEvent } from 'rc-util'
+import useLayoutEffect from 'rc-util/lib/hooks/useLayoutEffect'
 import React from 'react'
 import { unstable_batchedUpdates } from 'react-dom'
 import runes from 'runes2'
@@ -61,12 +61,12 @@ export default function useMeasure(
   })
 
   // Initialize
-  useIsomorphicLayoutEffect(() => {
+  useLayoutEffect(() => {
     startMeasure()
   }, [contentChars, rows])
 
   // Measure element height
-  useIsomorphicLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (status === MEASURE_STATUS.PREPARE) {
       const fullMeasureHeight = fullMeasureRef.current?.offsetHeight || 0
       const singleRowMeasureHeight =
@@ -83,7 +83,7 @@ export default function useMeasure(
   }, [status])
 
   // Walking measure
-  useIsomorphicLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (status === MEASURE_STATUS.MEASURE_WALKING) {
       const diff = walkingIndexes[1] - walkingIndexes[0]
       const midHeight = midMeasureRef.current?.offsetHeight || 0

--- a/src/components/swiper/swiper.tsx
+++ b/src/components/swiper/swiper.tsx
@@ -331,7 +331,10 @@ export const Swiper = forwardRef<SwiperRef, SwiperProps>(
             [isVertical ? 'y' : 'x']: position.to(position => {
               let finalPosition = -position + index * 100
               const totalWidth = mergedTotal * 100
-              const flagWidth = totalWidth / 2
+              const flagWidth = Math.min(
+                totalWidth / 2,
+                Math.max(100, (offsetRatio / slideRatio + 1) * 100)
+              )
               finalPosition =
                 modulus(finalPosition + flagWidth, totalWidth) - flagWidth
               return `${finalPosition}%`

--- a/src/components/swiper/swiper.tsx
+++ b/src/components/swiper/swiper.tsx
@@ -331,7 +331,7 @@ export const Swiper = forwardRef<SwiperRef, SwiperProps>(
           const totalWidth = mergedTotal * 100
           const flagWidth = Math.min(
             totalWidth / 2,
-            Math.max(100, (offsetRatio / slideRatio + 1) * 100)
+            (offsetRatio / slideRatio + 1) * 100
           )
 
           itemStyle = {

--- a/src/components/swiper/swiper.tsx
+++ b/src/components/swiper/swiper.tsx
@@ -93,7 +93,7 @@ export const Swiper = forwardRef<SwiperRef, SwiperProps>(
     const timeoutRef = useRef<number | null>(null)
     const isVertical = direction === 'vertical'
 
-    const slideRatio = props.slideSize / 100
+    const slideRatio = Math.max(props.slideSize, 1) / 100
     const offsetRatio = props.trackOffset / 100
 
     const { validChildren, count, renderChildren } = useMemo(() => {
@@ -327,14 +327,16 @@ export const Swiper = forwardRef<SwiperRef, SwiperProps>(
         let itemStyle: React.CSSProperties = {}
 
         if (loop) {
+          // 计算循环模式下定位所需的常量，避免在动画回调中重复计算
+          const totalWidth = mergedTotal * 100
+          const flagWidth = Math.min(
+            totalWidth / 2,
+            Math.max(100, (offsetRatio / slideRatio + 1) * 100)
+          )
+
           itemStyle = {
             [isVertical ? 'y' : 'x']: position.to(position => {
               let finalPosition = -position + index * 100
-              const totalWidth = mergedTotal * 100
-              const flagWidth = Math.min(
-                totalWidth / 2,
-                Math.max(100, (offsetRatio / slideRatio + 1) * 100)
-              )
               finalPosition =
                 modulus(finalPosition + flagWidth, totalWidth) - flagWidth
               return `${finalPosition}%`

--- a/src/components/swiper/tests/swiper.test.tsx
+++ b/src/components/swiper/tests/swiper.test.tsx
@@ -381,6 +381,62 @@ describe('Swiper', () => {
     expect(container).toMatchSnapshot()
   })
 
+  test('loop with small slideSize should show correct number of slides', () => {
+    const sixItems = [1, 2, 3, 4, 5, 6].map(item => (
+      <Swiper.Item key={item}>
+        <div>{item}</div>
+      </Swiper.Item>
+    ))
+
+    render(
+      <Swiper slideSize={20} loop stuckAtBoundary={false}>
+        {sixItems}
+      </Swiper>
+    )
+
+    const slides = $$(`.${classPrefix}-slide`)
+    expect(slides.length).toBe(6)
+
+    const visibleCount = Array.from(slides).filter(slide => {
+      const style = slide.getAttribute('style') || ''
+      if (style.includes('transform: none')) return true
+      const match = style.match(/translate3d\((-?\d+)%/)
+      if (!match) return false
+      const pos = parseInt(match[1])
+      const actualPos = (pos * 20) / 100
+      return actualPos >= 0 && actualPos < 100
+    }).length
+
+    expect(visibleCount).toBe(5)
+  })
+
+  test('loop with small slideSize and trackOffset should show correct slides', () => {
+    const sixItems = [1, 2, 3, 4, 5, 6].map(item => (
+      <Swiper.Item key={item}>
+        <div>{item}</div>
+      </Swiper.Item>
+    ))
+
+    render(
+      <Swiper slideSize={70} trackOffset={15} loop stuckAtBoundary={false}>
+        {sixItems}
+      </Swiper>
+    )
+
+    const slides = $$(`.${classPrefix}-slide`)
+    expect(slides.length).toBe(6)
+
+    const positions = Array.from(slides).map(slide => {
+      const style = slide.getAttribute('style') || ''
+      const match = style.match(/translate3d\((-?\d+)%/)
+      return match ? parseInt(match[1]) : null
+    })
+
+    const validPositions = positions.filter(p => p !== null)
+    const uniquePositions = new Set(validPositions)
+    expect(uniquePositions.size).toBe(validPositions.length)
+  })
+
   test('should not remount items when reordering', () => {
     const mountLog: any[] = []
 

--- a/src/components/swiper/tests/swiper.test.tsx
+++ b/src/components/swiper/tests/swiper.test.tsx
@@ -428,6 +428,7 @@ describe('Swiper', () => {
 
     const positions = Array.from(slides).map(slide => {
       const style = slide.getAttribute('style') || ''
+      if (style.includes('transform: none')) return 0
       const match = style.match(/translate3d\((-?\d+(?:\.\d+)?)%/)
       return match ? parseFloat(match[1]) : null
     })

--- a/src/components/swiper/tests/swiper.test.tsx
+++ b/src/components/swiper/tests/swiper.test.tsx
@@ -400,9 +400,9 @@ describe('Swiper', () => {
     const visibleCount = Array.from(slides).filter(slide => {
       const style = slide.getAttribute('style') || ''
       if (style.includes('transform: none')) return true
-      const match = style.match(/translate3d\((-?\d+)%/)
+      const match = style.match(/translate3d\((-?\d+(?:\.\d+)?)%/)
       if (!match) return false
-      const pos = parseInt(match[1])
+      const pos = parseFloat(match[1])
       const actualPos = (pos * 20) / 100
       return actualPos >= 0 && actualPos < 100
     }).length
@@ -428,11 +428,13 @@ describe('Swiper', () => {
 
     const positions = Array.from(slides).map(slide => {
       const style = slide.getAttribute('style') || ''
-      const match = style.match(/translate3d\((-?\d+)%/)
-      return match ? parseInt(match[1]) : null
+      const match = style.match(/translate3d\((-?\d+(?:\.\d+)?)%/)
+      return match ? parseFloat(match[1]) : null
     })
 
     const validPositions = positions.filter(p => p !== null)
+    // 确保所有 slides 都成功解析了位置，避免空通过
+    expect(validPositions.length).toBe(slides.length)
     const uniquePositions = new Set(validPositions)
     expect(uniquePositions.size).toBe(validPositions.length)
   })


### PR DESCRIPTION
close #7034 优化`slideSize` 在小于 `1/3` 的情况下 `slide` 的展示数量较少的情况

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug修复**
  * 修正循环模式下滑块位置与换算边界逻辑：对极小/异常 slideSize 和偏移值做保护与边界钳制，避免负值/零导致的环绕错位，提升循环对齐与稳定性。

* **测试**
  * 新增循环场景测试：验证不同 slideSize 与 trackOffset 下渲染数量、可见性判定与位置唯一性，确保行为一致。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->