### PR TITLE
feat(passcode-input): 支持 rtl 输入方向

### DIFF
--- a/src/components/passcode-input/demos/demo1.tsx
+++ b/src/components/passcode-input/demos/demo1.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react'
 import { NumberKeyboard, PasscodeInput, Space } from 'antd-mobile'
 import { DemoBlock, DemoDescription } from 'demos'
+import React, { useState } from 'react'
 
 export default () => {
   const [error, setError] = useState(false)
@@ -34,6 +34,9 @@ export default () => {
       </DemoBlock>
       <DemoBlock title='使用系统原生键盘'>
         <PasscodeInput plain />
+      </DemoBlock>
+      <DemoBlock title='输入框方向'>
+        <PasscodeInput direction='rtl' />
       </DemoBlock>
     </>
   )

--- a/src/components/passcode-input/index.en.md
+++ b/src/components/passcode-input/index.en.md
@@ -21,6 +21,7 @@ Input for password, captcha and verification code.
 | caret | Whether to show the caret | `boolean` | `true` |  |
 | className | ClassName of passcode | `string` | - |  |
 | defaultValue | The initial passcode content | `string` | - |  |
+| direction | The direction of the input | `'ltr' \| 'rtl'` | `'ltr'` |  |
 | error | Whether to show the error style | `boolean` | `false` |  |
 | keyboard | The virtual keyboard component. If not set, it will use the native keyboard. | `NumberKeyboard` | - |  |
 | inputMode | The type of the input box, which changes the native keyboard type | `'numeric' \| 'text'` | `'numeric'` | 5.39.0 |

--- a/src/components/passcode-input/index.zh.md
+++ b/src/components/passcode-input/index.zh.md
@@ -21,6 +21,7 @@
 | caret | 是否展示光标 | `boolean` | `true` |  |
 | className | 外层 className | `string` | - |  |
 | defaultValue | 非受控值 | `string` | - |  |
+| direction | 输入框方向 | `'ltr' \| 'rtl'` | `'ltr'` |  |
 | error | 是否有错 | `boolean` | `false` |  |
 | keyboard | 键盘组件，如不传，默认使用系统原生的键盘 | `NumberKeyboard` | - |  |
 | inputMode | 输入框类型, 改变原生键盘类型 | `'numeric' \| 'text'` | `'numeric'` | 5.39.0 |

--- a/src/components/passcode-input/passcode-input.less
+++ b/src/components/passcode-input/passcode-input.less
@@ -65,20 +65,20 @@
   }
 
   &&-rtl:not(.@{class-prefix-passcode-input}-seperated) {
-    .@{class-prefix-passcode-input}-cell:not(:last-child) {
+    .@{class-prefix-passcode-input}-cell:first-child {
       border-right: none;
     }
-    .@{class-prefix-passcode-input}-cell:not(:first-child) {
+    .@{class-prefix-passcode-input}-cell:last-child {
       border-right: 1px solid var(--border-color);
     }
   }
 
   &&-rtl&&-seperated {
     .@{class-prefix-passcode-input}-cell {
-      &:not(:last-child) {
+      &:first-child {
         margin-right: 0;
       }
-      &:not(:first-child) {
+      &:last-child {
         margin-right: var(--cell-gap);
       }
     }

--- a/src/components/passcode-input/passcode-input.less
+++ b/src/components/passcode-input/passcode-input.less
@@ -15,6 +15,10 @@
     vertical-align: top;
   }
 
+  &&-rtl &-cell-container {
+    flex-direction: row-reverse;
+  }
+
   &-cell {
     flex: none;
     display: flex;
@@ -56,6 +60,26 @@
       &-focused {
         border-color: var(--adm-color-primary);
         box-shadow: 0 0 2px 0 var(--adm-color-primary);
+      }
+    }
+  }
+
+  &&-rtl:not(.@{class-prefix-passcode-input}-seperated) {
+    .@{class-prefix-passcode-input}-cell:not(:last-child) {
+      border-right: none;
+    }
+    .@{class-prefix-passcode-input}-cell:not(:first-child) {
+      border-right: 1px solid var(--border-color);
+    }
+  }
+
+  &&-rtl&&-seperated {
+    .@{class-prefix-passcode-input}-cell {
+      &:not(:last-child) {
+        margin-right: 0;
+      }
+      &:not(:first-child) {
+        margin-right: var(--cell-gap);
       }
     }
   }

--- a/src/components/passcode-input/passcode-input.tsx
+++ b/src/components/passcode-input/passcode-input.tsx
@@ -24,6 +24,7 @@ export type PasscodeInputProps = {
   seperated?: boolean
   keyboard?: ReactElement<NumberKeyboardProps>
   inputMode?: 'numeric' | 'text'
+  direction?: 'ltr' | 'rtl'
   onBlur?: () => void
   onFocus?: () => void
   onChange?: (val: string) => void
@@ -51,6 +52,7 @@ const defaultProps = {
   seperated: false,
   caret: true,
   inputMode: 'numeric',
+  direction: 'ltr' as const,
 }
 
 export const PasscodeInput = forwardRef<PasscodeInputRef, PasscodeInputProps>(
@@ -110,11 +112,13 @@ export const PasscodeInput = forwardRef<PasscodeInputRef, PasscodeInputProps>(
       },
     }))
 
+    const isRTL = props.direction === 'rtl'
+
     const renderCells = () => {
       const cells: ReactElement[] = []
 
       const chars = value.split('')
-      const caretIndex = chars.length // 光标位置index等于当前文字长度
+      const caretIndex = chars.length
       const focusedIndex = bound(chars.length, 0, cellLength - 1)
 
       for (let i = 0; i < cellLength; i++) {
@@ -139,6 +143,7 @@ export const PasscodeInput = forwardRef<PasscodeInputRef, PasscodeInputProps>(
       [`${classPrefix}-focused`]: focused,
       [`${classPrefix}-error`]: props.error,
       [`${classPrefix}-seperated`]: props.seperated,
+      [`${classPrefix}-rtl`]: isRTL,
     })
 
     return (

--- a/src/components/passcode-input/passcode-input.tsx
+++ b/src/components/passcode-input/passcode-input.tsx
@@ -52,7 +52,7 @@ const defaultProps = {
   seperated: false,
   caret: true,
   inputMode: 'numeric',
-  direction: 'ltr' as const,
+  direction: 'ltr',
 }
 
 export const PasscodeInput = forwardRef<PasscodeInputRef, PasscodeInputProps>(

--- a/src/components/passcode-input/tests/passcode-input.test.tsx
+++ b/src/components/passcode-input/tests/passcode-input.test.tsx
@@ -131,44 +131,8 @@ describe('PasscodeInput', () => {
   })
 
   test('RTL direction should be supported', () => {
-    render(
-      <PasscodeInput direction='rtl' plain keyboard={<NumberKeyboard />} />
-    )
+    render(<PasscodeInput direction='rtl' />)
     const input = screen.getByRole('button', { name: '密码输入框' })
     expect(input).toHaveClass(`${classPrefix}-rtl`)
-
-    fireEvent.focus(input)
-
-    mockClick(screen.getByText('1'))
-    mockClick(screen.getByText('2'))
-
-    const cells = getCells()
-    expect(cells[0]).toHaveTextContent('1')
-    expect(cells[1]).toHaveTextContent('2')
-    expect(cells[2]).toHaveClass(`${cellClassPrefix}-caret`)
-  })
-
-  test('RTL direction with seperated should be supported', () => {
-    render(
-      <PasscodeInput
-        direction='rtl'
-        seperated
-        plain
-        keyboard={<NumberKeyboard />}
-      />
-    )
-    const input = screen.getByRole('button', { name: '密码输入框' })
-    expect(input).toHaveClass(`${classPrefix}-rtl`)
-    expect(input).toHaveClass(`${classPrefix}-seperated`)
-
-    fireEvent.focus(input)
-
-    mockClick(screen.getByText('1'))
-    mockClick(screen.getByText('2'))
-
-    const cells = getCells()
-    expect(cells[0]).toHaveTextContent('1')
-    expect(cells[1]).toHaveTextContent('2')
-    expect(cells[2]).toHaveClass(`${cellClassPrefix}-caret`)
   })
 })

--- a/src/components/passcode-input/tests/passcode-input.test.tsx
+++ b/src/components/passcode-input/tests/passcode-input.test.tsx
@@ -129,4 +129,46 @@ describe('PasscodeInput', () => {
     const input2 = container2.querySelector('input')
     expect(input2).toHaveAttribute('inputMode', 'text')
   })
+
+  test('RTL direction should be supported', () => {
+    render(
+      <PasscodeInput direction='rtl' plain keyboard={<NumberKeyboard />} />
+    )
+    const input = screen.getByRole('button', { name: '密码输入框' })
+    expect(input).toHaveClass(`${classPrefix}-rtl`)
+
+    fireEvent.focus(input)
+
+    mockClick(screen.getByText('1'))
+    mockClick(screen.getByText('2'))
+
+    const cells = getCells()
+    expect(cells[0]).toHaveTextContent('1')
+    expect(cells[1]).toHaveTextContent('2')
+    expect(cells[2]).toHaveClass(`${cellClassPrefix}-caret`)
+  })
+
+  test('RTL direction with seperated should be supported', () => {
+    render(
+      <PasscodeInput
+        direction='rtl'
+        seperated
+        plain
+        keyboard={<NumberKeyboard />}
+      />
+    )
+    const input = screen.getByRole('button', { name: '密码输入框' })
+    expect(input).toHaveClass(`${classPrefix}-rtl`)
+    expect(input).toHaveClass(`${classPrefix}-seperated`)
+
+    fireEvent.focus(input)
+
+    mockClick(screen.getByText('1'))
+    mockClick(screen.getByText('2'))
+
+    const cells = getCells()
+    expect(cells[0]).toHaveTextContent('1')
+    expect(cells[1]).toHaveTextContent('2')
+    expect(cells[2]).toHaveClass(`${cellClassPrefix}-caret`)
+  })
 })


### PR DESCRIPTION
close #6998  新增 direction 属性控制输入框方向

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * PasscodeInput 支持从右到左（RTL）文本方向，示例中新增 RTL 演示，便于体验镜像输入场景。

* **文档**
  * 新增并更新 direction 属性说明，支持 'ltr' | 'rtl'，默认 'ltr'，说明了方向行为。

* **样式**
  * 添加 RTL 专用样式，调整单元格方向、分隔线与间距以实现镜像布局。

* **测试**
  * 新增针对 RTL 行为的自动化测试用例以验证样式类与光标/聚焦表现。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->