### PR TITLE
Fix(List): 修复箭头图片配置错误逻辑

### DIFF
--- a/src/components/list/list-item.tsx
+++ b/src/components/list/list-item.tsx
@@ -35,8 +35,8 @@ export const ListItem: FC<ListItemProps> = props => {
   const showArrow = arrow ?? arrowIcon ?? clickable
   const mergedArrowIcon = mergeProp<React.ReactNode>(
     componentConfig.arrowIcon,
-    arrow !== true ? arrow : null,
-    arrowIcon !== true ? arrowIcon : null
+    arrow !== true ? arrow : undefined,
+    arrowIcon !== true ? arrowIcon : undefined
   )
 
   const content = (

--- a/src/components/list/tests/list.test.tsx
+++ b/src/components/list/tests/list.test.tsx
@@ -78,5 +78,17 @@ describe('list', () => {
 
       expect(screen.getByText('bamboo')).toBeVisible()
     })
+
+    it('arrowIcon={true} should use config provider arrow', () => {
+      render(
+        <ConfigProvider list={{ arrowIcon: 'little' }}>
+          <List>
+            <List.Item clickable arrowIcon={true} />
+          </List>
+        </ConfigProvider>
+      )
+
+      expect(screen.getByText('little')).toBeVisible()
+    })
   })
 })


### PR DESCRIPTION
close #7040 将 `null` 改为 `undefined` 以正确合并箭头图标配置

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了列表项箭头图标在配置提供者上下文中的处理逻辑，确保自定义箭头图标配置正确应用。

* **Tests**
  * 新增单元测试以验证箭头图标配置与上下文默认值的交互行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->