### PR TITLE
feat(swiper): 添加切换来源参数到 onIndexChange

### DIFF
--- a/src/components/image-viewer/tests/image-viewer.test.tsx
+++ b/src/components/image-viewer/tests/image-viewer.test.tsx
@@ -333,16 +333,15 @@ describe('ImageViewer.Multi', () => {
     ])
 
     // 等待拖拽完成并确保指示器已更新
-    await act(async () => {
-      await new Promise(resolve => setTimeout(resolve, 100))
+    await waitFor(() => {
+      const indicatorElementsAfterDragBack =
+        screen.getAllByText(/\d+\s*\/\s*\d+/)
+      expect(
+        indicatorElementsAfterDragBack.some(el =>
+          el.textContent?.includes('4 / 4')
+        )
+      ).toBe(true)
     })
-
-    const indicatorElementsAfterDragBack = screen.getAllByText(/\d+\s*\/\s*\d+/)
-    expect(
-      indicatorElementsAfterDragBack.some(el =>
-        el.textContent?.includes('4 / 4')
-      )
-    ).toBe(true)
 
     await waitFor(() => expect(onIndexChange).toBeCalledTimes(2))
     await waitFor(() => expect(onIndexChange).toBeCalledWith(3))

--- a/src/components/image-viewer/tests/image-viewer.test.tsx
+++ b/src/components/image-viewer/tests/image-viewer.test.tsx
@@ -308,14 +308,13 @@ describe('ImageViewer.Multi', () => {
     ])
 
     // 等待拖拽完成并确保指示器已更新
-    await act(async () => {
-      await new Promise(resolve => setTimeout(resolve, 100))
-    })
-
-    const indicatorElementsAfterDrag = screen.getAllByText(/\d+\s*\/\s*\d+/)
-    expect(
-      indicatorElementsAfterDrag.some(el => el.textContent?.includes('3 / 4'))
-    ).toBe(true)
+    await waitFor(() =>
+      expect(
+        screen
+          .getAllByText(/\d+\s*\/\s*\d+/)
+          .some(el => el.textContent?.includes('3 / 4'))
+      ).toBe(true)
+    )
 
     await waitFor(() => expect(onIndexChange).toBeCalledTimes(1))
     await waitFor(() => expect(onIndexChange).toBeCalledWith(2))
@@ -333,16 +332,13 @@ describe('ImageViewer.Multi', () => {
     ])
 
     // 等待拖拽完成并确保指示器已更新
-    await act(async () => {
-      await new Promise(resolve => setTimeout(resolve, 100))
-    })
-
-    const indicatorElementsAfterDragBack = screen.getAllByText(/\d+\s*\/\s*\d+/)
-    expect(
-      indicatorElementsAfterDragBack.some(el =>
-        el.textContent?.includes('4 / 4')
-      )
-    ).toBe(true)
+    await waitFor(() =>
+      expect(
+        screen
+          .getAllByText(/\d+\s*\/\s*\d+/)
+          .some(el => el.textContent?.includes('4 / 4'))
+      ).toBe(true)
+    )
 
     await waitFor(() => expect(onIndexChange).toBeCalledTimes(2))
     await waitFor(() => expect(onIndexChange).toBeCalledWith(3))

--- a/src/components/image-viewer/tests/image-viewer.test.tsx
+++ b/src/components/image-viewer/tests/image-viewer.test.tsx
@@ -333,15 +333,16 @@ describe('ImageViewer.Multi', () => {
     ])
 
     // 等待拖拽完成并确保指示器已更新
-    await waitFor(() => {
-      const indicatorElementsAfterDragBack =
-        screen.getAllByText(/\d+\s*\/\s*\d+/)
-      expect(
-        indicatorElementsAfterDragBack.some(el =>
-          el.textContent?.includes('4 / 4')
-        )
-      ).toBe(true)
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 100))
     })
+
+    const indicatorElementsAfterDragBack = screen.getAllByText(/\d+\s*\/\s*\d+/)
+    expect(
+      indicatorElementsAfterDragBack.some(el =>
+        el.textContent?.includes('4 / 4')
+      )
+    ).toBe(true)
 
     await waitFor(() => expect(onIndexChange).toBeCalledTimes(2))
     await waitFor(() => expect(onIndexChange).toBeCalledWith(3))

--- a/src/components/swiper/index.en.md
+++ b/src/components/swiper/index.en.md
@@ -58,7 +58,7 @@ Use `total` with `renderProps` for render. Not support `loop`
 | indicator | Render a customized indicator | `(total: number, current: number) => ReactNode` | - |
 | indicatorProps | Related attributes of the indicator | support [PageIndicator](/components/page-indicator) `color` `style` `className` prop | - |
 | loop | Whether to loop | `boolean` | `false` |
-| onIndexChange | Triggered on index is changed | `(index: number) => void` | - |
+| onIndexChange | Triggered on index is changed | `(index: number, source: SwiperIndexChangeSource) => void` | - |
 | rubberband | Whether to enable the rubberband effect. | `boolean` | `true` |
 | slideSize | The slide width in percentage | `number` | `100` |
 | stuckAtBoundary | Whether to stuck at boundary in order to prevent white spaces. Only available when `loop` is `false` and `slideWidth` < 100. | `boolean` | `true` |
@@ -81,11 +81,11 @@ type PropagationEvent = 'mouseup' | 'mousemove' | 'mousedown'
 
 ### Ref
 
-| Name      | Description                   | Type                      |
-| --------- | ----------------------------- | ------------------------- |
-| swipeNext | Switch to the next one        | `() => void`              |
-| swipePrev | Switch to the previous one    | `() => void`              |
-| swipeTo   | Switch to the specified index | `(index: number) => void` |
+| Name | Description | Type |
+| --- | --- | --- |
+| swipeNext | Switch to the next one | `() => void` |
+| swipePrev | Switch to the previous one | `() => void` |
+| swipeTo | Switch to the specified index | `(index: number, source: SwiperIndexChangeSource) => void` |
 
 ## Swiper.Item
 

--- a/src/components/swiper/index.en.md
+++ b/src/components/swiper/index.en.md
@@ -58,7 +58,7 @@ Use `total` with `renderProps` for render. Not support `loop`
 | indicator | Render a customized indicator | `(total: number, current: number) => ReactNode` | - |
 | indicatorProps | Related attributes of the indicator | support [PageIndicator](/components/page-indicator) `color` `style` `className` prop | - |
 | loop | Whether to loop | `boolean` | `false` |
-| onIndexChange | Triggered on index is changed | `(index: number, source: SwiperIndexChangeSource) => void` | - |
+| onIndexChange | Triggered on index is changed | `(index: number, info: { source: SwiperIndexChangeSource }) => void` | - |
 | rubberband | Whether to enable the rubberband effect. | `boolean` | `true` |
 | slideSize | The slide width in percentage | `number` | `100` |
 | stuckAtBoundary | Whether to stuck at boundary in order to prevent white spaces. Only available when `loop` is `false` and `slideWidth` < 100. | `boolean` | `true` |
@@ -81,11 +81,11 @@ type PropagationEvent = 'mouseup' | 'mousemove' | 'mousedown'
 
 ### Ref
 
-| Name | Description | Type |
-| --- | --- | --- |
-| swipeNext | Switch to the next one | `() => void` |
-| swipePrev | Switch to the previous one | `() => void` |
-| swipeTo | Switch to the specified index | `(index: number, info?: { source: SwiperIndexChangeSource }) => void` |
+| Name      | Description                   | Type                      |
+| --------- | ----------------------------- | ------------------------- |
+| swipeNext | Switch to the next one        | `() => void`              |
+| swipePrev | Switch to the previous one    | `() => void`              |
+| swipeTo   | Switch to the specified index | `(index: number) => void` |
 
 ## Swiper.Item
 

--- a/src/components/swiper/index.en.md
+++ b/src/components/swiper/index.en.md
@@ -85,7 +85,7 @@ type PropagationEvent = 'mouseup' | 'mousemove' | 'mousedown'
 | --- | --- | --- |
 | swipeNext | Switch to the next one | `() => void` |
 | swipePrev | Switch to the previous one | `() => void` |
-| swipeTo | Switch to the specified index | `(index: number, source: SwiperIndexChangeSource) => void` |
+| swipeTo | Switch to the specified index | `(index: number, info?: { source: SwiperIndexChangeSource }) => void` |
 
 ## Swiper.Item
 

--- a/src/components/swiper/index.en.md
+++ b/src/components/swiper/index.en.md
@@ -71,7 +71,7 @@ type PropagationEvent = 'mouseup' | 'mousemove' | 'mousedown'
 ```
 
 ```ts
-type SwiperIndexChangeSource = 'swipe' | 'swipeNext' | 'swipePrev' | 'resize'
+type SwiperIndexChangeSource = 'auto' | 'swipe' | 'resize'
 ```
 
 ### CSS Variables

--- a/src/components/swiper/index.en.md
+++ b/src/components/swiper/index.en.md
@@ -70,6 +70,10 @@ Use `total` with `renderProps` for render. Not support `loop`
 type PropagationEvent = 'mouseup' | 'mousemove' | 'mousedown'
 ```
 
+```ts
+type SwiperIndexChangeSource = 'swipe' | 'swipeNext' | 'swipePrev' | 'resize'
+```
+
 ### CSS Variables
 
 | Name            | Description                              | Default |

--- a/src/components/swiper/index.zh.md
+++ b/src/components/swiper/index.zh.md
@@ -58,7 +58,7 @@
 | indicator | 自定义指示器 | `(total: number, current: number) => ReactNode` | - |
 | indicatorProps | 指示器的相关属性 | 支持 [PageIndicator](/zh/components/page-indicator) 的 `color` `style` `className` 属性 | - |
 | loop | 是否循环 | `boolean` | `false` |
-| onIndexChange | 切换时触发 | `(index: number, source: SwiperIndexChangeSource) => void` | - |
+| onIndexChange | 切换时触发 | `(index: number, info: { source: SwiperIndexChangeSource }) => void` | - |
 | rubberband | 是否在拖动超出内容区域时启用橡皮筋效果，仅在非 `loop` 模式下生效 | `boolean` | `true` |
 | slideSize | 滑块的宽度百分比 | `number` | `100` |
 | stuckAtBoundary | 是否在边界两边卡住，避免出现空白，仅在非 `loop` 模式且 `slideSize` < 100 时生效 | `boolean` | `true` |
@@ -81,11 +81,11 @@ type PropagationEvent = 'mouseup' | 'mousemove' | 'mousedown'
 
 ### Ref
 
-| 属性 | 说明 | 类型 |
-| --- | --- | --- |
-| swipeNext | 切换到下一张 | `() => void` |
-| swipePrev | 切换到上一张 | `() => void` |
-| swipeTo | 切换到指定索引 | `(index: number, info?: { source: SwiperIndexChangeSource }) => void` |
+| 属性      | 说明           | 类型                      |
+| --------- | -------------- | ------------------------- |
+| swipeNext | 切换到下一张   | `() => void`              |
+| swipePrev | 切换到上一张   | `() => void`              |
+| swipeTo   | 切换到指定索引 | `(index: number) => void` |
 
 ## Swiper.Item
 

--- a/src/components/swiper/index.zh.md
+++ b/src/components/swiper/index.zh.md
@@ -71,7 +71,7 @@ type PropagationEvent = 'mouseup' | 'mousemove' | 'mousedown'
 ```
 
 ```ts
-type SwiperIndexChangeSource = 'swipe' | 'swipeNext' | 'swipePrev' | 'resize'
+type SwiperIndexChangeSource = 'auto' | 'swipe' | 'resize'
 ```
 
 ### CSS 变量

--- a/src/components/swiper/index.zh.md
+++ b/src/components/swiper/index.zh.md
@@ -58,7 +58,7 @@
 | indicator | 自定义指示器 | `(total: number, current: number) => ReactNode` | - |
 | indicatorProps | 指示器的相关属性 | 支持 [PageIndicator](/zh/components/page-indicator) 的 `color` `style` `className` 属性 | - |
 | loop | 是否循环 | `boolean` | `false` |
-| onIndexChange | 切换时触发 | `(index: number) => void` | - |
+| onIndexChange | 切换时触发 | `(index: number, source: SwiperIndexChangeSource) => void` | - |
 | rubberband | 是否在拖动超出内容区域时启用橡皮筋效果，仅在非 `loop` 模式下生效 | `boolean` | `true` |
 | slideSize | 滑块的宽度百分比 | `number` | `100` |
 | stuckAtBoundary | 是否在边界两边卡住，避免出现空白，仅在非 `loop` 模式且 `slideSize` < 100 时生效 | `boolean` | `true` |
@@ -81,11 +81,11 @@ type PropagationEvent = 'mouseup' | 'mousemove' | 'mousedown'
 
 ### Ref
 
-| 属性      | 说明           | 类型                      |
-| --------- | -------------- | ------------------------- |
-| swipeNext | 切换到下一张   | `() => void`              |
-| swipePrev | 切换到上一张   | `() => void`              |
-| swipeTo   | 切换到指定索引 | `(index: number) => void` |
+| 属性 | 说明 | 类型 |
+| --- | --- | --- |
+| swipeNext | 切换到下一张 | `() => void` |
+| swipePrev | 切换到上一张 | `() => void` |
+| swipeTo | 切换到指定索引 | `(index: number, source: SwiperIndexChangeSource) => void` |
 
 ## Swiper.Item
 

--- a/src/components/swiper/index.zh.md
+++ b/src/components/swiper/index.zh.md
@@ -85,7 +85,7 @@ type PropagationEvent = 'mouseup' | 'mousemove' | 'mousedown'
 | --- | --- | --- |
 | swipeNext | 切换到下一张 | `() => void` |
 | swipePrev | 切换到上一张 | `() => void` |
-| swipeTo | 切换到指定索引 | `(index: number, source: SwiperIndexChangeSource) => void` |
+| swipeTo | 切换到指定索引 | `(index: number, info?: { source: SwiperIndexChangeSource }) => void` |
 
 ## Swiper.Item
 

--- a/src/components/swiper/index.zh.md
+++ b/src/components/swiper/index.zh.md
@@ -70,6 +70,10 @@
 type PropagationEvent = 'mouseup' | 'mousemove' | 'mousedown'
 ```
 
+```ts
+type SwiperIndexChangeSource = 'swipe' | 'swipeNext' | 'swipePrev' | 'resize'
+```
+
 ### CSS 变量
 
 | 属性            | 说明                 | 默认值 |

--- a/src/components/swiper/swiper.tsx
+++ b/src/components/swiper/swiper.tsx
@@ -42,6 +42,14 @@ export type SwiperRef = {
   swipePrev: () => void
 }
 
+export type SwiperIndexChangeSource =
+  | 'drag'
+  | 'autoplay'
+  | 'swipeTo'
+  | 'swipeNext'
+  | 'swipePrev'
+  | 'resize'
+
 export type SwiperProps = {
   defaultIndex?: number
   allowTouchMove?: boolean
@@ -49,7 +57,7 @@ export type SwiperProps = {
   autoplayInterval?: number
   loop?: boolean
   direction?: 'horizontal' | 'vertical'
-  onIndexChange?: (index: number) => void
+  onIndexChange?: (index: number, source: SwiperIndexChangeSource) => void
   indicatorProps?: Pick<PageIndicatorProps, 'color' | 'style' | 'className'>
   indicator?: false | ((total: number, current: number) => ReactNode)
   slideSize?: number
@@ -216,7 +224,7 @@ export const Swiper = forwardRef<SwiperRef, SwiperProps>(
             const index = Math.round(
               (offset + velocity * 2000 * direction) / slidePixels
             )
-            swipeTo(bound(index, minIndex, maxIndex))
+            swipeTo(bound(index, minIndex, maxIndex), false, 'drag')
             window.setTimeout(() => {
               setDragging(false)
             })
@@ -256,14 +264,18 @@ export const Swiper = forwardRef<SwiperRef, SwiperProps>(
         }
       )
 
-      function swipeTo(index: number, immediate = false) {
+      function swipeTo(
+        index: number,
+        immediate = false,
+        source: SwiperIndexChangeSource = 'swipeTo'
+      ) {
         const roundedIndex = Math.round(index)
         const targetIndex = loop
           ? modulus(roundedIndex, mergedTotal)
           : bound(roundedIndex, 0, mergedTotal - 1)
 
         if (targetIndex !== getCurrent()) {
-          props.onIndexChange?.(targetIndex)
+          props.onIndexChange?.(targetIndex, source)
         }
 
         setCurrent(targetIndex)
@@ -275,11 +287,11 @@ export const Swiper = forwardRef<SwiperRef, SwiperProps>(
       }
 
       function swipeNext() {
-        swipeTo(Math.round(position.get() / 100) + 1)
+        swipeTo(Math.round(position.get() / 100) + 1, false, 'swipeNext')
       }
 
       function swipePrev() {
-        swipeTo(Math.round(position.get() / 100) - 1)
+        swipeTo(Math.round(position.get() / 100) - 1, false, 'swipePrev')
       }
 
       useImperativeHandle(ref, () => ({
@@ -291,7 +303,7 @@ export const Swiper = forwardRef<SwiperRef, SwiperProps>(
       useIsomorphicLayoutEffect(() => {
         const maxIndex = mergedTotal - 1
         if (current > maxIndex) {
-          swipeTo(maxIndex, true)
+          swipeTo(maxIndex, true, 'resize')
         }
       })
 
@@ -300,9 +312,9 @@ export const Swiper = forwardRef<SwiperRef, SwiperProps>(
       const runTimeSwiper = () => {
         timeoutRef.current = window.setTimeout(() => {
           if (autoplay === 'reverse') {
-            swipePrev()
+            swipeTo(Math.round(position.get() / 100) - 1, false, 'autoplay')
           } else {
-            swipeNext()
+            swipeTo(Math.round(position.get() / 100) + 1, false, 'autoplay')
           }
           runTimeSwiper()
         }, autoplayInterval)

--- a/src/components/swiper/swiper.tsx
+++ b/src/components/swiper/swiper.tsx
@@ -37,7 +37,7 @@ type ValuesToUnion<T, K extends keyof T = keyof T> = K extends keyof T
 type PropagationEvent = keyof typeof eventToPropRecord
 
 export type SwiperRef = {
-  swipeTo: (index: number, source?: SwiperIndexChangeSource) => void
+  swipeTo: (index: number, info?: { source: SwiperIndexChangeSource }) => void
   swipeNext: () => void
   swipePrev: () => void
 }
@@ -224,7 +224,7 @@ export const Swiper = forwardRef<SwiperRef, SwiperProps>(
             const index = Math.round(
               (offset + velocity * 2000 * direction) / slidePixels
             )
-            swipeTo(bound(index, minIndex, maxIndex), 'drag', false)
+            swipeTo(bound(index, minIndex, maxIndex), { source: 'drag' }, false)
             window.setTimeout(() => {
               setDragging(false)
             })
@@ -266,7 +266,7 @@ export const Swiper = forwardRef<SwiperRef, SwiperProps>(
 
       function swipeTo(
         index: number,
-        source: SwiperIndexChangeSource = 'swipeTo',
+        info: { source: SwiperIndexChangeSource } = { source: 'swipeTo' },
         immediate = false
       ) {
         const roundedIndex = Math.round(index)
@@ -275,7 +275,7 @@ export const Swiper = forwardRef<SwiperRef, SwiperProps>(
           : bound(roundedIndex, 0, mergedTotal - 1)
 
         if (targetIndex !== getCurrent()) {
-          props.onIndexChange?.(targetIndex, source)
+          props.onIndexChange?.(targetIndex, info.source)
         }
 
         setCurrent(targetIndex)
@@ -287,15 +287,23 @@ export const Swiper = forwardRef<SwiperRef, SwiperProps>(
       }
 
       function swipeNext() {
-        swipeTo(Math.round(position.get() / 100) + 1, 'swipeNext', false)
+        swipeTo(
+          Math.round(position.get() / 100) + 1,
+          { source: 'swipeNext' },
+          false
+        )
       }
 
       function swipePrev() {
-        swipeTo(Math.round(position.get() / 100) - 1, 'swipePrev', false)
+        swipeTo(
+          Math.round(position.get() / 100) - 1,
+          { source: 'swipePrev' },
+          false
+        )
       }
 
       useImperativeHandle(ref, () => ({
-        swipeTo: (index, source) => swipeTo(index, source, false),
+        swipeTo: (index, info) => swipeTo(index, info, false),
         swipeNext,
         swipePrev,
       }))
@@ -303,7 +311,7 @@ export const Swiper = forwardRef<SwiperRef, SwiperProps>(
       useIsomorphicLayoutEffect(() => {
         const maxIndex = mergedTotal - 1
         if (current > maxIndex) {
-          swipeTo(maxIndex, 'resize', true)
+          swipeTo(maxIndex, { source: 'resize' }, true)
         }
       })
 
@@ -312,9 +320,17 @@ export const Swiper = forwardRef<SwiperRef, SwiperProps>(
       const runTimeSwiper = () => {
         timeoutRef.current = window.setTimeout(() => {
           if (autoplay === 'reverse') {
-            swipeTo(Math.round(position.get() / 100) - 1, 'autoplay', false)
+            swipeTo(
+              Math.round(position.get() / 100) - 1,
+              { source: 'autoplay' },
+              false
+            )
           } else {
-            swipeTo(Math.round(position.get() / 100) + 1, 'autoplay', false)
+            swipeTo(
+              Math.round(position.get() / 100) + 1,
+              { source: 'autoplay' },
+              false
+            )
           }
           runTimeSwiper()
         }, autoplayInterval)

--- a/src/components/swiper/swiper.tsx
+++ b/src/components/swiper/swiper.tsx
@@ -37,7 +37,7 @@ type ValuesToUnion<T, K extends keyof T = keyof T> = K extends keyof T
 type PropagationEvent = keyof typeof eventToPropRecord
 
 export type SwiperRef = {
-  swipeTo: (index: number) => void
+  swipeTo: (index: number, source?: SwiperIndexChangeSource) => void
   swipeNext: () => void
   swipePrev: () => void
 }
@@ -224,7 +224,7 @@ export const Swiper = forwardRef<SwiperRef, SwiperProps>(
             const index = Math.round(
               (offset + velocity * 2000 * direction) / slidePixels
             )
-            swipeTo(bound(index, minIndex, maxIndex), false, 'drag')
+            swipeTo(bound(index, minIndex, maxIndex), 'drag', false)
             window.setTimeout(() => {
               setDragging(false)
             })
@@ -266,8 +266,8 @@ export const Swiper = forwardRef<SwiperRef, SwiperProps>(
 
       function swipeTo(
         index: number,
-        immediate = false,
-        source: SwiperIndexChangeSource = 'swipeTo'
+        source: SwiperIndexChangeSource = 'swipeTo',
+        immediate = false
       ) {
         const roundedIndex = Math.round(index)
         const targetIndex = loop
@@ -287,15 +287,15 @@ export const Swiper = forwardRef<SwiperRef, SwiperProps>(
       }
 
       function swipeNext() {
-        swipeTo(Math.round(position.get() / 100) + 1, false, 'swipeNext')
+        swipeTo(Math.round(position.get() / 100) + 1, 'swipeNext', false)
       }
 
       function swipePrev() {
-        swipeTo(Math.round(position.get() / 100) - 1, false, 'swipePrev')
+        swipeTo(Math.round(position.get() / 100) - 1, 'swipePrev', false)
       }
 
       useImperativeHandle(ref, () => ({
-        swipeTo,
+        swipeTo: (index, source) => swipeTo(index, source, false),
         swipeNext,
         swipePrev,
       }))
@@ -303,7 +303,7 @@ export const Swiper = forwardRef<SwiperRef, SwiperProps>(
       useIsomorphicLayoutEffect(() => {
         const maxIndex = mergedTotal - 1
         if (current > maxIndex) {
-          swipeTo(maxIndex, true, 'resize')
+          swipeTo(maxIndex, 'resize', true)
         }
       })
 
@@ -312,9 +312,9 @@ export const Swiper = forwardRef<SwiperRef, SwiperProps>(
       const runTimeSwiper = () => {
         timeoutRef.current = window.setTimeout(() => {
           if (autoplay === 'reverse') {
-            swipeTo(Math.round(position.get() / 100) - 1, false, 'autoplay')
+            swipeTo(Math.round(position.get() / 100) - 1, 'autoplay', false)
           } else {
-            swipeTo(Math.round(position.get() / 100) + 1, false, 'autoplay')
+            swipeTo(Math.round(position.get() / 100) + 1, 'autoplay', false)
           }
           runTimeSwiper()
         }, autoplayInterval)

--- a/src/components/swiper/swiper.tsx
+++ b/src/components/swiper/swiper.tsx
@@ -42,11 +42,7 @@ export type SwiperRef = {
   swipePrev: () => void
 }
 
-export type SwiperIndexChangeSource =
-  | 'swipe'
-  | 'swipeNext'
-  | 'swipePrev'
-  | 'resize'
+export type SwiperIndexChangeSource = 'auto' | 'swipe' | 'resize'
 
 export type SwiperProps = {
   defaultIndex?: number
@@ -287,11 +283,11 @@ export const Swiper = forwardRef<SwiperRef, SwiperProps>(
         })
       }
 
-      function swipeNext(source: SwiperIndexChangeSource = 'swipeNext') {
+      function swipeNext(source: SwiperIndexChangeSource = 'swipe') {
         swipeTo(Math.round(position.get() / 100) + 1, source, false)
       }
 
-      function swipePrev(source: SwiperIndexChangeSource = 'swipePrev') {
+      function swipePrev(source: SwiperIndexChangeSource = 'swipe') {
         swipeTo(Math.round(position.get() / 100) - 1, source, false)
       }
 
@@ -313,9 +309,9 @@ export const Swiper = forwardRef<SwiperRef, SwiperProps>(
       const runTimeSwiper = () => {
         timeoutRef.current = window.setTimeout(() => {
           if (autoplay === 'reverse') {
-            swipePrev('swipe')
+            swipePrev('auto')
           } else {
-            swipeNext('swipe')
+            swipeNext('auto')
           }
           runTimeSwiper()
         }, autoplayInterval)

--- a/src/components/swiper/swiper.tsx
+++ b/src/components/swiper/swiper.tsx
@@ -37,7 +37,7 @@ type ValuesToUnion<T, K extends keyof T = keyof T> = K extends keyof T
 type PropagationEvent = keyof typeof eventToPropRecord
 
 export type SwiperRef = {
-  swipeTo: (index: number, info?: { source: SwiperIndexChangeSource }) => void
+  swipeTo: (index: number) => void
   swipeNext: () => void
   swipePrev: () => void
 }
@@ -57,7 +57,10 @@ export type SwiperProps = {
   autoplayInterval?: number
   loop?: boolean
   direction?: 'horizontal' | 'vertical'
-  onIndexChange?: (index: number, source: SwiperIndexChangeSource) => void
+  onIndexChange?: (
+    index: number,
+    info: { source: SwiperIndexChangeSource }
+  ) => void
   indicatorProps?: Pick<PageIndicatorProps, 'color' | 'style' | 'className'>
   indicator?: false | ((total: number, current: number) => ReactNode)
   slideSize?: number
@@ -224,7 +227,7 @@ export const Swiper = forwardRef<SwiperRef, SwiperProps>(
             const index = Math.round(
               (offset + velocity * 2000 * direction) / slidePixels
             )
-            swipeTo(bound(index, minIndex, maxIndex), { source: 'drag' }, false)
+            swipeTo(bound(index, minIndex, maxIndex), 'drag', false)
             window.setTimeout(() => {
               setDragging(false)
             })
@@ -266,7 +269,7 @@ export const Swiper = forwardRef<SwiperRef, SwiperProps>(
 
       function swipeTo(
         index: number,
-        info: { source: SwiperIndexChangeSource } = { source: 'swipeTo' },
+        source: SwiperIndexChangeSource = 'swipeTo',
         immediate = false
       ) {
         const roundedIndex = Math.round(index)
@@ -275,7 +278,7 @@ export const Swiper = forwardRef<SwiperRef, SwiperProps>(
           : bound(roundedIndex, 0, mergedTotal - 1)
 
         if (targetIndex !== getCurrent()) {
-          props.onIndexChange?.(targetIndex, info.source)
+          props.onIndexChange?.(targetIndex, { source })
         }
 
         setCurrent(targetIndex)
@@ -287,23 +290,15 @@ export const Swiper = forwardRef<SwiperRef, SwiperProps>(
       }
 
       function swipeNext() {
-        swipeTo(
-          Math.round(position.get() / 100) + 1,
-          { source: 'swipeNext' },
-          false
-        )
+        swipeTo(Math.round(position.get() / 100) + 1, 'swipeNext', false)
       }
 
       function swipePrev() {
-        swipeTo(
-          Math.round(position.get() / 100) - 1,
-          { source: 'swipePrev' },
-          false
-        )
+        swipeTo(Math.round(position.get() / 100) - 1, 'swipePrev', false)
       }
 
       useImperativeHandle(ref, () => ({
-        swipeTo: (index, info) => swipeTo(index, info, false),
+        swipeTo: index => swipeTo(index, 'swipeTo', false),
         swipeNext,
         swipePrev,
       }))
@@ -311,7 +306,7 @@ export const Swiper = forwardRef<SwiperRef, SwiperProps>(
       useIsomorphicLayoutEffect(() => {
         const maxIndex = mergedTotal - 1
         if (current > maxIndex) {
-          swipeTo(maxIndex, { source: 'resize' }, true)
+          swipeTo(maxIndex, 'resize', true)
         }
       })
 
@@ -320,17 +315,9 @@ export const Swiper = forwardRef<SwiperRef, SwiperProps>(
       const runTimeSwiper = () => {
         timeoutRef.current = window.setTimeout(() => {
           if (autoplay === 'reverse') {
-            swipeTo(
-              Math.round(position.get() / 100) - 1,
-              { source: 'autoplay' },
-              false
-            )
+            swipeTo(Math.round(position.get() / 100) - 1, 'autoplay', false)
           } else {
-            swipeTo(
-              Math.round(position.get() / 100) + 1,
-              { source: 'autoplay' },
-              false
-            )
+            swipeTo(Math.round(position.get() / 100) + 1, 'autoplay', false)
           }
           runTimeSwiper()
         }, autoplayInterval)

--- a/src/components/swiper/swiper.tsx
+++ b/src/components/swiper/swiper.tsx
@@ -43,9 +43,7 @@ export type SwiperRef = {
 }
 
 export type SwiperIndexChangeSource =
-  | 'drag'
-  | 'autoplay'
-  | 'swipeTo'
+  | 'swipe'
   | 'swipeNext'
   | 'swipePrev'
   | 'resize'
@@ -227,7 +225,7 @@ export const Swiper = forwardRef<SwiperRef, SwiperProps>(
             const index = Math.round(
               (offset + velocity * 2000 * direction) / slidePixels
             )
-            swipeTo(bound(index, minIndex, maxIndex), 'drag', false)
+            swipeTo(bound(index, minIndex, maxIndex), 'swipe', false)
             window.setTimeout(() => {
               setDragging(false)
             })
@@ -269,7 +267,7 @@ export const Swiper = forwardRef<SwiperRef, SwiperProps>(
 
       function swipeTo(
         index: number,
-        source: SwiperIndexChangeSource = 'swipeTo',
+        source: SwiperIndexChangeSource = 'swipe',
         immediate = false
       ) {
         const roundedIndex = Math.round(index)
@@ -289,16 +287,16 @@ export const Swiper = forwardRef<SwiperRef, SwiperProps>(
         })
       }
 
-      function swipeNext() {
-        swipeTo(Math.round(position.get() / 100) + 1, 'swipeNext', false)
+      function swipeNext(source: SwiperIndexChangeSource = 'swipeNext') {
+        swipeTo(Math.round(position.get() / 100) + 1, source, false)
       }
 
-      function swipePrev() {
-        swipeTo(Math.round(position.get() / 100) - 1, 'swipePrev', false)
+      function swipePrev(source: SwiperIndexChangeSource = 'swipePrev') {
+        swipeTo(Math.round(position.get() / 100) - 1, source, false)
       }
 
       useImperativeHandle(ref, () => ({
-        swipeTo: index => swipeTo(index, 'swipeTo', false),
+        swipeTo: index => swipeTo(index, 'swipe', false),
         swipeNext,
         swipePrev,
       }))
@@ -315,9 +313,9 @@ export const Swiper = forwardRef<SwiperRef, SwiperProps>(
       const runTimeSwiper = () => {
         timeoutRef.current = window.setTimeout(() => {
           if (autoplay === 'reverse') {
-            swipeTo(Math.round(position.get() / 100) - 1, 'autoplay', false)
+            swipePrev('swipe')
           } else {
-            swipeTo(Math.round(position.get() / 100) + 1, 'autoplay', false)
+            swipeNext('swipe')
           }
           runTimeSwiper()
         }, autoplayInterval)

--- a/src/components/swiper/tests/swiper.test.tsx
+++ b/src/components/swiper/tests/swiper.test.tsx
@@ -187,7 +187,7 @@ describe('Swiper', () => {
           </Swiper>
           <button
             onClick={() => {
-              ref.current?.swipeTo(3, { source: 'swipeTo' })
+              ref.current?.swipeTo(3)
             }}
           >
             to
@@ -198,7 +198,7 @@ describe('Swiper', () => {
     const { getByText } = render(<App />)
 
     fireEvent.click(getByText('to'))
-    expect(onIndexChange).toBeCalledWith(2, 'swipeTo')
+    expect(onIndexChange).toBeCalledWith(2, { source: 'swipeTo' })
   })
 
   test('`onIndexChange` source should be `swipeNext` when use `swipeNext`', () => {
@@ -223,7 +223,7 @@ describe('Swiper', () => {
     const { getByText } = render(<App />)
 
     fireEvent.click(getByText('next'))
-    expect(onIndexChange).toBeCalledWith(1, 'swipeNext')
+    expect(onIndexChange).toBeCalledWith(1, { source: 'swipeNext' })
   })
 
   test('`onIndexChange` source should be `swipePrev` when use `swipePrev`', () => {
@@ -248,7 +248,7 @@ describe('Swiper', () => {
     const { getByText } = render(<App />)
 
     fireEvent.click(getByText('prev'))
-    expect(onIndexChange).toBeCalledWith(0, 'swipePrev')
+    expect(onIndexChange).toBeCalledWith(0, { source: 'swipePrev' })
   })
 
   test('`onIndexChange` source should be `autoplay`', () => {
@@ -264,7 +264,7 @@ describe('Swiper', () => {
       jest.runOnlyPendingTimers()
     })
 
-    expect(onIndexChange).toBeCalledWith(1, 'autoplay')
+    expect(onIndexChange).toBeCalledWith(1, { source: 'autoplay' })
     jest.useRealTimers()
   })
 
@@ -281,7 +281,7 @@ describe('Swiper', () => {
       jest.runOnlyPendingTimers()
     })
 
-    expect(onIndexChange).toBeCalledWith(0, 'autoplay')
+    expect(onIndexChange).toBeCalledWith(0, { source: 'autoplay' })
     jest.useRealTimers()
   })
 
@@ -306,7 +306,7 @@ describe('Swiper', () => {
       5
     )
 
-    expect(onIndexChange).toBeCalledWith(1, 'drag')
+    expect(onIndexChange).toBeCalledWith(1, { source: 'drag' })
   })
 
   test('`onIndexChange` source should be `resize` when current index out of range', () => {
@@ -328,7 +328,7 @@ describe('Swiper', () => {
     const { getByText } = render(<App />)
 
     fireEvent.click(getByText('shrink'))
-    expect(onIndexChange).toBeCalledWith(1, 'resize')
+    expect(onIndexChange).toBeCalledWith(1, { source: 'resize' })
   })
 
   test('`onIndexChange` should not be called when use `swipeTo` equal value', () => {
@@ -342,7 +342,7 @@ describe('Swiper', () => {
           </Swiper>
           <button
             onClick={() => {
-              ref.current?.swipeTo(0, { source: 'swipeTo' })
+              ref.current?.swipeTo(0)
             }}
           >
             to

--- a/src/components/swiper/tests/swiper.test.tsx
+++ b/src/components/swiper/tests/swiper.test.tsx
@@ -187,7 +187,7 @@ describe('Swiper', () => {
           </Swiper>
           <button
             onClick={() => {
-              ref.current?.swipeTo(3)
+              ref.current?.swipeTo(3, { source: 'swipeTo' })
             }}
           >
             to
@@ -342,7 +342,7 @@ describe('Swiper', () => {
           </Swiper>
           <button
             onClick={() => {
-              ref.current?.swipeTo(0)
+              ref.current?.swipeTo(0, { source: 'swipeTo' })
             }}
           >
             to

--- a/src/components/swiper/tests/swiper.test.tsx
+++ b/src/components/swiper/tests/swiper.test.tsx
@@ -176,7 +176,7 @@ describe('Swiper', () => {
     expect($$(`.${classPrefix}-track-inner`)[0]).toHaveStyle('transform: none')
   })
 
-  test('`onIndexChange` should be called when use `swipeTo`', () => {
+  test('`onIndexChange` source should be `swipe` when use `swipeTo`', () => {
     const onIndexChange = jest.fn()
     const App = () => {
       const ref = useRef<SwiperRef>(null)
@@ -198,7 +198,7 @@ describe('Swiper', () => {
     const { getByText } = render(<App />)
 
     fireEvent.click(getByText('to'))
-    expect(onIndexChange).toBeCalledWith(2, { source: 'swipeTo' })
+    expect(onIndexChange).toBeCalledWith(2, { source: 'swipe' })
   })
 
   test('`onIndexChange` source should be `swipeNext` when use `swipeNext`', () => {
@@ -249,64 +249,6 @@ describe('Swiper', () => {
 
     fireEvent.click(getByText('prev'))
     expect(onIndexChange).toBeCalledWith(0, { source: 'swipePrev' })
-  })
-
-  test('`onIndexChange` source should be `autoplay`', () => {
-    jest.useFakeTimers()
-    const onIndexChange = jest.fn()
-    render(
-      <Swiper autoplay onIndexChange={onIndexChange}>
-        {items}
-      </Swiper>
-    )
-
-    act(() => {
-      jest.runOnlyPendingTimers()
-    })
-
-    expect(onIndexChange).toBeCalledWith(1, { source: 'autoplay' })
-    jest.useRealTimers()
-  })
-
-  test('`onIndexChange` source should be `autoplay` when autoplay reverse', () => {
-    jest.useFakeTimers()
-    const onIndexChange = jest.fn()
-    render(
-      <Swiper autoplay='reverse' defaultIndex={1} onIndexChange={onIndexChange}>
-        {items}
-      </Swiper>
-    )
-
-    act(() => {
-      jest.runOnlyPendingTimers()
-    })
-
-    expect(onIndexChange).toBeCalledWith(0, { source: 'autoplay' })
-    jest.useRealTimers()
-  })
-
-  test('`onIndexChange` source should be `drag` when dragged', async () => {
-    const onIndexChange = jest.fn()
-    render(<Swiper onIndexChange={onIndexChange}>{items}</Swiper>)
-
-    const el = $$(`.${classPrefix}-track`)[0]
-    await mockDrag(
-      el,
-      [
-        { clientX: 300, clientY: 0 },
-        {
-          clientX: 200,
-          clientY: 25,
-        },
-        {
-          clientX: 100,
-          clientY: 30,
-        },
-      ],
-      5
-    )
-
-    expect(onIndexChange).toBeCalledWith(1, { source: 'drag' })
   })
 
   test('`onIndexChange` source should be `resize` when current index out of range', () => {

--- a/src/components/swiper/tests/swiper.test.tsx
+++ b/src/components/swiper/tests/swiper.test.tsx
@@ -246,13 +246,13 @@ describe('Swiper', () => {
     }
     const { getByText } = render(<App />)
 
-    // Test swipeNext
     fireEvent.click(getByText('next'))
     expect(onIndexChange).toBeCalledWith(2, { source: 'swipe' })
 
-    // Test swipePrev
+    onIndexChange.mockClear()
+
     fireEvent.click(getByText('prev'))
-    expect(onIndexChange).toBeCalledWith(0, { source: 'swipe' })
+    expect(onIndexChange).toBeCalledWith(1, { source: 'swipe' })
   })
 
   test('`onIndexChange` source should be `resize` when current index out of range', () => {

--- a/src/components/swiper/tests/swiper.test.tsx
+++ b/src/components/swiper/tests/swiper.test.tsx
@@ -198,7 +198,137 @@ describe('Swiper', () => {
     const { getByText } = render(<App />)
 
     fireEvent.click(getByText('to'))
-    expect(onIndexChange).toBeCalledWith(2)
+    expect(onIndexChange).toBeCalledWith(2, 'swipeTo')
+  })
+
+  test('`onIndexChange` source should be `swipeNext` when use `swipeNext`', () => {
+    const onIndexChange = jest.fn()
+    const App = () => {
+      const ref = useRef<SwiperRef>(null)
+      return (
+        <>
+          <Swiper ref={ref} onIndexChange={onIndexChange}>
+            {items}
+          </Swiper>
+          <button
+            onClick={() => {
+              ref.current?.swipeNext()
+            }}
+          >
+            next
+          </button>
+        </>
+      )
+    }
+    const { getByText } = render(<App />)
+
+    fireEvent.click(getByText('next'))
+    expect(onIndexChange).toBeCalledWith(1, 'swipeNext')
+  })
+
+  test('`onIndexChange` source should be `swipePrev` when use `swipePrev`', () => {
+    const onIndexChange = jest.fn()
+    const App = () => {
+      const ref = useRef<SwiperRef>(null)
+      return (
+        <>
+          <Swiper defaultIndex={1} ref={ref} onIndexChange={onIndexChange}>
+            {items}
+          </Swiper>
+          <button
+            onClick={() => {
+              ref.current?.swipePrev()
+            }}
+          >
+            prev
+          </button>
+        </>
+      )
+    }
+    const { getByText } = render(<App />)
+
+    fireEvent.click(getByText('prev'))
+    expect(onIndexChange).toBeCalledWith(0, 'swipePrev')
+  })
+
+  test('`onIndexChange` source should be `autoplay`', () => {
+    jest.useFakeTimers()
+    const onIndexChange = jest.fn()
+    render(
+      <Swiper autoplay onIndexChange={onIndexChange}>
+        {items}
+      </Swiper>
+    )
+
+    act(() => {
+      jest.runOnlyPendingTimers()
+    })
+
+    expect(onIndexChange).toBeCalledWith(1, 'autoplay')
+    jest.useRealTimers()
+  })
+
+  test('`onIndexChange` source should be `autoplay` when autoplay reverse', () => {
+    jest.useFakeTimers()
+    const onIndexChange = jest.fn()
+    render(
+      <Swiper autoplay='reverse' defaultIndex={1} onIndexChange={onIndexChange}>
+        {items}
+      </Swiper>
+    )
+
+    act(() => {
+      jest.runOnlyPendingTimers()
+    })
+
+    expect(onIndexChange).toBeCalledWith(0, 'autoplay')
+    jest.useRealTimers()
+  })
+
+  test('`onIndexChange` source should be `drag` when dragged', async () => {
+    const onIndexChange = jest.fn()
+    render(<Swiper onIndexChange={onIndexChange}>{items}</Swiper>)
+
+    const el = $$(`.${classPrefix}-track`)[0]
+    await mockDrag(
+      el,
+      [
+        { clientX: 300, clientY: 0 },
+        {
+          clientX: 200,
+          clientY: 25,
+        },
+        {
+          clientX: 100,
+          clientY: 30,
+        },
+      ],
+      5
+    )
+
+    expect(onIndexChange).toBeCalledWith(1, 'drag')
+  })
+
+  test('`onIndexChange` source should be `resize` when current index out of range', () => {
+    const onIndexChange = jest.fn()
+    const App = () => {
+      const [list, setList] = useState(['1', '2', '3'])
+      return (
+        <>
+          <Swiper defaultIndex={2} onIndexChange={onIndexChange}>
+            {list.map(item => (
+              <Swiper.Item key={item}>{item}</Swiper.Item>
+            ))}
+          </Swiper>
+          <button onClick={() => setList(['1', '2'])}>shrink</button>
+        </>
+      )
+    }
+
+    const { getByText } = render(<App />)
+
+    fireEvent.click(getByText('shrink'))
+    expect(onIndexChange).toBeCalledWith(1, 'resize')
   })
 
   test('`onIndexChange` should not be called when use `swipeTo` equal value', () => {

--- a/src/components/swiper/tests/swiper.test.tsx
+++ b/src/components/swiper/tests/swiper.test.tsx
@@ -201,13 +201,30 @@ describe('Swiper', () => {
     expect(onIndexChange).toBeCalledWith(2, { source: 'swipe' })
   })
 
-  test('`onIndexChange` source should be `swipeNext` when use `swipeNext`', () => {
+  test('`onIndexChange` source should be `auto` when autoplay', () => {
+    jest.useFakeTimers()
+    const onIndexChange = jest.fn()
+    render(
+      <Swiper autoplay onIndexChange={onIndexChange}>
+        {items}
+      </Swiper>
+    )
+
+    act(() => {
+      jest.runOnlyPendingTimers()
+    })
+
+    expect(onIndexChange).toBeCalledWith(1, { source: 'auto' })
+    jest.useRealTimers()
+  })
+
+  test('`onIndexChange` source should be `swipe` when use `swipeNext` and `swipePrev`', () => {
     const onIndexChange = jest.fn()
     const App = () => {
       const ref = useRef<SwiperRef>(null)
       return (
         <>
-          <Swiper ref={ref} onIndexChange={onIndexChange}>
+          <Swiper defaultIndex={1} ref={ref} onIndexChange={onIndexChange}>
             {items}
           </Swiper>
           <button
@@ -217,24 +234,6 @@ describe('Swiper', () => {
           >
             next
           </button>
-        </>
-      )
-    }
-    const { getByText } = render(<App />)
-
-    fireEvent.click(getByText('next'))
-    expect(onIndexChange).toBeCalledWith(1, { source: 'swipeNext' })
-  })
-
-  test('`onIndexChange` source should be `swipePrev` when use `swipePrev`', () => {
-    const onIndexChange = jest.fn()
-    const App = () => {
-      const ref = useRef<SwiperRef>(null)
-      return (
-        <>
-          <Swiper defaultIndex={1} ref={ref} onIndexChange={onIndexChange}>
-            {items}
-          </Swiper>
           <button
             onClick={() => {
               ref.current?.swipePrev()
@@ -247,8 +246,13 @@ describe('Swiper', () => {
     }
     const { getByText } = render(<App />)
 
+    // Test swipeNext
+    fireEvent.click(getByText('next'))
+    expect(onIndexChange).toBeCalledWith(2, { source: 'swipe' })
+
+    // Test swipePrev
     fireEvent.click(getByText('prev'))
-    expect(onIndexChange).toBeCalledWith(0, { source: 'swipePrev' })
+    expect(onIndexChange).toBeCalledWith(0, { source: 'swipe' })
   })
 
   test('`onIndexChange` source should be `resize` when current index out of range', () => {


### PR DESCRIPTION
close #6980 onIndexChange 换回调新增了触发来源参数，便于业务侧区分“是怎么发生的切换”

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * Swiper 的索引变化回调现在携带来源参数，可区分拖拽、自动播放、编程控制、窗口调整等触发原因。
  * 编程接口支持可选的来源信息以明确触发上下文。

* **文档**
  * 更新中/英文 Swiper API 文档与示例，说明新增来源参数及引用结构调整。

* **测试**
  * 扩展测试覆盖各触发场景的来源值验证。
  * 调整图片查看器相关测试为异步等待断言以提高稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->