### PR TITLE
fix(cascader): 修复外部值变化时同步问题

### DIFF
--- a/src/components/cascader/cascader.tsx
+++ b/src/components/cascader/cascader.tsx
@@ -1,24 +1,23 @@
 import React, {
-  useState,
   ReactNode,
   forwardRef,
+  useEffect,
   useImperativeHandle,
+  useState,
 } from 'react'
-import { useDeepCompareEffect } from 'ahooks'
-import Popup, { PopupProps } from '../popup'
-import {
-  CascaderValue,
-  CascaderValueExtend,
-  CascaderOption,
-} from '../cascader-view'
-import { mergeProps } from '../../utils/with-default-props'
+import type { FieldNamesType } from '../../hooks'
+import { useFieldNames } from '../../hooks'
 import { NativeProps, withNativeProps } from '../../utils/native-props'
 import { usePropsValue } from '../../utils/use-props-value'
-import CascaderView from '../cascader-view'
-import { useConfig } from '../config-provider'
+import { mergeProps } from '../../utils/with-default-props'
+import CascaderView, {
+  CascaderOption,
+  CascaderValue,
+  CascaderValueExtend,
+} from '../cascader-view'
 import { useCascaderValueExtend } from '../cascader-view/use-cascader-value-extend'
-import { useFieldNames } from '../../hooks'
-import type { FieldNamesType } from '../../hooks'
+import { useConfig } from '../config-provider'
+import Popup, { PopupProps } from '../popup'
 
 const classPrefix = `adm-cascader`
 
@@ -119,7 +118,7 @@ export const Cascader = forwardRef<CascaderRef, CascaderProps>((p, ref) => {
 
   const [innerValue, setInnerValue] = useState<CascaderValue[]>(value)
 
-  useDeepCompareEffect(() => {
+  useEffect(() => {
     setInnerValue(value)
   }, [visible, value])
 

--- a/src/components/cascader/cascader.tsx
+++ b/src/components/cascader/cascader.tsx
@@ -1,10 +1,10 @@
 import React, {
   useState,
-  useEffect,
   ReactNode,
   forwardRef,
   useImperativeHandle,
 } from 'react'
+import { useDeepCompareEffect } from 'ahooks'
 import Popup, { PopupProps } from '../popup'
 import {
   CascaderValue,
@@ -119,7 +119,7 @@ export const Cascader = forwardRef<CascaderRef, CascaderProps>((p, ref) => {
 
   const [innerValue, setInnerValue] = useState<CascaderValue[]>(value)
 
-  useEffect(() => {
+  useDeepCompareEffect(() => {
     setInnerValue(value)
   }, [visible, value])
 

--- a/src/components/cascader/cascader.tsx
+++ b/src/components/cascader/cascader.tsx
@@ -120,9 +120,7 @@ export const Cascader = forwardRef<CascaderRef, CascaderProps>((p, ref) => {
   const [innerValue, setInnerValue] = useState<CascaderValue[]>(value)
 
   useEffect(() => {
-    if (!visible) {
-      setInnerValue(value)
-    }
+    setInnerValue(value)
   }, [visible, value])
 
   const cascaderElement = withNativeProps(

--- a/src/components/cascader/tests/cascader.test.tsx
+++ b/src/components/cascader/tests/cascader.test.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
-import { fireEvent, render, testA11y, waitFor } from 'testing'
-import Cascader from '../'
+import { fireEvent, render, screen, testA11y, waitFor } from 'testing'
+import Cascader, { CascaderValue } from '../'
 import { options } from '../demos/data'
 
 describe('Cascader', () => {
@@ -50,6 +50,47 @@ describe('Cascader', () => {
     fireEvent.click(getByText('确定'))
 
     expect(onConfirm.mock.calls[0][0]).toEqual(['浙江', '杭州'])
+  })
+
+  test('should sync value when visible and external value changes', async () => {
+    const App = () => {
+      const [visible, setVisible] = useState(false)
+      const [value, setValue] = useState<CascaderValue[]>([])
+
+      return (
+        <>
+          <button onClick={() => setVisible(true)}>Open</button>
+          <button onClick={() => setValue(['安徽', '合肥'])}>Set Value</button>
+          <Cascader
+            options={options}
+            visible={visible}
+            value={value}
+            onConfirm={val => {
+              setValue(val)
+              setVisible(false)
+            }}
+            onClose={() => setVisible(false)}
+            onCancel={() => setVisible(false)}
+          />
+        </>
+      )
+    }
+
+    render(<App />)
+
+    fireEvent.click(screen.getByText('Open'))
+    await waitFor(() => {
+      expect(screen.getByText('浙江')).toBeInTheDocument()
+    })
+
+    // While the popup is open, change the external value
+    fireEvent.click(screen.getByText('Set Value'))
+
+    // The cascader should reflect the new value (合肥 should appear in both tab and list)
+    await waitFor(() => {
+      const matches = screen.getAllByText('合肥')
+      expect(matches.length).toBeGreaterThanOrEqual(1)
+    })
   })
 
   test('use in an imperative way', async () => {

--- a/src/components/cascader/tests/cascader.test.tsx
+++ b/src/components/cascader/tests/cascader.test.tsx
@@ -93,6 +93,54 @@ describe('Cascader', () => {
     })
   })
 
+  test('should preserve draft selection when parent re-renders with same value', async () => {
+    const App = () => {
+      const [visible, setVisible] = useState(false)
+      const [value, setValue] = useState<CascaderValue[]>([])
+      const [, setTick] = useState(0)
+
+      return (
+        <>
+          <button onClick={() => setVisible(true)}>Open</button>
+          {/* Trigger a parent re-render without changing value content */}
+          <button onClick={() => setTick(t => t + 1)}>Rerender</button>
+          <Cascader
+            options={options}
+            visible={visible}
+            value={value}
+            onConfirm={val => {
+              setValue(val)
+              setVisible(false)
+            }}
+            onClose={() => setVisible(false)}
+            onCancel={() => setVisible(false)}
+          />
+        </>
+      )
+    }
+
+    render(<App />)
+
+    fireEvent.click(screen.getByText('Open'))
+    await waitFor(() => {
+      expect(screen.getByText('浙江')).toBeInTheDocument()
+    })
+
+    // User selects 浙江 in the cascader (draft, not confirmed)
+    fireEvent.click(screen.getByText('浙江'))
+
+    // Wait for the selection to take effect
+    await waitFor(() => {
+      expect(screen.getAllByText('浙江').length).toBeGreaterThanOrEqual(2)
+    })
+
+    // Parent re-renders with the same value content ([])
+    fireEvent.click(screen.getByText('Rerender'))
+
+    // The draft selection should be preserved — 浙江 should still appear as a selected tab
+    expect(screen.getAllByText('浙江').length).toBeGreaterThanOrEqual(2)
+  })
+
   test('use in an imperative way', async () => {
     const fn = jest.fn()
     const onClick = async () => {


### PR DESCRIPTION
close #6596 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 修复级联选择器在弹窗打开时无法实时同步外部值的问题；外部 value 变更会立即更新显示的选中项。

* **Tests**
  * 新增并完善测试，覆盖弹窗打开期间外部值同步以及草稿选择稳定性的场景，确保 UI 行为符合预期。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ant-design/ant-design-mobile/pull/7046)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->