### PR TITLE
feat(PullToRefresh): 增加 loading 的外部控制

### DIFF
--- a/src/components/pull-to-refresh/demos/demo4.tsx
+++ b/src/components/pull-to-refresh/demos/demo4.tsx
@@ -1,0 +1,48 @@
+import React, { useRef, useState } from 'react'
+import { PullToRefresh, List, Button } from 'antd-mobile'
+import type { PullToRefreshRef } from '..'
+import { lorem } from 'demos'
+
+function getNextData() {
+  const ret: string[] = []
+  for (let i = 0; i < 18; i++) {
+    ret.unshift(lorem.generateWords(1))
+  }
+  return ret
+}
+
+export default () => {
+  const [data, setData] = useState(() => getNextData())
+  const ref = useRef<PullToRefreshRef>(null)
+
+  return (
+    <>
+      <Button
+        style={{ margin: '8px 16px' }}
+        onClick={() => ref.current?.startRefresh()}
+      >
+        外部触发刷新
+      </Button>
+      <PullToRefresh
+        ref={ref}
+        onRefresh={() => {
+          return new Promise<void>(() => {
+            // Never resolve — manually call completeRefresh() when done.
+            // This is useful when onRefresh cannot return a Promise
+            // (e.g. rtk-query, callbacks, event-driven data sources).
+            setTimeout(() => {
+              setData(prev => [...getNextData(), ...prev])
+              ref.current?.completeRefresh()
+            }, 2000)
+          })
+        }}
+      >
+        <List style={{ minHeight: '100vh' }}>
+          {data.map((item, index) => (
+            <List.Item key={index}>{item}</List.Item>
+          ))}
+        </List>
+      </PullToRefresh>
+    </>
+  )
+}

--- a/src/components/pull-to-refresh/demos/demo4.tsx
+++ b/src/components/pull-to-refresh/demos/demo4.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { PullToRefresh, List, Button } from 'antd-mobile'
 import type { PullToRefreshRef } from '..'
 import { lorem } from 'demos'
@@ -14,6 +14,15 @@ function getNextData() {
 export default () => {
   const [data, setData] = useState(() => getNextData())
   const ref = useRef<PullToRefreshRef>(null)
+  const timeoutRef = useRef<ReturnType<typeof setTimeout>>()
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current)
+      }
+    }
+  }, [])
 
   return (
     <>
@@ -26,15 +35,11 @@ export default () => {
       <PullToRefresh
         ref={ref}
         onRefresh={() => {
-          return new Promise<void>(() => {
-            // Never resolve — manually call completeRefresh() when done.
-            // This is useful when onRefresh cannot return a Promise
-            // (e.g. rtk-query, callbacks, event-driven data sources).
-            setTimeout(() => {
-              setData(prev => [...getNextData(), ...prev])
-              ref.current?.completeRefresh()
-            }, 2000)
-          })
+          timeoutRef.current = setTimeout(() => {
+            setData(prev => [...getNextData(), ...prev])
+            ref.current?.completeRefresh()
+          }, 2000)
+          return Promise.resolve()
         }}
       >
         <List style={{ minHeight: '100vh' }}>

--- a/src/components/pull-to-refresh/index.en.md
+++ b/src/components/pull-to-refresh/index.en.md
@@ -24,6 +24,10 @@ It is suitable for updating the content of the current page.
 
 <code src="./demos/demo-nested.tsx"></code>
 
+### Manual Control via Ref
+
+<code src="./demos/demo4.tsx"></code>
+
 ## PullToRefresh
 
 ### Props
@@ -45,6 +49,20 @@ type PullStatus = 'pulling' | 'canRelease' | 'refreshing' | 'complete'
 | renderText | Customize the pulling content according to the pulling status | `(status: PullStatus) => ReactNode` | - |
 | threshold | How far to pull down to trigger refresh, unit is px | `number` | `60` |
 
+### Ref
+
+```ts | pure
+type PullToRefreshRef = {
+  startRefresh: () => void
+  completeRefresh: () => void
+}
+```
+
+| Method | Description |
+| --- | --- |
+| startRefresh | Manually trigger a refresh (same as user pulling down) |
+| completeRefresh | Manually complete the current refresh (useful when onRefresh cannot return a Promise, e.g. rtk-query) |
+
 ## FAQ
 
 ### Does it support pull up to load more?
@@ -54,3 +72,17 @@ Pull-up loading is another component: [InfiniteScroll](/components/infinite-scro
 ### About the browser's default pull-down behavior
 
 Some browsers or webview containers have elastic effects or pull-to-refresh logic. We do not recommend using the PullToRefresh component in this environment. If you must use it, please disable the default pull-down and elastic effects of the outer browser. , otherwise PullToRefresh and the browser's default behavior may be triggered at the same time, resulting in a poor user experience.
+
+### How to control the refresh state externally?
+
+You can manually trigger and complete a refresh via Ref:
+
+```tsx | pure
+const ref = useRef<PullToRefreshRef>(null)
+
+// Manually trigger a refresh
+ref.current?.startRefresh()
+
+// Manually complete the refresh (useful when onRefresh cannot return a Promise)
+ref.current?.completeRefresh()
+```

--- a/src/components/pull-to-refresh/index.en.md
+++ b/src/components/pull-to-refresh/index.en.md
@@ -61,7 +61,7 @@ type PullToRefreshRef = {
 | Method | Description |
 | --- | --- |
 | startRefresh | Manually trigger a refresh (same as user pulling down) |
-| completeRefresh | Manually complete the current refresh (useful when onRefresh cannot return a Promise, e.g. rtk-query) |
+| completeRefresh | Manually complete the current refresh (useful when onRefresh cannot return a Promise, e.g. callback-based APIs or event-driven data sources) |
 
 ## FAQ
 

--- a/src/components/pull-to-refresh/index.ts
+++ b/src/components/pull-to-refresh/index.ts
@@ -1,6 +1,10 @@
 import './pull-to-refresh.less'
 import { PullToRefresh } from './pull-to-refresh'
 
-export type { PullToRefreshProps, PullStatus } from './pull-to-refresh'
+export type {
+  PullToRefreshProps,
+  PullToRefreshRef,
+  PullStatus,
+} from './pull-to-refresh'
 
 export default PullToRefresh

--- a/src/components/pull-to-refresh/index.zh.md
+++ b/src/components/pull-to-refresh/index.zh.md
@@ -61,7 +61,7 @@ type PullToRefreshRef = {
 | 方法 | 说明 |
 | --- | --- |
 | startRefresh | 手动触发刷新（与用户下拉触发效果一致） |
-| completeRefresh | 手动结束刷新（适用于 onRefresh 无法返回 Promise 的场景，如 rtk-query） |
+| completeRefresh | 手动结束刷新（适用于 onRefresh 无法返回 Promise 的场景，如基于回调的 API 或事件驱动的数据源） |
 
 ## 常见问题
 

--- a/src/components/pull-to-refresh/index.zh.md
+++ b/src/components/pull-to-refresh/index.zh.md
@@ -24,6 +24,10 @@
 
 <code src="./demos/demo-nested.tsx"></code>
 
+### 通过 Ref 手动控制刷新
+
+<code src="./demos/demo4.tsx"></code>
+
 ## PullToRefresh
 
 ### 属性
@@ -45,6 +49,20 @@ type PullStatus = 'pulling' | 'canRelease' | 'refreshing' | 'complete'
 | renderText | 根据下拉状态，自定义下拉提示文案 | `(status: PullStatus) => ReactNode` | - |
 | threshold | 触发刷新需要下拉多少距离，单位为 px | `number` | `60` |
 
+### Ref
+
+```ts | pure
+type PullToRefreshRef = {
+  startRefresh: () => void
+  completeRefresh: () => void
+}
+```
+
+| 方法 | 说明 |
+| --- | --- |
+| startRefresh | 手动触发刷新（与用户下拉触发效果一致） |
+| completeRefresh | 手动结束刷新（适用于 onRefresh 无法返回 Promise 的场景，如 rtk-query） |
+
 ## 常见问题
 
 ### 是否支持上拉加载更多？
@@ -54,3 +72,17 @@ type PullStatus = 'pulling' | 'canRelease' | 'refreshing' | 'complete'
 ### 关于浏览器的默认下拉行为
 
 一些浏览器或者 webview 容器本身会有弹性效果或下拉刷新的逻辑，我们不太建议在这种环境中使用 PullToRefresh 组件，如果你一定要用的话，请禁用掉外层浏览器默认的下拉和弹性效果，不然可能会出现 PullToRefresh 和浏览器的默认行为同时被触发的情况，从而导致用户体验比较差。
+
+### 如何在外部控制刷新状态？
+
+通过 Ref 可以手动触发和结束刷新：
+
+```tsx | pure
+const ref = useRef<PullToRefreshRef>(null)
+
+// 手动触发刷新
+ref.current?.startRefresh()
+
+// 手动结束刷新（适用于 onRefresh 无法返回 Promise 的场景）
+ref.current?.completeRefresh()
+```

--- a/src/components/pull-to-refresh/pull-to-refresh.tsx
+++ b/src/components/pull-to-refresh/pull-to-refresh.tsx
@@ -1,3 +1,6 @@
+import { animated, useSpring } from '@react-spring/web'
+import { useDrag } from '@use-gesture/react'
+import type { ReactNode } from 'react'
 import React, {
   forwardRef,
   useEffect,
@@ -5,32 +8,20 @@ import React, {
   useRef,
   useState,
 } from 'react'
-import type { ReactNode } from 'react'
-import { mergeProps } from '../../utils/with-default-props'
-import { animated, useSpring } from '@react-spring/web'
-import { useDrag } from '@use-gesture/react'
-import { getScrollParent } from '../../utils/get-scroll-parent'
-import { supportsPassive } from '../../utils/supports-passive'
 import { convertPx } from '../../utils/convert-px'
+import { getScrollParent } from '../../utils/get-scroll-parent'
 import { rubberbandIfOutOfBounds } from '../../utils/rubberband'
-import { useConfig } from '../config-provider'
 import { sleep } from '../../utils/sleep'
+import { supportsPassive } from '../../utils/supports-passive'
+import { mergeProps } from '../../utils/with-default-props'
+import { useConfig } from '../config-provider'
 
 const classPrefix = `adm-pull-to-refresh`
 
 export type PullStatus = 'pulling' | 'canRelease' | 'refreshing' | 'complete'
 
 export type PullToRefreshRef = {
-  /**
-   * Manually trigger a refresh (same as user pulling down).
-   * Only works when current status is 'pulling'.
-   */
   startRefresh: () => void
-  /**
-   * Manually complete the current refresh.
-   * Only works when current status is 'refreshing'.
-   * Useful when onRefresh does not return a Promise (e.g. rtk-query).
-   */
   completeRefresh: () => void
 }
 
@@ -120,14 +111,11 @@ export const PullToRefresh = forwardRef<PullToRefreshRef, PullToRefreshProps>(
       try {
         await props.onRefresh()
       } catch (e) {
-        // Only reset if still in refreshing state (not manually completed)
         if (statusRef.current === 'refreshing') {
           reset()
         }
         throw e
       }
-      // Auto-complete only if still in refreshing state
-      // (if completeRefresh was called during onRefresh, skip auto-complete)
       if (statusRef.current === 'refreshing') {
         await doCompleteRefresh()
       }
@@ -141,8 +129,6 @@ export const PullToRefresh = forwardRef<PullToRefreshRef, PullToRefreshProps>(
       await reset()
     }
 
-    // Use refs to hold the latest functions so that useImperativeHandle
-    // always calls the up-to-date versions without recreating the handle.
     const doRefreshRef = useRef(doRefresh)
     doRefreshRef.current = doRefresh
     const doCompleteRefreshRef = useRef(doCompleteRefresh)

--- a/src/components/pull-to-refresh/pull-to-refresh.tsx
+++ b/src/components/pull-to-refresh/pull-to-refresh.tsx
@@ -1,5 +1,11 @@
-import React, { useEffect, useRef, useState } from 'react'
-import type { FC, ReactNode } from 'react'
+import React, {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react'
+import type { ReactNode } from 'react'
 import { mergeProps } from '../../utils/with-default-props'
 import { animated, useSpring } from '@react-spring/web'
 import { useDrag } from '@use-gesture/react'
@@ -13,6 +19,20 @@ import { sleep } from '../../utils/sleep'
 const classPrefix = `adm-pull-to-refresh`
 
 export type PullStatus = 'pulling' | 'canRelease' | 'refreshing' | 'complete'
+
+export type PullToRefreshRef = {
+  /**
+   * Manually trigger a refresh (same as user pulling down).
+   * Only works when current status is 'pulling'.
+   */
+  startRefresh: () => void
+  /**
+   * Manually complete the current refresh.
+   * Only works when current status is 'refreshing'.
+   * Useful when onRefresh does not return a Promise (e.g. rtk-query).
+   */
+  completeRefresh: () => void
+}
 
 export type PullToRefreshProps = {
   onRefresh?: () => Promise<any>
@@ -38,156 +58,198 @@ export const defaultProps = {
   onRefresh: () => {},
 }
 
-export const PullToRefresh: FC<PullToRefreshProps> = p => {
-  const { locale } = useConfig()
-  const props = mergeProps(
-    defaultProps,
-    {
-      refreshingText: `${locale.common.loading}...`,
-      pullingText: locale.PullToRefresh.pulling,
-      canReleaseText: locale.PullToRefresh.canRelease,
-      completeText: locale.PullToRefresh.complete,
-    },
-    p
-  )
-  const headHeight = props.headHeight ?? convertPx(40)
-  const threshold = props.threshold ?? convertPx(60)
+export const PullToRefresh = forwardRef<PullToRefreshRef, PullToRefreshProps>(
+  (p, ref) => {
+    const { locale } = useConfig()
+    const props = mergeProps(
+      defaultProps,
+      {
+        refreshingText: `${locale.common.loading}...`,
+        pullingText: locale.PullToRefresh.pulling,
+        canReleaseText: locale.PullToRefresh.canRelease,
+        completeText: locale.PullToRefresh.complete,
+      },
+      p
+    )
+    const headHeight = props.headHeight ?? convertPx(40)
+    const threshold = props.threshold ?? convertPx(60)
 
-  const [status, setStatus] = useState<PullStatus>('pulling')
+    const [status, setStatus] = useState<PullStatus>('pulling')
 
-  const [springStyles, api] = useSpring(() => ({
-    from: { height: 0 },
-    config: {
-      tension: 300,
-      friction: 30,
-      round: true,
-      clamp: true,
-    },
-  }))
+    const statusRef = useRef<PullStatus>(status)
+    useEffect(() => {
+      statusRef.current = status
+    }, [status])
 
-  const elementRef = useRef<HTMLDivElement>(null)
+    const [springStyles, api] = useSpring(() => ({
+      from: { height: 0 },
+      config: {
+        tension: 300,
+        friction: 30,
+        round: true,
+        clamp: true,
+      },
+    }))
 
-  const pullingRef = useRef(false)
+    const elementRef = useRef<HTMLDivElement>(null)
 
-  //防止下拉时抖动
-  useEffect(() => {
-    elementRef.current?.addEventListener('touchmove', () => {})
-  }, [])
+    const pullingRef = useRef(false)
 
-  const reset = () => {
-    return new Promise<void>(resolve => {
-      api.start({
-        to: {
-          height: 0,
-        },
-        onResolve() {
-          setStatus('pulling')
-          resolve()
-        },
+    //防止下拉时抖动
+    useEffect(() => {
+      elementRef.current?.addEventListener('touchmove', () => {})
+    }, [])
+
+    const reset = () => {
+      return new Promise<void>(resolve => {
+        api.start({
+          to: {
+            height: 0,
+          },
+          onResolve() {
+            setStatus('pulling')
+            resolve()
+          },
+        })
       })
-    })
-  }
+    }
 
-  async function doRefresh() {
-    api.start({ height: headHeight })
-    setStatus('refreshing')
-    try {
-      await props.onRefresh()
+    async function doRefresh() {
+      api.start({ height: headHeight })
+      setStatus('refreshing')
+      try {
+        await props.onRefresh()
+      } catch (e) {
+        // Only reset if still in refreshing state (not manually completed)
+        if (statusRef.current === 'refreshing') {
+          reset()
+        }
+        throw e
+      }
+      // Auto-complete only if still in refreshing state
+      // (if completeRefresh was called during onRefresh, skip auto-complete)
+      if (statusRef.current === 'refreshing') {
+        await doCompleteRefresh()
+      }
+    }
+
+    async function doCompleteRefresh() {
       setStatus('complete')
-    } catch (e) {
-      reset()
-      throw e
-    }
-    if (props.completeDelay > 0) {
-      await sleep(props.completeDelay)
-    }
-    reset()
-  }
-
-  useDrag(
-    state => {
-      if (status === 'refreshing' || status === 'complete') return
-
-      const { event } = state
-
-      if (state.last) {
-        pullingRef.current = false
-        if (status === 'canRelease') {
-          doRefresh()
-        } else {
-          api.start({ height: 0 })
-        }
-        return
+      if (props.completeDelay > 0) {
+        await sleep(props.completeDelay)
       }
+      await reset()
+    }
 
-      const [, y] = state.movement
-      const parsedY = Math.ceil(y)
+    // Use refs to hold the latest functions so that useImperativeHandle
+    // always calls the up-to-date versions without recreating the handle.
+    const doRefreshRef = useRef(doRefresh)
+    doRefreshRef.current = doRefresh
+    const doCompleteRefreshRef = useRef(doCompleteRefresh)
+    doCompleteRefreshRef.current = doCompleteRefresh
 
-      if (state.first && parsedY > 0) {
-        const target = state.event.target
-        if (!target || !(target instanceof Element)) return
-        let scrollParent = getScrollParent(target)
-        while (true) {
-          if (!scrollParent) return
-          const scrollTop = getScrollTop(scrollParent)
-          if (scrollTop > 0) {
-            return
+    useImperativeHandle(
+      ref,
+      () => ({
+        startRefresh: () => {
+          if (statusRef.current === 'pulling') {
+            doRefreshRef.current().catch(() => {})
           }
-          if (scrollParent instanceof Window) {
-            break
+        },
+        completeRefresh: () => {
+          if (statusRef.current === 'refreshing') {
+            doCompleteRefreshRef.current()
           }
-          scrollParent = getScrollParent(scrollParent.parentNode as Element)
+        },
+      }),
+      []
+    )
+
+    useDrag(
+      state => {
+        if (status === 'refreshing' || status === 'complete') return
+
+        const { event } = state
+
+        if (state.last) {
+          pullingRef.current = false
+          if (status === 'canRelease') {
+            doRefresh().catch(() => {})
+          } else {
+            api.start({ height: 0 })
+          }
+          return
         }
-        pullingRef.current = true
-        function getScrollTop(element: Window | Element) {
-          return 'scrollTop' in element ? element.scrollTop : element.scrollY
+
+        const [, y] = state.movement
+        const parsedY = Math.ceil(y)
+
+        if (state.first && parsedY > 0) {
+          const target = state.event.target
+          if (!target || !(target instanceof Element)) return
+          let scrollParent = getScrollParent(target)
+          while (true) {
+            if (!scrollParent) return
+            const scrollTop = getScrollTop(scrollParent)
+            if (scrollTop > 0) {
+              return
+            }
+            if (scrollParent instanceof Window) {
+              break
+            }
+            scrollParent = getScrollParent(scrollParent.parentNode as Element)
+          }
+          pullingRef.current = true
+          function getScrollTop(element: Window | Element) {
+            return 'scrollTop' in element ? element.scrollTop : element.scrollY
+          }
         }
+
+        if (!pullingRef.current) return
+
+        if (event.cancelable) {
+          event.preventDefault()
+        }
+        event.stopPropagation()
+        const height = Math.max(
+          rubberbandIfOutOfBounds(parsedY, 0, 0, headHeight * 5, 0.5),
+          0
+        )
+        api.start({ height })
+        setStatus(height > threshold ? 'canRelease' : 'pulling')
+      },
+      {
+        pointer: { touch: true },
+        axis: 'y',
+        target: elementRef,
+        enabled: !props.disabled,
+        eventOptions: supportsPassive ? { passive: false } : undefined,
+      }
+    )
+
+    const renderStatusText = () => {
+      if (props.renderText) {
+        return props.renderText?.(status)
       }
 
-      if (!pullingRef.current) return
-
-      if (event.cancelable) {
-        event.preventDefault()
-      }
-      event.stopPropagation()
-      const height = Math.max(
-        rubberbandIfOutOfBounds(parsedY, 0, 0, headHeight * 5, 0.5),
-        0
-      )
-      api.start({ height })
-      setStatus(height > threshold ? 'canRelease' : 'pulling')
-    },
-    {
-      pointer: { touch: true },
-      axis: 'y',
-      target: elementRef,
-      enabled: !props.disabled,
-      eventOptions: supportsPassive ? { passive: false } : undefined,
-    }
-  )
-
-  const renderStatusText = () => {
-    if (props.renderText) {
-      return props.renderText?.(status)
+      if (status === 'pulling') return props.pullingText
+      if (status === 'canRelease') return props.canReleaseText
+      if (status === 'refreshing') return props.refreshingText
+      if (status === 'complete') return props.completeText
     }
 
-    if (status === 'pulling') return props.pullingText
-    if (status === 'canRelease') return props.canReleaseText
-    if (status === 'refreshing') return props.refreshingText
-    if (status === 'complete') return props.completeText
-  }
-
-  return (
-    <animated.div ref={elementRef} className={classPrefix}>
-      <animated.div style={springStyles} className={`${classPrefix}-head`}>
-        <div
-          className={`${classPrefix}-head-content`}
-          style={{ height: headHeight }}
-        >
-          {renderStatusText()}
-        </div>
+    return (
+      <animated.div ref={elementRef} className={classPrefix}>
+        <animated.div style={springStyles} className={`${classPrefix}-head`}>
+          <div
+            className={`${classPrefix}-head-content`}
+            style={{ height: headHeight }}
+          >
+            {renderStatusText()}
+          </div>
+        </animated.div>
+        <div className={`${classPrefix}-content`}>{props.children}</div>
       </animated.div>
-      <div className={`${classPrefix}-content`}>{props.children}</div>
-    </animated.div>
-  )
-}
+    )
+  }
+)

--- a/src/components/pull-to-refresh/pull-to-refresh.tsx
+++ b/src/components/pull-to-refresh/pull-to-refresh.tsx
@@ -68,9 +68,11 @@ export const PullToRefresh = forwardRef<PullToRefreshRef, PullToRefreshProps>(
     const [status, setStatus] = useState<PullStatus>('pulling')
 
     const statusRef = useRef<PullStatus>(status)
-    useEffect(() => {
-      statusRef.current = status
-    }, [status])
+
+    const setStatusWithRef = (next: PullStatus) => {
+      statusRef.current = next
+      setStatus(next)
+    }
 
     const [springStyles, api] = useSpring(() => ({
       from: { height: 0 },
@@ -88,7 +90,12 @@ export const PullToRefresh = forwardRef<PullToRefreshRef, PullToRefreshProps>(
 
     //防止下拉时抖动
     useEffect(() => {
-      elementRef.current?.addEventListener('touchmove', () => {})
+      const noop = () => {}
+      const element = elementRef.current
+      element?.addEventListener('touchmove', noop)
+      return () => {
+        element?.removeEventListener('touchmove', noop)
+      }
     }, [])
 
     const reset = () => {
@@ -98,7 +105,7 @@ export const PullToRefresh = forwardRef<PullToRefreshRef, PullToRefreshProps>(
             height: 0,
           },
           onResolve() {
-            setStatus('pulling')
+            setStatusWithRef('pulling')
             resolve()
           },
         })
@@ -106,8 +113,11 @@ export const PullToRefresh = forwardRef<PullToRefreshRef, PullToRefreshProps>(
     }
 
     async function doRefresh() {
+      if (props.disabled) return
+      const current = statusRef.current
+      if (current !== 'pulling' && current !== 'canRelease') return
       api.start({ height: headHeight })
-      setStatus('refreshing')
+      setStatusWithRef('refreshing')
       try {
         await props.onRefresh()
       } catch (e) {
@@ -122,7 +132,8 @@ export const PullToRefresh = forwardRef<PullToRefreshRef, PullToRefreshProps>(
     }
 
     async function doCompleteRefresh() {
-      setStatus('complete')
+      if (statusRef.current !== 'refreshing') return
+      setStatusWithRef('complete')
       if (props.completeDelay > 0) {
         await sleep(props.completeDelay)
       }
@@ -138,14 +149,10 @@ export const PullToRefresh = forwardRef<PullToRefreshRef, PullToRefreshProps>(
       ref,
       () => ({
         startRefresh: () => {
-          if (statusRef.current === 'pulling') {
-            doRefreshRef.current().catch(() => {})
-          }
+          doRefreshRef.current().catch(() => {})
         },
         completeRefresh: () => {
-          if (statusRef.current === 'refreshing') {
-            doCompleteRefreshRef.current()
-          }
+          doCompleteRefreshRef.current()
         },
       }),
       []

--- a/src/components/pull-to-refresh/tests/pull-to-refresh.test.tsx
+++ b/src/components/pull-to-refresh/tests/pull-to-refresh.test.tsx
@@ -1,6 +1,10 @@
 import React, { useState } from 'react'
 import { render, fireEvent, sleep, screen, act } from 'testing'
-import PullToRefresh, { PullToRefreshProps, PullStatus } from '..'
+import PullToRefresh, {
+  PullToRefreshProps,
+  PullToRefreshRef,
+  PullStatus,
+} from '..'
 import { List } from 'antd-mobile'
 
 const classPrefix = `adm-pull-to-refresh`
@@ -182,5 +186,94 @@ describe('PullToRefresh', () => {
       jest.advanceTimersByTime(1000)
     })
     expect(screen.getByText('刷新成功')).toBeInTheDocument()
+  })
+
+  test('ref: startRefresh and completeRefresh', async () => {
+    const ref = React.createRef<PullToRefreshRef>()
+    render(
+      <PullToRefresh
+        ref={ref}
+        completeDelay={500}
+        onRefresh={() => new Promise(() => {})}
+      >
+        <div>Content</div>
+      </PullToRefresh>
+    )
+
+    // startRefresh triggers refreshing
+    await act(async () => {
+      ref.current?.startRefresh()
+    })
+    expect(screen.getByText('加载中...')).toBeInTheDocument()
+
+    // startRefresh again is no-op while refreshing
+    await act(async () => {
+      ref.current?.startRefresh()
+    })
+    expect(screen.getByText('加载中...')).toBeInTheDocument()
+
+    // completeRefresh ends the cycle → complete state
+    await act(async () => {
+      ref.current?.completeRefresh()
+    })
+    expect(screen.getByText('刷新成功')).toBeInTheDocument()
+
+    // after completeDelay → back to pulling
+    await act(async () => {
+      jest.advanceTimersByTime(500)
+    })
+    expect(screen.getByText('下拉刷新')).toBeInTheDocument()
+
+    // can startRefresh again after cycle completes
+    await act(async () => {
+      ref.current?.startRefresh()
+    })
+    expect(screen.getByText('加载中...')).toBeInTheDocument()
+
+    await act(async () => {
+      ref.current?.completeRefresh()
+    })
+    expect(screen.getByText('刷新成功')).toBeInTheDocument()
+
+    await act(async () => {
+      jest.advanceTimersByTime(500)
+    })
+    expect(screen.getByText('下拉刷新')).toBeInTheDocument()
+  })
+
+  test('ref: startRefresh should be no-op when not in pulling status', async () => {
+    const onRefresh = jest.fn(() => new Promise(() => {}))
+    const ref = React.createRef<PullToRefreshRef>()
+    render(
+      <PullToRefresh ref={ref} onRefresh={onRefresh}>
+        <div>Content</div>
+      </PullToRefresh>
+    )
+
+    // Trigger refresh via startRefresh
+    await act(async () => {
+      ref.current?.startRefresh()
+    })
+    expect(onRefresh).toBeCalledTimes(1)
+
+    // startRefresh while refreshing should be no-op
+    await act(async () => {
+      ref.current?.startRefresh()
+    })
+    expect(onRefresh).toBeCalledTimes(1)
+
+    // completeRefresh
+    await act(async () => {
+      ref.current?.completeRefresh()
+    })
+
+    // Now in pulling status again, startRefresh should work
+    await act(async () => {
+      jest.advanceTimersByTime(500)
+    })
+    await act(async () => {
+      ref.current?.startRefresh()
+    })
+    expect(onRefresh).toBeCalledTimes(2)
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,10 @@ export type {
 } from './components/checkbox'
 export { default as Collapse } from './components/collapse'
 export type { CollapseProps, CollapsePanelProps } from './components/collapse'
-export { default as ConfigProvider, useConfig } from './components/config-provider'
+export {
+  default as ConfigProvider,
+  useConfig,
+} from './components/config-provider'
 export type { ConfigProviderProps } from './components/config-provider'
 export { default as DatePicker } from './components/date-picker'
 export type { DatePickerProps, DatePickerRef } from './components/date-picker'
@@ -173,7 +176,10 @@ export type { ProgressBarProps } from './components/progress-bar'
 export { default as ProgressCircle } from './components/progress-circle'
 export type { ProgressCircleProps } from './components/progress-circle'
 export { default as PullToRefresh } from './components/pull-to-refresh'
-export type { PullToRefreshProps } from './components/pull-to-refresh'
+export type {
+  PullToRefreshProps,
+  PullToRefreshRef,
+} from './components/pull-to-refresh'
 export { default as Radio } from './components/radio'
 export type { RadioProps, RadioGroupProps } from './components/radio'
 export { default as Rate } from './components/rate'


### PR DESCRIPTION
close #6270 #5653 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * PullToRefresh 增加 Ref 控制能力，支持 startRefresh() 与 completeRefresh() 以外部触发/结束刷新。
  * 新增演示组件，展示通过外部按钮手动触发刷新的交互。

* **文档**
  * 补充中英文文档，新增 Ref 使用示例与 FAQ 说明。

* **测试**
  * 增加用例验证 Ref 方法在不同状态下的行为。

* **Chores**
  * 对导出类型进行了整理，暴露了新的引用类型。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ant-design/ant-design-mobile/pull/7053?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->