### PR TITLE
feat(cascader): 添加自定义选项渲染功能

### DIFF
--- a/src/components/cascader-view/cascader-view.tsx
+++ b/src/components/cascader-view/cascader-view.tsx
@@ -30,6 +30,11 @@ export type CascaderValueExtend = {
   isLeaf: boolean
 }
 
+export type CascaderViewOptionRender = (
+  option: CascaderOption,
+  depth: number
+) => ReactNode
+
 export type CascaderViewProps = {
   options: CascaderOption[]
   value?: CascaderValue[]
@@ -40,6 +45,7 @@ export type CascaderViewProps = {
   activeIcon?: ReactNode
   loading?: boolean
   fieldNames?: FieldNamesType
+  optionRender?: CascaderViewOptionRender
 } & NativeProps<'--height'>
 
 const defaultProps = {
@@ -143,8 +149,8 @@ export const CascaderView: FC<CascaderViewProps> = p => {
                   {selected
                     ? selected[labelName]
                     : typeof placeholder === 'function'
-                    ? placeholder(index)
-                    : placeholder}
+                      ? placeholder(index)
+                      : placeholder}
                 </div>
               }
               forceRender
@@ -188,7 +194,9 @@ export const CascaderView: FC<CascaderViewProps> = p => {
                             [`${classPrefix}-item-active`]: active,
                           })}
                         >
-                          {option[labelName]}
+                          {props.optionRender
+                            ? props.optionRender(option, index)
+                            : option[labelName]}
                         </CheckList.Item>
                       )
                     })}

--- a/src/components/cascader-view/cascader-view.tsx
+++ b/src/components/cascader-view/cascader-view.tsx
@@ -30,10 +30,14 @@ export type CascaderValueExtend = {
   isLeaf: boolean
 }
 
+export type CascaderViewOptionRenderInfo = {
+  depth: number
+  active: boolean
+}
+
 export type CascaderViewOptionRender = (
   option: CascaderOption,
-  depth: number,
-  active: boolean
+  info: CascaderViewOptionRenderInfo
 ) => ReactNode
 
 export type CascaderViewProps = {
@@ -196,7 +200,10 @@ export const CascaderView: FC<CascaderViewProps> = p => {
                           })}
                         >
                           {props.optionRender
-                            ? props.optionRender(option, index, active)
+                            ? props.optionRender(option, {
+                                depth: index,
+                                active,
+                              })
                             : option[labelName]}
                         </CheckList.Item>
                       )

--- a/src/components/cascader-view/cascader-view.tsx
+++ b/src/components/cascader-view/cascader-view.tsx
@@ -1,18 +1,18 @@
-import React, { useState, useEffect, useMemo } from 'react'
-import type { FC, ReactNode } from 'react'
-import classNames from 'classnames'
-import Tabs from '../tabs'
-import CheckList, { CheckListValue } from '../check-list'
-import { NativeProps, withNativeProps } from '../../utils/native-props'
-import { mergeProps } from '../../utils/with-default-props'
-import { usePropsValue } from '../../utils/use-props-value'
-import { useCascaderValueExtend } from './use-cascader-value-extend'
-import { useConfig } from '../config-provider'
-import { optionSkeleton } from './option-skeleton'
-import Skeleton from '../skeleton'
 import { useUpdateEffect } from 'ahooks'
+import classNames from 'classnames'
+import type { FC, ReactNode } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
+import type { BaseOptionType, FieldNamesType } from '../../hooks'
 import { useFieldNames } from '../../hooks'
-import type { FieldNamesType, BaseOptionType } from '../../hooks'
+import { NativeProps, withNativeProps } from '../../utils/native-props'
+import { usePropsValue } from '../../utils/use-props-value'
+import { mergeProps } from '../../utils/with-default-props'
+import CheckList, { CheckListValue } from '../check-list'
+import { useConfig } from '../config-provider'
+import Skeleton from '../skeleton'
+import Tabs from '../tabs'
+import { optionSkeleton } from './option-skeleton'
+import { useCascaderValueExtend } from './use-cascader-value-extend'
 
 const classPrefix = `adm-cascader-view`
 
@@ -32,7 +32,8 @@ export type CascaderValueExtend = {
 
 export type CascaderViewOptionRender = (
   option: CascaderOption,
-  depth: number
+  depth: number,
+  active: boolean
 ) => ReactNode
 
 export type CascaderViewProps = {
@@ -195,7 +196,7 @@ export const CascaderView: FC<CascaderViewProps> = p => {
                           })}
                         >
                           {props.optionRender
-                            ? props.optionRender(option, index)
+                            ? props.optionRender(option, index, active)
                             : option[labelName]}
                         </CheckList.Item>
                       )

--- a/src/components/cascader-view/demos/demo1.tsx
+++ b/src/components/cascader-view/demos/demo1.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react'
 import { CascaderView } from 'antd-mobile'
 import { DemoBlock } from 'demos'
+import React, { useState } from 'react'
 
 import { options, sameValueOptions } from '../../cascader/demos/data'
 
@@ -27,7 +27,7 @@ export default () => {
       <DemoBlock title='自定义选项渲染' padding='0'>
         <CascaderView
           options={options}
-          optionRender={(option, depth) => (
+          optionRender={option => (
             <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
               {option.label}
               {option.disabled && (

--- a/src/components/cascader-view/demos/demo1.tsx
+++ b/src/components/cascader-view/demos/demo1.tsx
@@ -24,6 +24,22 @@ export default () => {
         />
       </DemoBlock>
 
+      <DemoBlock title='自定义选项渲染' padding='0'>
+        <CascaderView
+          options={options}
+          optionRender={(option, depth) => (
+            <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+              {option.label}
+              {option.disabled && (
+                <span style={{ fontSize: 12, color: 'var(--adm-color-weak)' }}>
+                  已满
+                </span>
+              )}
+            </span>
+          )}
+        />
+      </DemoBlock>
+
       <DemoBlock title='自定义高度' padding='0'>
         <CascaderView options={options} style={{ '--height': '320px' }} />
       </DemoBlock>

--- a/src/components/cascader-view/index.en.md
+++ b/src/components/cascader-view/index.en.md
@@ -21,6 +21,7 @@ CascaderView is the content area of [Cascader](/components/cascader).
 | placeholder | Hint text | `string` \| `(index: number) => string` | `'请选择'` |
 | value | Selected options | `CascaderValue[]` | - |
 | loading | Open the skeleton screen | `boolean` | `false` |
+| optionRender | Custom render function for options | `(option: CascaderOption, depth: number) => ReactNode` | - |
 
 For the type definition of `CascaderValue` `CascaderOption` `CascaderValueExtend`, please refer to the document of [Cascader](/components/cascader#api).
 

--- a/src/components/cascader-view/index.en.md
+++ b/src/components/cascader-view/index.en.md
@@ -21,7 +21,7 @@ CascaderView is the content area of [Cascader](/components/cascader).
 | placeholder | Hint text | `string` \| `(index: number) => string` | `'请选择'` |
 | value | Selected options | `CascaderValue[]` | - |
 | loading | Open the skeleton screen | `boolean` | `false` |
-| optionRender | Custom render function for options | `(option: CascaderOption, depth: number) => ReactNode` | - |
+| optionRender | Custom render function for options | `(option: CascaderOption, info: { depth: number, active: boolean }) => ReactNode` | - |
 
 For the type definition of `CascaderValue` `CascaderOption` `CascaderValueExtend`, please refer to the document of [Cascader](/components/cascader#api).
 

--- a/src/components/cascader-view/index.ts
+++ b/src/components/cascader-view/index.ts
@@ -6,6 +6,7 @@ import { optionSkeleton } from './option-skeleton'
 export type {
   CascaderViewProps,
   CascaderViewOptionRender,
+  CascaderViewOptionRenderInfo,
   CascaderValue,
   CascaderValueExtend,
   CascaderOption,

--- a/src/components/cascader-view/index.ts
+++ b/src/components/cascader-view/index.ts
@@ -5,6 +5,7 @@ import { optionSkeleton } from './option-skeleton'
 
 export type {
   CascaderViewProps,
+  CascaderViewOptionRender,
   CascaderValue,
   CascaderValueExtend,
   CascaderOption,

--- a/src/components/cascader-view/index.zh.md
+++ b/src/components/cascader-view/index.zh.md
@@ -21,7 +21,7 @@ CascaderView 是 [Cascader](/zh/components/cascader) 的内容区域。
 | placeholder | 未选中时的提示文案 | `string` \| `(index: number) => string` | `'请选择'` |
 | value | 选中项 | `CascaderValue[]` | - |
 | loading | 开启骨架屏 | `boolean` | `false` |
-| optionRender | 自定义选项的渲染函数 | `(option: CascaderOption, depth: number) => ReactNode` | - |
+| optionRender | 自定义选项的渲染函数 | `(option: CascaderOption, info: { depth: number, active: boolean }) => ReactNode` | - |
 
 关于 `CascaderValue` `CascaderOption[]` `CascaderValueExtend` 的类型定义，请参考 [Cascader](/zh/components/cascader#api) 的文档。
 

--- a/src/components/cascader-view/index.zh.md
+++ b/src/components/cascader-view/index.zh.md
@@ -21,6 +21,7 @@ CascaderView 是 [Cascader](/zh/components/cascader) 的内容区域。
 | placeholder | 未选中时的提示文案 | `string` \| `(index: number) => string` | `'请选择'` |
 | value | 选中项 | `CascaderValue[]` | - |
 | loading | 开启骨架屏 | `boolean` | `false` |
+| optionRender | 自定义选项的渲染函数 | `(option: CascaderOption, depth: number) => ReactNode` | - |
 
 关于 `CascaderValue` `CascaderOption[]` `CascaderValueExtend` 的类型定义，请参考 [Cascader](/zh/components/cascader#api) 的文档。
 

--- a/src/components/cascader-view/tests/cascader-view.test.tsx
+++ b/src/components/cascader-view/tests/cascader-view.test.tsx
@@ -137,4 +137,20 @@ describe('CascaderView', () => {
 
     expect(baseElement.querySelector('.adm-skeleton')).toBeInTheDocument()
   })
+
+  test('optionRender', async () => {
+    const { getByText } = render(
+      <CascaderView
+        options={options}
+        optionRender={(option, depth) => (
+          <span>
+            {option.label}-{depth}
+          </span>
+        )}
+      />
+    )
+    expect(getByText('浙江-0')).toBeInTheDocument()
+    fireEvent.click(getByText('浙江-0'))
+    expect(getByText('杭州-1')).toBeInTheDocument()
+  })
 })

--- a/src/components/cascader-view/tests/cascader-view.test.tsx
+++ b/src/components/cascader-view/tests/cascader-view.test.tsx
@@ -142,7 +142,7 @@ describe('CascaderView', () => {
     const { getByText } = render(
       <CascaderView
         options={options}
-        optionRender={(option, depth) => (
+        optionRender={(option, { depth }) => (
           <span>
             {option.label}-{depth}
           </span>

--- a/src/components/cascader/cascader.tsx
+++ b/src/components/cascader/cascader.tsx
@@ -14,6 +14,7 @@ import CascaderView, {
   CascaderOption,
   CascaderValue,
   CascaderValueExtend,
+  CascaderViewOptionRender,
 } from '../cascader-view'
 import { useCascaderValueExtend } from '../cascader-view/use-cascader-value-extend'
 import { useConfig } from '../config-provider'
@@ -49,6 +50,7 @@ export type CascaderProps = {
   onTabsChange?: (index: number) => void
   activeIcon?: ReactNode
   fieldNames?: FieldNamesType
+  optionRender?: CascaderViewOptionRender
 } & Pick<
   PopupProps,
   | 'getContainer'

--- a/src/components/cascader/demos/demo1.tsx
+++ b/src/components/cascader/demos/demo1.tsx
@@ -4,6 +4,39 @@ import { DemoBlock, DemoDescription } from 'demos'
 
 import { options, longOptions } from './data'
 
+// 自定义选项渲染
+function ItemRenderDemo() {
+  const [visible, setVisible] = useState(false)
+  return (
+    <>
+      <Button
+        onClick={() => {
+          setVisible(true)
+        }}
+      >
+        选择
+      </Button>
+      <Cascader
+        options={options}
+        visible={visible}
+        onClose={() => {
+          setVisible(false)
+        }}
+        optionRender={(option, depth) => (
+          <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+            {option.label}
+            {option.disabled && (
+              <span style={{ fontSize: 12, color: 'var(--adm-color-weak)' }}>
+                已满
+              </span>
+            )}
+          </span>
+        )}
+      />
+    </>
+  )
+}
+
 // 基础用法
 function BasicDemo() {
   const [visible, setVisible] = useState(false)
@@ -118,6 +151,10 @@ export default () => {
         >
           选择
         </Button>
+      </DemoBlock>
+
+      <DemoBlock title='自定义选项渲染'>
+        <ItemRenderDemo />
       </DemoBlock>
 
       <DemoBlock title='使用 actions 来控制显示/隐藏'>

--- a/src/components/cascader/demos/demo1.tsx
+++ b/src/components/cascader/demos/demo1.tsx
@@ -1,8 +1,8 @@
-import React, { useState } from 'react'
-import { Cascader, Button, Space, Toast } from 'antd-mobile'
+import { Button, Cascader, Space, Toast } from 'antd-mobile'
 import { DemoBlock, DemoDescription } from 'demos'
+import React, { useState } from 'react'
 
-import { options, longOptions } from './data'
+import { longOptions, options } from './data'
 
 // 自定义选项渲染
 function ItemRenderDemo() {
@@ -22,7 +22,7 @@ function ItemRenderDemo() {
         onClose={() => {
           setVisible(false)
         }}
-        optionRender={(option, depth) => (
+        optionRender={option => (
           <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
             {option.label}
             {option.disabled && (

--- a/src/components/cascader/index.en.md
+++ b/src/components/cascader/index.en.md
@@ -52,7 +52,7 @@ type CascaderValueExtend = {
 | value | Selected options | `CascaderValue[]` | - |
 | visible | Whether to show or hide the Picker | `boolean` | `false` |
 | loading | Open the skeleton screen | `boolean` | `false` |
-| optionRender | Custom render function for options | `(option: CascaderOption, depth: number) => ReactNode` | - |
+| optionRender | Custom render function for options | `(option: CascaderOption, info: { depth: number, active: boolean }) => ReactNode` | - |
 
 Please pay attention to the `children` property of `CascaderOption`. If the `children` of an `option` is `[]`, then when the user selects this `option`, the Cascader component will automatically jump to the next level, even if There are currently no options at this level (because Cascader has no way to determine whether this empty array will become an array with content in subsequent updates). Therefore, please make sure that the `children` property of the last level option (aka "leaf node") does not exist or has the value `undefined`, so that the Cascader component can correctly recognize it.
 

--- a/src/components/cascader/index.en.md
+++ b/src/components/cascader/index.en.md
@@ -52,6 +52,7 @@ type CascaderValueExtend = {
 | value | Selected options | `CascaderValue[]` | - |
 | visible | Whether to show or hide the Picker | `boolean` | `false` |
 | loading | Open the skeleton screen | `boolean` | `false` |
+| optionRender | Custom render function for options | `(option: CascaderOption, depth: number) => ReactNode` | - |
 
 Please pay attention to the `children` property of `CascaderOption`. If the `children` of an `option` is `[]`, then when the user selects this `option`, the Cascader component will automatically jump to the next level, even if There are currently no options at this level (because Cascader has no way to determine whether this empty array will become an array with content in subsequent updates). Therefore, please make sure that the `children` property of the last level option (aka "leaf node") does not exist or has the value `undefined`, so that the Cascader component can correctly recognize it.
 

--- a/src/components/cascader/index.ts
+++ b/src/components/cascader/index.ts
@@ -11,6 +11,7 @@ export type {
   CascaderValueExtend,
   CascaderOption,
   CascaderViewOptionRender,
+  CascaderViewOptionRenderInfo,
 } from '../cascader-view'
 
 export default attachPropertiesToComponent(Cascader, {

--- a/src/components/cascader/index.ts
+++ b/src/components/cascader/index.ts
@@ -10,6 +10,7 @@ export type {
   CascaderValue,
   CascaderValueExtend,
   CascaderOption,
+  CascaderViewOptionRender,
 } from '../cascader-view'
 
 export default attachPropertiesToComponent(Cascader, {

--- a/src/components/cascader/index.zh.md
+++ b/src/components/cascader/index.zh.md
@@ -52,7 +52,7 @@ type CascaderValueExtend = {
 | value | 选中项 | `CascaderValue[]` | - |
 | visible | 是否显示级联选择 | `boolean` | `false` |
 | loading | 开启骨架屏 | `boolean` | `false` |
-| optionRender | 自定义选项的渲染函数 | `(option: CascaderOption, depth: number) => ReactNode` | - |
+| optionRender | 自定义选项的渲染函数 | `(option: CascaderOption, info: { depth: number, active: boolean }) => ReactNode` | - |
 
 请留意 `CascaderOption` 的 `children` 属性，如果某个 `option` 的 `children` 为 `[]`，那当用户选择了这个 `option` 时，Cascader 组件会自动跳转到下一级，即便这一级当前是没有任何选项的（因为 Cascader 没有办法判断，在后续的更新中，这个空数组会不会变为一个有内容的数组）。因此，请确保最末一级的 option（也就是"叶子节点"）的 `children` 属性不存在或者值为 `undefined`，这样 Cascader 组件才能将其正确地识别。
 

--- a/src/components/cascader/index.zh.md
+++ b/src/components/cascader/index.zh.md
@@ -52,6 +52,7 @@ type CascaderValueExtend = {
 | value | 选中项 | `CascaderValue[]` | - |
 | visible | 是否显示级联选择 | `boolean` | `false` |
 | loading | 开启骨架屏 | `boolean` | `false` |
+| optionRender | 自定义选项的渲染函数 | `(option: CascaderOption, depth: number) => ReactNode` | - |
 
 请留意 `CascaderOption` 的 `children` 属性，如果某个 `option` 的 `children` 为 `[]`，那当用户选择了这个 `option` 时，Cascader 组件会自动跳转到下一级，即便这一级当前是没有任何选项的（因为 Cascader 没有办法判断，在后续的更新中，这个空数组会不会变为一个有内容的数组）。因此，请确保最末一级的 option（也就是"叶子节点"）的 `children` 属性不存在或者值为 `undefined`，这样 Cascader 组件才能将其正确地识别。
 


### PR DESCRIPTION
close #7054 
- 新增 optionRender 属性支持自定义选项渲染
- 更新文档和测试用例
- 同时支持 Cascader 和 CascaderView 组件

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 级联组件新增 optionRender 支持，允许按层级和活跃状态自定义每项显示，禁用项可显示“已满”提示，并在示例中展示效果。

* **文档**
  * 中英文文档补充 optionRender 属性说明与参数签名（含 depth 与 active 信息）。

* **测试**
  * 新增单元测试覆盖 optionRender 的渲染与交互行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->