### PR TITLE
选项为0时判断短路了

### DIFF
--- a/src/components/selector/selector.tsx
+++ b/src/components/selector/selector.tsx
@@ -71,7 +71,7 @@ export const Selector = <V extends SelectorValue>(p: SelectorProps<V>) => {
   const { locale } = useConfig()
 
   const items = props.options.map(option => {
-    const active = (value || []).includes(option[valueName])
+    const active = (Array.isArray(value) ? value : [value]).includes(option[valueName])
     const disabled = option[disabledName] || props.disabled
     const itemCls = classNames(`${classPrefix}-item`, {
       [`${classPrefix}-item-active`]: active && !props.multiple,


### PR DESCRIPTION
我的 Selector.options[0,1,2] 如果表单initialValues值为0无法渲染出选中内容

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 修复了选择器组件在不同数值格式下激活状态显示不正确的问题，确保选项的激活态判断更加稳定可靠。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->