### PR TITLE
fix(notice-bar): 阻止关闭按钮点击事件冒泡

### DIFF
--- a/src/components/notice-bar/notice-bar.tsx
+++ b/src/components/notice-bar/notice-bar.tsx
@@ -166,7 +166,8 @@ export const NoticeBar = memo<NoticeBarProps>(props => {
           {mergedProps.closeable && (
             <div
               className={`${classPrefix}-close`}
-              onClick={() => {
+              onClick={e => {
+                e.stopPropagation()
                 setVisible(false)
                 mergedProps.onClose?.()
               }}

--- a/src/components/notice-bar/tests/notice-bar.test.tsx
+++ b/src/components/notice-bar/tests/notice-bar.test.tsx
@@ -124,8 +124,8 @@ describe('NoticeBar', () => {
     const closeIcon = container.querySelectorAll(`.${classPrefix}-close`)[0]
     fireEvent.click(closeIcon)
 
-    expect(handleClose).toBeCalledTimes(1)
-    expect(handleClick).not.toBeCalled()
+    expect(handleClose).toHaveBeenCalledTimes(1)
+    expect(handleClick).not.toHaveBeenCalled()
   })
 
   describe('closeIcon', () => {

--- a/src/components/notice-bar/tests/notice-bar.test.tsx
+++ b/src/components/notice-bar/tests/notice-bar.test.tsx
@@ -109,6 +109,25 @@ describe('NoticeBar', () => {
     expect(handleClick).toHaveBeenCalled()
   })
 
+  test('closeable click should not bubble to onClick', () => {
+    const handleClick = jest.fn()
+    const handleClose = jest.fn()
+    const { container } = render(
+      <NoticeBar
+        content='notice'
+        closeable
+        onClick={handleClick}
+        onClose={handleClose}
+      />
+    )
+
+    const closeIcon = container.querySelectorAll(`.${classPrefix}-close`)[0]
+    fireEvent.click(closeIcon)
+
+    expect(handleClose).toBeCalledTimes(1)
+    expect(handleClick).not.toBeCalled()
+  })
+
   describe('closeIcon', () => {
     it('default', () => {
       const { baseElement } = render(<NoticeBar content='foobar' closeable />)


### PR DESCRIPTION
close #6559 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复 NoticeBar 关闭按钮点击时的事件冒泡问题：点击关闭图标只会触发关闭回调，不会再向外层容器传递点击事件，避免意外触发外层点击处理。

* **Tests**
  * 新增关闭按钮点击行为的测试用例，验证在同时提供 onClick 与 onClose 时，点击关闭图标仅调用关闭回调且不冒泡。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->