### PR TITLE
feat(dropdown): 新增 onVisibleChange 回调

### DIFF
--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -71,9 +71,7 @@ const Dropdown = forwardRef<DropdownRef, PropsWithChildren<DropdownProps>>(
     })
 
     const cacheKeyRef = useRef<string | null>(null)
-    if (value !== null) {
-      cacheKeyRef.current = value
-    }
+    cacheKeyRef.current = value ?? cacheKeyRef.current
 
     const navRef = useRef<HTMLDivElement>(null)
     const contentRef = useRef<HTMLDivElement>(null)

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -64,14 +64,16 @@ const Dropdown = forwardRef<DropdownRef, PropsWithChildren<DropdownProps>>(
       props.arrowIcon
     )
 
+    const closingKeyRef = useRef<string | null>(null)
+
     const [value, setValue] = usePropsValue({
       value: mergedProps.activeKey,
       defaultValue: mergedProps.defaultActiveKey,
       onChange: (v: string | null) => {
         mergedProps.onChange?.(v)
         if (v === null) {
-          mergedProps.onVisibleChange?.(false, value)
-        } else {
+          closingKeyRef.current = value
+        } else if (value !== null) {
           mergedProps.onVisibleChange?.(true, v)
         }
       },
@@ -189,6 +191,12 @@ const Dropdown = forwardRef<DropdownRef, PropsWithChildren<DropdownProps>>(
                 }
               : undefined
           }
+          afterShow={() => {
+            mergedProps.onVisibleChange?.(true, value)
+          }}
+          afterClose={() => {
+            mergedProps.onVisibleChange?.(false, closingKeyRef.current)
+          }}
         >
           <div ref={contentRef}>
             {items.map(item => {

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -1,5 +1,6 @@
 import { useClickAway } from 'ahooks'
 import classNames from 'classnames'
+import raf from 'rc-util/lib/raf'
 import type {
   ComponentProps,
   PropsWithChildren,
@@ -16,7 +17,6 @@ import React, {
   useRef,
   useState,
 } from 'react'
-import raf from 'rc-util/lib/raf'
 import { NativeProps, withNativeProps } from '../../utils/native-props'
 import { usePropsValue } from '../../utils/use-props-value'
 import { mergeProp, mergeProps } from '../../utils/with-default-props'
@@ -63,9 +63,6 @@ const Dropdown = forwardRef<DropdownRef, PropsWithChildren<DropdownProps>>(
       props.arrow,
       props.arrowIcon
     )
-    const prevActiveKeyRef = useRef<string | null>(
-      mergedProps.activeKey ?? mergedProps.defaultActiveKey ?? null
-    )
 
     const [value, setValue] = usePropsValue({
       value: mergedProps.activeKey,
@@ -73,16 +70,12 @@ const Dropdown = forwardRef<DropdownRef, PropsWithChildren<DropdownProps>>(
       onChange: (v: string | null) => {
         mergedProps.onChange?.(v)
         if (v === null) {
-          mergedProps.onVisibleChange?.(false, prevActiveKeyRef.current)
+          mergedProps.onVisibleChange?.(false, value)
         } else {
           mergedProps.onVisibleChange?.(true, v)
         }
       },
     })
-
-    useEffect(() => {
-      prevActiveKeyRef.current = value
-    }, [value])
 
     const navRef = useRef<HTMLDivElement>(null)
     const contentRef = useRef<HTMLDivElement>(null)

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -64,18 +64,18 @@ const Dropdown = forwardRef<DropdownRef, PropsWithChildren<DropdownProps>>(
       props.arrowIcon
     )
 
-    const closingKeyRef = useRef<string | null>(null)
-
     const [value, setValue] = usePropsValue({
       value: mergedProps.activeKey,
       defaultValue: mergedProps.defaultActiveKey,
-      onChange: (v: string | null) => {
-        mergedProps.onChange?.(v)
-        if (v === null) {
-          closingKeyRef.current = value
-        }
-      },
+      onChange: mergedProps.onChange,
     })
+
+    const cacheKeyRef = useRef<string | null>(null)
+    useEffect(() => {
+      if (value !== null) {
+        cacheKeyRef.current = value
+      }
+    }, [value])
 
     const navRef = useRef<HTMLDivElement>(null)
     const contentRef = useRef<HTMLDivElement>(null)
@@ -190,10 +190,10 @@ const Dropdown = forwardRef<DropdownRef, PropsWithChildren<DropdownProps>>(
               : undefined
           }
           afterShow={() => {
-            mergedProps.onVisibleChange?.(true, { key: value })
+            mergedProps.onVisibleChange?.(true, { key: cacheKeyRef.current })
           }}
           afterClose={() => {
-            mergedProps.onVisibleChange?.(false, { key: closingKeyRef.current })
+            mergedProps.onVisibleChange?.(false, { key: cacheKeyRef.current })
           }}
         >
           <div ref={contentRef}>

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -71,11 +71,9 @@ const Dropdown = forwardRef<DropdownRef, PropsWithChildren<DropdownProps>>(
     })
 
     const cacheKeyRef = useRef<string | null>(null)
-    useEffect(() => {
-      if (value !== null) {
-        cacheKeyRef.current = value
-      }
-    }, [value])
+    if (value !== null) {
+      cacheKeyRef.current = value
+    }
 
     const navRef = useRef<HTMLDivElement>(null)
     const contentRef = useRef<HTMLDivElement>(null)

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -34,6 +34,7 @@ export type DropdownProps = {
   closeOnMaskClick?: boolean
   closeOnClickAway?: boolean
   onChange?: (key: string | null) => void
+  onVisibleChange?: (visible: boolean, key: string | null) => void
   arrowIcon?: ReactNode
   /**
    * @deprecated use `arrowIcon` instead
@@ -62,11 +63,26 @@ const Dropdown = forwardRef<DropdownRef, PropsWithChildren<DropdownProps>>(
       props.arrow,
       props.arrowIcon
     )
+    const prevActiveKeyRef = useRef<string | null>(
+      mergedProps.activeKey ?? mergedProps.defaultActiveKey ?? null
+    )
+
     const [value, setValue] = usePropsValue({
       value: mergedProps.activeKey,
       defaultValue: mergedProps.defaultActiveKey,
-      onChange: mergedProps.onChange,
+      onChange: (v: string | null) => {
+        mergedProps.onChange?.(v)
+        if (v === null) {
+          mergedProps.onVisibleChange?.(false, prevActiveKeyRef.current)
+        } else {
+          mergedProps.onVisibleChange?.(true, v)
+        }
+      },
     })
+
+    useEffect(() => {
+      prevActiveKeyRef.current = value
+    }, [value])
 
     const navRef = useRef<HTMLDivElement>(null)
     const contentRef = useRef<HTMLDivElement>(null)

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -34,7 +34,7 @@ export type DropdownProps = {
   closeOnMaskClick?: boolean
   closeOnClickAway?: boolean
   onChange?: (key: string | null) => void
-  onVisibleChange?: (visible: boolean, key: string | null) => void
+  onVisibleChange?: (visible: boolean, info: { key: string | null }) => void
   arrowIcon?: ReactNode
   /**
    * @deprecated use `arrowIcon` instead
@@ -74,7 +74,7 @@ const Dropdown = forwardRef<DropdownRef, PropsWithChildren<DropdownProps>>(
         if (v === null) {
           closingKeyRef.current = value
         } else if (value !== null) {
-          mergedProps.onVisibleChange?.(true, v)
+          mergedProps.onVisibleChange?.(true, { key: v })
         }
       },
     })
@@ -192,10 +192,10 @@ const Dropdown = forwardRef<DropdownRef, PropsWithChildren<DropdownProps>>(
               : undefined
           }
           afterShow={() => {
-            mergedProps.onVisibleChange?.(true, value)
+            mergedProps.onVisibleChange?.(true, { key: value })
           }}
           afterClose={() => {
-            mergedProps.onVisibleChange?.(false, closingKeyRef.current)
+            mergedProps.onVisibleChange?.(false, { key: closingKeyRef.current })
           }}
         >
           <div ref={contentRef}>

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -73,8 +73,6 @@ const Dropdown = forwardRef<DropdownRef, PropsWithChildren<DropdownProps>>(
         mergedProps.onChange?.(v)
         if (v === null) {
           closingKeyRef.current = value
-        } else if (value !== null) {
-          mergedProps.onVisibleChange?.(true, { key: v })
         }
       },
     })

--- a/src/components/dropdown/index.en.md
+++ b/src/components/dropdown/index.en.md
@@ -22,7 +22,7 @@ It is suitable for filtering, sorting and changing the display range or order of
 | closeOnMaskClick | Whether to automatically close after clicking on the mask | `boolean` | `true` |
 | defaultActiveKey | The default active `Item` key | `string \| null` | `null` |
 | onChange | Triggered when `activeKey` changes | `(activeKey: string \| null)=> void` | - |
-| onVisibleChange | Triggered when the dropdown panel is shown or hidden | `(visible: boolean, key: string \| null) => void` | - |
+| onVisibleChange | Triggered when the dropdown panel is shown or hidden | `(visible: boolean, info: { key: string \| null }) => void` | - |
 | getContainer | The parent container of the custom popup | `HTMLElement \| (() => HTMLElement) \| null` | `document.body` |
 
 ### Ref

--- a/src/components/dropdown/index.en.md
+++ b/src/components/dropdown/index.en.md
@@ -22,6 +22,7 @@ It is suitable for filtering, sorting and changing the display range or order of
 | closeOnMaskClick | Whether to automatically close after clicking on the mask | `boolean` | `true` |
 | defaultActiveKey | The default active `Item` key | `string \| null` | `null` |
 | onChange | Triggered when `activeKey` changes | `(activeKey: string \| null)=> void` | - |
+| onVisibleChange | Triggered when the dropdown panel is shown or hidden | `(visible: boolean, key: string \| null) => void` | - |
 | getContainer | The parent container of the custom popup | `HTMLElement \| (() => HTMLElement) \| null` | `document.body` |
 
 ### Ref

--- a/src/components/dropdown/index.zh.md
+++ b/src/components/dropdown/index.zh.md
@@ -22,7 +22,7 @@
 | closeOnMaskClick | 是否在点击遮罩后自动隐藏 | `boolean` | `true` |
 | defaultActiveKey | 默认激活的 `Item` `key` | `string \| null` | `null` |
 | onChange | `activeKey` 变化时触发 | `(activeKey: string \| null)=> void` | - |
-| onVisibleChange | 面板显示/隐藏时触发 | `(visible: boolean, key: string \| null) => void` | - |
+| onVisibleChange | 面板显示/隐藏时触发 | `(visible: boolean, info: { key: string \| null }) => void` | - |
 | getContainer | 自定义弹窗的父容器 | `HTMLElement \| (() => HTMLElement) \| null` | `document.body` |
 
 ### Ref

--- a/src/components/dropdown/index.zh.md
+++ b/src/components/dropdown/index.zh.md
@@ -22,6 +22,7 @@
 | closeOnMaskClick | 是否在点击遮罩后自动隐藏 | `boolean` | `true` |
 | defaultActiveKey | 默认激活的 `Item` `key` | `string \| null` | `null` |
 | onChange | `activeKey` 变化时触发 | `(activeKey: string \| null)=> void` | - |
+| onVisibleChange | 面板显示/隐藏时触发 | `(visible: boolean, key: string \| null) => void` | - |
 | getContainer | 自定义弹窗的父容器 | `HTMLElement \| (() => HTMLElement) \| null` | `document.body` |
 
 ### Ref

--- a/src/components/dropdown/tests/dropdown.test.tsx
+++ b/src/components/dropdown/tests/dropdown.test.tsx
@@ -165,14 +165,14 @@ describe('Dropdown', () => {
       // 打开
       fireEvent.click(screen.getByText('sorter'))
       await waitFor(() => {
-        expect(onVisibleChange).lastCalledWith(true, 'sorter')
+        expect(onVisibleChange).lastCalledWith(true, { key: 'sorter' })
       })
       expect(onVisibleChange).toHaveBeenCalledTimes(1)
 
       // 再次点击同一项关闭
       fireEvent.click(screen.getByText('sorter'))
       await waitFor(() => {
-        expect(onVisibleChange).lastCalledWith(false, 'sorter')
+        expect(onVisibleChange).lastCalledWith(false, { key: 'sorter' })
       })
       expect(onVisibleChange).toHaveBeenCalledTimes(2)
     })
@@ -193,11 +193,11 @@ describe('Dropdown', () => {
       // 打开 sorter
       fireEvent.click(screen.getByText('sorter'))
       await waitFor(() => {
-        expect(onVisibleChange).lastCalledWith(true, 'sorter')
+        expect(onVisibleChange).lastCalledWith(true, { key: 'sorter' })
       })
 
       fireEvent.click(screen.getByText('filter'))
-      expect(onVisibleChange).lastCalledWith(true, 'filter')
+      expect(onVisibleChange).lastCalledWith(true, { key: 'filter' })
       expect(onVisibleChange).toHaveBeenCalledTimes(2)
     })
 
@@ -214,7 +214,7 @@ describe('Dropdown', () => {
       // 打开
       fireEvent.click(screen.getByText('sorter'))
       await waitFor(() => {
-        expect(onVisibleChange).lastCalledWith(true, 'sorter')
+        expect(onVisibleChange).lastCalledWith(true, { key: 'sorter' })
       })
 
       // 点击外部关闭
@@ -222,7 +222,7 @@ describe('Dropdown', () => {
         fireEvent.click(document.body)
       })
       await waitFor(() => {
-        expect(onVisibleChange).lastCalledWith(false, 'sorter')
+        expect(onVisibleChange).lastCalledWith(false, { key: 'sorter' })
       })
     })
 
@@ -240,13 +240,13 @@ describe('Dropdown', () => {
       // 打开
       fireEvent.click(screen.getByText('sorter'))
       await waitFor(() => {
-        expect(onVisibleChange).lastCalledWith(true, 'sorter')
+        expect(onVisibleChange).lastCalledWith(true, { key: 'sorter' })
       })
 
       // 通过 ref 关闭
       ref.current?.close()
       await waitFor(() => {
-        expect(onVisibleChange).lastCalledWith(false, 'sorter')
+        expect(onVisibleChange).lastCalledWith(false, { key: 'sorter' })
       })
     })
   })

--- a/src/components/dropdown/tests/dropdown.test.tsx
+++ b/src/components/dropdown/tests/dropdown.test.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { fireEvent, render, screen, waitFor } from 'testing'
+import { act, fireEvent, render, screen, waitFor } from 'testing'
 import Dropdown from '..'
 
 const classPrefix = `adm-dropdown`
@@ -148,6 +148,93 @@ describe('Dropdown', () => {
         </Dropdown>
       )
       expect(screen.getByText('bamboo')).toBeVisible()
+    })
+  })
+
+  describe('onVisibleChange', () => {
+    test('should fire onVisibleChange when opening and closing', async () => {
+      const onVisibleChange = jest.fn()
+      render(
+        <Dropdown onVisibleChange={onVisibleChange}>
+          <Dropdown.Item title='sorter' key='sorter'>
+            content
+          </Dropdown.Item>
+        </Dropdown>
+      )
+
+      // 打开
+      fireEvent.click(screen.getByText('sorter'))
+      expect(onVisibleChange).lastCalledWith(true, 'sorter')
+      expect(onVisibleChange).toHaveBeenCalledTimes(1)
+
+      // 再次点击同一项关闭
+      fireEvent.click(screen.getByText('sorter'))
+      expect(onVisibleChange).lastCalledWith(false, 'sorter')
+      expect(onVisibleChange).toHaveBeenCalledTimes(2)
+    })
+
+    test('should fire onVisibleChange when switching items', () => {
+      const onVisibleChange = jest.fn()
+      render(
+        <Dropdown onVisibleChange={onVisibleChange}>
+          <Dropdown.Item title='sorter' key='sorter'>
+            sorter content
+          </Dropdown.Item>
+          <Dropdown.Item title='filter' key='filter'>
+            filter content
+          </Dropdown.Item>
+        </Dropdown>
+      )
+
+      // 打开 sorter
+      fireEvent.click(screen.getByText('sorter'))
+      expect(onVisibleChange).lastCalledWith(true, 'sorter')
+
+      // 切换到 filter：直接切换，不经过关闭
+      fireEvent.click(screen.getByText('filter'))
+      expect(onVisibleChange).lastCalledWith(true, 'filter')
+      expect(onVisibleChange).toHaveBeenCalledTimes(2)
+    })
+
+    test('should fire onVisibleChange when closing via click away', () => {
+      const onVisibleChange = jest.fn()
+      render(
+        <Dropdown closeOnClickAway onVisibleChange={onVisibleChange}>
+          <Dropdown.Item title='sorter' key='sorter'>
+            content
+          </Dropdown.Item>
+        </Dropdown>
+      )
+
+      // 打开
+      fireEvent.click(screen.getByText('sorter'))
+      expect(onVisibleChange).lastCalledWith(true, 'sorter')
+
+      // 点击外部关闭
+      act(() => {
+        fireEvent.click(document.body)
+      })
+      expect(onVisibleChange).lastCalledWith(false, 'sorter')
+    })
+
+    test('should fire onVisibleChange when closing via ref.close()', () => {
+      const ref = React.createRef<{ close: () => void }>()
+      const onVisibleChange = jest.fn()
+      render(
+        <Dropdown ref={ref} onVisibleChange={onVisibleChange}>
+          <Dropdown.Item title='sorter' key='sorter'>
+            content
+          </Dropdown.Item>
+        </Dropdown>
+      )
+
+      // 打开
+      fireEvent.click(screen.getByText('sorter'))
+      expect(onVisibleChange).lastCalledWith(true, 'sorter')
+
+      // 通过 ref 关闭
+      ref.current?.close()
+      expect(onVisibleChange).lastCalledWith(false, 'sorter')
     })
   })
 })

--- a/src/components/dropdown/tests/dropdown.test.tsx
+++ b/src/components/dropdown/tests/dropdown.test.tsx
@@ -196,9 +196,9 @@ describe('Dropdown', () => {
         expect(onVisibleChange).lastCalledWith(true, { key: 'sorter' })
       })
 
+      // 切换 item 不会改变 visible，不应触发 onVisibleChange
       fireEvent.click(screen.getByText('filter'))
-      expect(onVisibleChange).lastCalledWith(true, { key: 'filter' })
-      expect(onVisibleChange).toHaveBeenCalledTimes(2)
+      expect(onVisibleChange).toHaveBeenCalledTimes(1)
     })
 
     test('should fire onVisibleChange when closing via click away', async () => {

--- a/src/components/dropdown/tests/dropdown.test.tsx
+++ b/src/components/dropdown/tests/dropdown.test.tsx
@@ -164,16 +164,20 @@ describe('Dropdown', () => {
 
       // 打开
       fireEvent.click(screen.getByText('sorter'))
-      expect(onVisibleChange).lastCalledWith(true, 'sorter')
+      await waitFor(() => {
+        expect(onVisibleChange).lastCalledWith(true, 'sorter')
+      })
       expect(onVisibleChange).toHaveBeenCalledTimes(1)
 
       // 再次点击同一项关闭
       fireEvent.click(screen.getByText('sorter'))
-      expect(onVisibleChange).lastCalledWith(false, 'sorter')
+      await waitFor(() => {
+        expect(onVisibleChange).lastCalledWith(false, 'sorter')
+      })
       expect(onVisibleChange).toHaveBeenCalledTimes(2)
     })
 
-    test('should fire onVisibleChange when switching items', () => {
+    test('should fire onVisibleChange when switching items', async () => {
       const onVisibleChange = jest.fn()
       render(
         <Dropdown onVisibleChange={onVisibleChange}>
@@ -188,15 +192,16 @@ describe('Dropdown', () => {
 
       // 打开 sorter
       fireEvent.click(screen.getByText('sorter'))
-      expect(onVisibleChange).lastCalledWith(true, 'sorter')
+      await waitFor(() => {
+        expect(onVisibleChange).lastCalledWith(true, 'sorter')
+      })
 
-      // 切换到 filter：直接切换，不经过关闭
       fireEvent.click(screen.getByText('filter'))
       expect(onVisibleChange).lastCalledWith(true, 'filter')
       expect(onVisibleChange).toHaveBeenCalledTimes(2)
     })
 
-    test('should fire onVisibleChange when closing via click away', () => {
+    test('should fire onVisibleChange when closing via click away', async () => {
       const onVisibleChange = jest.fn()
       render(
         <Dropdown closeOnClickAway onVisibleChange={onVisibleChange}>
@@ -208,16 +213,20 @@ describe('Dropdown', () => {
 
       // 打开
       fireEvent.click(screen.getByText('sorter'))
-      expect(onVisibleChange).lastCalledWith(true, 'sorter')
+      await waitFor(() => {
+        expect(onVisibleChange).lastCalledWith(true, 'sorter')
+      })
 
       // 点击外部关闭
       act(() => {
         fireEvent.click(document.body)
       })
-      expect(onVisibleChange).lastCalledWith(false, 'sorter')
+      await waitFor(() => {
+        expect(onVisibleChange).lastCalledWith(false, 'sorter')
+      })
     })
 
-    test('should fire onVisibleChange when closing via ref.close()', () => {
+    test('should fire onVisibleChange when closing via ref.close()', async () => {
       const ref = React.createRef<{ close: () => void }>()
       const onVisibleChange = jest.fn()
       render(
@@ -230,11 +239,15 @@ describe('Dropdown', () => {
 
       // 打开
       fireEvent.click(screen.getByText('sorter'))
-      expect(onVisibleChange).lastCalledWith(true, 'sorter')
+      await waitFor(() => {
+        expect(onVisibleChange).lastCalledWith(true, 'sorter')
+      })
 
       // 通过 ref 关闭
       ref.current?.close()
-      expect(onVisibleChange).lastCalledWith(false, 'sorter')
+      await waitFor(() => {
+        expect(onVisibleChange).lastCalledWith(false, 'sorter')
+      })
     })
   })
 })


### PR DESCRIPTION
close #6745 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 为 Dropdown 组件新增 `onVisibleChange(visible, info)`：下拉面板显示/隐藏时触发；`info` 中返回当前菜单项 `key`（可能为 `null`）。
* **增强**
  * 可见性回调在展示与关闭阶段均会触发，确保切换项、点击空白处关闭及手动关闭等场景下参数准确。
* **文档**
  * 更新 Dropdown 属性文档，补充 `onVisibleChange` 的签名说明。
* **测试**
  * 新增/完善 `onVisibleChange` 用例：切换项、click away、手动关闭，校验回调参数与调用次数。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->