### PR TITLE
fix: handle December 1981 in DatePicker

### DIFF
--- a/src/components/date-picker/date-picker-date-utils.ts
+++ b/src/components/date-picker/date-picker-date-utils.ts
@@ -1,15 +1,7 @@
-import dayjs from 'dayjs'
-import isLeapYear from 'dayjs/plugin/isLeapYear'
-import isoWeek from 'dayjs/plugin/isoWeek'
-import isoWeeksInYear from 'dayjs/plugin/isoWeeksInYear'
 import { RenderLabel } from '../date-picker-view/date-picker-view'
 import { PickerColumn } from '../picker'
 import type { DatePickerFilter } from './date-picker-utils'
 import { TILL_NOW } from './util'
-
-dayjs.extend(isoWeek)
-dayjs.extend(isoWeeksInYear)
-dayjs.extend(isLeapYear)
 
 export type DatePrecision =
   | 'year'
@@ -26,6 +18,10 @@ const precisionRankRecord: Record<DatePrecision, number> = {
   hour: 3,
   minute: 4,
   second: 5,
+}
+
+function getMonthDays(year: number, month: number) {
+  return new Date(Date.UTC(year, month, 0)).getUTCDate()
 }
 
 export function generateDatePickerColumns(
@@ -56,9 +52,6 @@ export function generateDatePickerColumns(
   const rank = precisionRankRecord[precision]
 
   const selectedYear = parseInt(selected[0])
-  const firstDayInSelectedMonth = dayjs(
-    convertStringArrayToDate([selected[0], selected[1], '1'])
-  )
   const selectedMonth = parseInt(selected[1])
   const selectedDay = parseInt(selected[2])
   const selectedHour = parseInt(selected[3])
@@ -125,7 +118,9 @@ export function generateDatePickerColumns(
   }
   if (rank >= precisionRankRecord.day) {
     const lower = isInMinMonth ? minDay : 1
-    const upper = isInMaxMonth ? maxDay : firstDayInSelectedMonth.daysInMonth()
+    const upper = isInMaxMonth
+      ? maxDay
+      : getMonthDays(selectedYear, selectedMonth)
     const days = generateColumn(lower, upper, 'day')
     ret.push(
       days.map(v => ({

--- a/src/components/date-picker/tests/date-picker.test.tsx
+++ b/src/components/date-picker/tests/date-picker.test.tsx
@@ -11,6 +11,7 @@ import {
   waitForElementToBeRemoved,
 } from 'testing'
 import DatePicker from '../'
+import { generateDatePickerColumns as generateDatePickerDateColumns } from '../date-picker-date-utils'
 import Button from '../../button'
 import {
   convertStringArrayToDate,
@@ -268,6 +269,37 @@ describe('DatePicker', () => {
       const weekColumn = columns[1] as { label: string; value: string }[]
       const weekValues = weekColumn.map(item => item.value)
       expect(weekValues).toEqual(['1'])
+    })
+  })
+
+  describe('generateDatePickerColumns for day precision', () => {
+    it('should include every day in December 1981', () => {
+      const originalTZ = process.env.TZ
+      // Asia/Singapore has a historical transition in December 1981 that
+      // makes dayjs().daysInMonth() report one day for this month.
+      process.env.TZ = 'Asia/Singapore'
+
+      try {
+        const columns = generateDatePickerDateColumns(
+          ['1981', '12', '1'],
+          new Date(1981, 0, 1),
+          new Date(1982, 0, 31),
+          'day',
+          (type, data) => type + '：' + data,
+          undefined
+        )
+
+        const dayColumn = columns[2] as { value: string }[]
+        expect(dayColumn.map(item => item.value)).toEqual(
+          Array.from({ length: 31 }, (_, index) => `${index + 1}`)
+        )
+      } finally {
+        if (originalTZ === undefined) {
+          delete process.env.TZ
+        } else {
+          process.env.TZ = originalTZ
+        }
+      }
     })
   })
 


### PR DESCRIPTION
Fixes #7028.

This avoids using DayJS `daysInMonth()` for the normal DatePicker day column. In time zones such as `Asia/Singapore`, DayJS can report December 1981 as having only one day because of the historical offset transition. The DatePicker only needs the calendar length of the selected month, so this uses the native end-of-month calculation instead.

Verification:

- `env TZ=Asia/Singapore pnpm test -- src/components/date-picker/tests/date-picker.test.tsx --runInBand -t "should include every day in December 1981"`
- `pnpm test -- src/components/date-picker/tests/date-picker.test.tsx --runInBand`
- `pnpm exec eslint src/components/date-picker/date-picker-date-utils.ts src/components/date-picker/tests/date-picker.test.tsx` (existing warning only)
- `pnpm build`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 优化日期选择器“day”列的月份天数计算方式，不再依赖原先的日期库插件；改为使用原生日期能力计算并调整边界逻辑。
* **Tests**
  * 新增“day 精度”日期列生成的单元测试用例，覆盖特定月份逐日生成结果，并在时区为 `Asia/Singapore` 时验证逻辑；测试后恢复时区环境。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->