### PR TITLE
feat(dropdown): 添加滚动容器内锁定功能

### DIFF
--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -27,6 +27,12 @@ import { defaultPopupBaseProps } from '../popup/popup-base-props'
 import { IconContext } from './context'
 import Item, { ItemChildrenWrap } from './item'
 
+// 按滚动容器维护锁计数，防止多 Dropdown 共享同一容器时提前解锁
+const scrollLockState = new WeakMap<
+  HTMLElement,
+  { count: number; originalOverflow: string }
+>()
+
 const classPrefix = `adm-dropdown`
 
 export type DropdownProps = {
@@ -107,7 +113,6 @@ const Dropdown = forwardRef<DropdownRef, PropsWithChildren<DropdownProps>>(
 
       const container = containerRef.current
       let scrollParent: HTMLElement | null = null
-      let originalOverflow = ''
 
       if (container) {
         const parent = getScrollParent(container)
@@ -118,8 +123,16 @@ const Dropdown = forwardRef<DropdownRef, PropsWithChildren<DropdownProps>>(
           parent !== document.documentElement
         ) {
           scrollParent = parent as HTMLElement
-          originalOverflow = scrollParent.style.overflow
-          scrollParent.style.overflow = 'hidden'
+          const state = scrollLockState.get(scrollParent)
+          if (state) {
+            state.count += 1
+          } else {
+            scrollLockState.set(scrollParent, {
+              count: 1,
+              originalOverflow: scrollParent.style.overflow,
+            })
+            scrollParent.style.overflow = 'hidden'
+          }
         }
       }
 
@@ -133,7 +146,14 @@ const Dropdown = forwardRef<DropdownRef, PropsWithChildren<DropdownProps>>(
         raf.cancel(rafIdRef.current)
 
         if (scrollParent) {
-          scrollParent.style.overflow = originalOverflow
+          const state = scrollLockState.get(scrollParent)
+          if (state) {
+            state.count -= 1
+            if (state.count === 0) {
+              scrollParent.style.overflow = state.originalOverflow
+              scrollLockState.delete(scrollParent)
+            }
+          }
         }
 
         window.removeEventListener('scroll', updateTop, true)

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -30,8 +30,28 @@ import Item, { ItemChildrenWrap } from './item'
 // 按滚动容器维护锁计数，防止多 Dropdown 共享同一容器时提前解锁
 const scrollLockState = new WeakMap<
   HTMLElement,
-  { count: number; originalOverflow: string }
+  { count: number; originalOverflowY: string }
 >()
+
+/**
+ * 获取要锁定的滚动容器。
+ */
+function getLockTarget(
+  el: HTMLElement
+): HTMLElement | Window | null | undefined {
+  let node: Element | null = el
+  while (node && node !== document.body && node !== document.documentElement) {
+    if (scrollLockState.has(node as HTMLElement)) {
+      return node as HTMLElement
+    }
+    node = node.parentElement
+  }
+  const parent = getScrollParent(el)
+  if (parent && parent !== window && !(parent instanceof HTMLElement)) {
+    return null
+  }
+  return parent as HTMLElement | Window | null | undefined
+}
 
 const classPrefix = `adm-dropdown`
 
@@ -115,7 +135,7 @@ const Dropdown = forwardRef<DropdownRef, PropsWithChildren<DropdownProps>>(
       let scrollParent: HTMLElement | null = null
 
       if (container) {
-        const parent = getScrollParent(container)
+        const parent = getLockTarget(container)
         if (
           parent &&
           parent !== window &&
@@ -129,9 +149,9 @@ const Dropdown = forwardRef<DropdownRef, PropsWithChildren<DropdownProps>>(
           } else {
             scrollLockState.set(scrollParent, {
               count: 1,
-              originalOverflow: scrollParent.style.overflow,
+              originalOverflowY: scrollParent.style.overflowY,
             })
-            scrollParent.style.overflow = 'hidden'
+            scrollParent.style.overflowY = 'hidden'
           }
         }
       }
@@ -150,7 +170,7 @@ const Dropdown = forwardRef<DropdownRef, PropsWithChildren<DropdownProps>>(
           if (state) {
             state.count -= 1
             if (state.count === 0) {
-              scrollParent.style.overflow = state.originalOverflow
+              scrollParent.style.overflowY = state.originalOverflowY
               scrollLockState.delete(scrollParent)
             }
           }

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -17,6 +17,7 @@ import React, {
   useRef,
   useState,
 } from 'react'
+import { getScrollParent } from '../../utils/get-scroll-parent'
 import { NativeProps, withNativeProps } from '../../utils/native-props'
 import { usePropsValue } from '../../utils/use-props-value'
 import { mergeProp, mergeProps } from '../../utils/with-default-props'
@@ -104,6 +105,24 @@ const Dropdown = forwardRef<DropdownRef, PropsWithChildren<DropdownProps>>(
 
       updatePosition()
 
+      const container = containerRef.current
+      let scrollParent: HTMLElement | null = null
+      let originalOverflow = ''
+
+      if (container) {
+        const parent = getScrollParent(container)
+        if (
+          parent &&
+          parent !== window &&
+          parent !== document.body &&
+          parent !== document.documentElement
+        ) {
+          scrollParent = parent as HTMLElement
+          originalOverflow = scrollParent.style.overflow
+          scrollParent.style.overflow = 'hidden'
+        }
+      }
+
       window.addEventListener('scroll', updateTop, {
         passive: true,
         capture: true,
@@ -112,6 +131,10 @@ const Dropdown = forwardRef<DropdownRef, PropsWithChildren<DropdownProps>>(
 
       return () => {
         raf.cancel(rafIdRef.current)
+
+        if (scrollParent) {
+          scrollParent.style.overflow = originalOverflow
+        }
 
         window.removeEventListener('scroll', updateTop, true)
         window.removeEventListener('resize', updateTop)

--- a/src/components/dropdown/tests/dropdown.test.tsx
+++ b/src/components/dropdown/tests/dropdown.test.tsx
@@ -2,6 +2,16 @@ import React, { useState } from 'react'
 import { act, fireEvent, render, screen, waitFor } from 'testing'
 import Dropdown from '..'
 
+jest.mock('../../../utils/get-scroll-parent', () => ({
+  getScrollParent: jest.fn(),
+}))
+
+import { getScrollParent } from '../../../utils/get-scroll-parent'
+
+const mockedGetScrollParent = getScrollParent as jest.MockedFunction<
+  typeof getScrollParent
+>
+
 const classPrefix = `adm-dropdown`
 
 describe('Dropdown', () => {
@@ -149,6 +159,61 @@ describe('Dropdown', () => {
       )
       expect(screen.getByText('bamboo')).toBeVisible()
     })
+  })
+
+  test('should lock scroll of nested scrollable container when open', async () => {
+    const scrollParentEl = document.createElement('div')
+    scrollParentEl.style.overflow = 'auto'
+    mockedGetScrollParent.mockReturnValue(scrollParentEl)
+
+    render(
+      <Dropdown>
+        <Dropdown.Item title='sorter' key='sorter'>
+          content
+        </Dropdown.Item>
+      </Dropdown>
+    )
+
+    expect(scrollParentEl.style.overflow).toBe('auto')
+
+    fireEvent.click(screen.getByText('sorter'))
+    await waitFor(() => {
+      expect(screen.getByText('content')).toBeVisible()
+    })
+
+    expect(scrollParentEl.style.overflow).toBe('hidden')
+
+    fireEvent.click(screen.getByText('sorter'))
+    await waitFor(() => {
+      expect(screen.getByText('content')).not.toBeVisible()
+    })
+
+    expect(scrollParentEl.style.overflow).toBe('auto')
+
+    mockedGetScrollParent.mockRestore()
+  })
+
+  test('should not lock scroll when scroll parent is window', async () => {
+    mockedGetScrollParent.mockReturnValue(window)
+
+    render(
+      <Dropdown>
+        <Dropdown.Item title='sorter' key='sorter'>
+          content
+        </Dropdown.Item>
+      </Dropdown>
+    )
+
+    // 打开 Dropdown
+    fireEvent.click(screen.getByText('sorter'))
+    await waitFor(() => {
+      expect(screen.getByText('content')).toBeVisible()
+    })
+
+    // scroll parent 为 window 时不应设置 overflow
+    expect(document.body.style.overflow).toBe('')
+
+    mockedGetScrollParent.mockRestore()
   })
 
   describe('onVisibleChange', () => {

--- a/src/components/dropdown/tests/dropdown.test.tsx
+++ b/src/components/dropdown/tests/dropdown.test.tsx
@@ -163,7 +163,7 @@ describe('Dropdown', () => {
 
   test('should lock scroll of nested scrollable container when open', async () => {
     const scrollParentEl = document.createElement('div')
-    scrollParentEl.style.overflow = 'auto'
+    scrollParentEl.style.overflowY = 'auto'
     mockedGetScrollParent.mockReturnValue(scrollParentEl)
 
     render(
@@ -174,21 +174,21 @@ describe('Dropdown', () => {
       </Dropdown>
     )
 
-    expect(scrollParentEl.style.overflow).toBe('auto')
+    expect(scrollParentEl.style.overflowY).toBe('auto')
 
     fireEvent.click(screen.getByText('sorter'))
     await waitFor(() => {
       expect(screen.getByText('content')).toBeVisible()
     })
 
-    expect(scrollParentEl.style.overflow).toBe('hidden')
+    expect(scrollParentEl.style.overflowY).toBe('hidden')
 
     fireEvent.click(screen.getByText('sorter'))
     await waitFor(() => {
       expect(screen.getByText('content')).not.toBeVisible()
     })
 
-    expect(scrollParentEl.style.overflow).toBe('auto')
+    expect(scrollParentEl.style.overflowY).toBe('auto')
 
     mockedGetScrollParent.mockRestore()
   })
@@ -218,62 +218,65 @@ describe('Dropdown', () => {
 
   test('should not prematurely unlock when multiple Dropdowns share the same scroll parent', async () => {
     const scrollParentEl = document.createElement('div')
-    scrollParentEl.style.overflow = 'auto'
+    scrollParentEl.style.overflowY = 'auto'
 
-    const dropdown1 = document.createElement('div')
-    const dropdown2 = document.createElement('div')
+    mockedGetScrollParent.mockImplementation(() => {
+      if (scrollParentEl.style.overflowY === 'hidden') {
+        return window
+      }
+      return scrollParentEl
+    })
+
+    const container = document.createElement('div')
+    scrollParentEl.appendChild(container)
     document.body.appendChild(scrollParentEl)
-    scrollParentEl.appendChild(dropdown1)
-    scrollParentEl.appendChild(dropdown2)
-
-    mockedGetScrollParent.mockReturnValue(scrollParentEl)
 
     const { unmount } = render(
-      <>
-        <Dropdown>
-          <Dropdown.Item title='A' key='a'>
-            a-content
-          </Dropdown.Item>
-        </Dropdown>
-        <Dropdown>
-          <Dropdown.Item title='B' key='b'>
-            b-content
-          </Dropdown.Item>
-        </Dropdown>
-      </>
+      <Dropdown>
+        <Dropdown.Item title='A' key='a'>
+          a-content
+        </Dropdown.Item>
+      </Dropdown>,
+      { container }
     )
 
-    // 打开第一个 Dropdown
     fireEvent.click(screen.getByText('A'))
     await waitFor(() => {
       expect(screen.getByText('a-content')).toBeVisible()
     })
-    expect(scrollParentEl.style.overflow).toBe('hidden')
+    expect(scrollParentEl.style.overflowY).toBe('hidden')
 
-    // 打开第二个 Dropdown（共享同一 scroll parent）
+    const container2 = document.createElement('div')
+    scrollParentEl.appendChild(container2)
+    const { unmount: unmount2 } = render(
+      <Dropdown>
+        <Dropdown.Item title='B' key='b'>
+          b-content
+        </Dropdown.Item>
+      </Dropdown>,
+      { container: container2 }
+    )
+
     fireEvent.click(screen.getByText('B'))
     await waitFor(() => {
       expect(screen.getByText('b-content')).toBeVisible()
     })
-    // 仍为 hidden（引用计数 = 2）
-    expect(scrollParentEl.style.overflow).toBe('hidden')
+    expect(scrollParentEl.style.overflowY).toBe('hidden')
 
-    // 关闭第一个 Dropdown，不应提前解锁
     fireEvent.click(screen.getByText('A'))
     await waitFor(() => {
       expect(screen.getByText('a-content')).not.toBeVisible()
     })
-    // 仍为 hidden（引用计数 = 1）
-    expect(scrollParentEl.style.overflow).toBe('hidden')
+    expect(scrollParentEl.style.overflowY).toBe('hidden')
 
-    // 关闭第二个 Dropdown，计数归零，恢复原始 overflow
     fireEvent.click(screen.getByText('B'))
     await waitFor(() => {
       expect(screen.getByText('b-content')).not.toBeVisible()
     })
-    expect(scrollParentEl.style.overflow).toBe('auto')
+    expect(scrollParentEl.style.overflowY).toBe('auto')
 
     unmount()
+    unmount2()
     document.body.removeChild(scrollParentEl)
     mockedGetScrollParent.mockRestore()
   })

--- a/src/components/dropdown/tests/dropdown.test.tsx
+++ b/src/components/dropdown/tests/dropdown.test.tsx
@@ -216,6 +216,68 @@ describe('Dropdown', () => {
     mockedGetScrollParent.mockRestore()
   })
 
+  test('should not prematurely unlock when multiple Dropdowns share the same scroll parent', async () => {
+    const scrollParentEl = document.createElement('div')
+    scrollParentEl.style.overflow = 'auto'
+
+    const dropdown1 = document.createElement('div')
+    const dropdown2 = document.createElement('div')
+    document.body.appendChild(scrollParentEl)
+    scrollParentEl.appendChild(dropdown1)
+    scrollParentEl.appendChild(dropdown2)
+
+    mockedGetScrollParent.mockReturnValue(scrollParentEl)
+
+    const { unmount } = render(
+      <>
+        <Dropdown>
+          <Dropdown.Item title='A' key='a'>
+            a-content
+          </Dropdown.Item>
+        </Dropdown>
+        <Dropdown>
+          <Dropdown.Item title='B' key='b'>
+            b-content
+          </Dropdown.Item>
+        </Dropdown>
+      </>
+    )
+
+    // 打开第一个 Dropdown
+    fireEvent.click(screen.getByText('A'))
+    await waitFor(() => {
+      expect(screen.getByText('a-content')).toBeVisible()
+    })
+    expect(scrollParentEl.style.overflow).toBe('hidden')
+
+    // 打开第二个 Dropdown（共享同一 scroll parent）
+    fireEvent.click(screen.getByText('B'))
+    await waitFor(() => {
+      expect(screen.getByText('b-content')).toBeVisible()
+    })
+    // 仍为 hidden（引用计数 = 2）
+    expect(scrollParentEl.style.overflow).toBe('hidden')
+
+    // 关闭第一个 Dropdown，不应提前解锁
+    fireEvent.click(screen.getByText('A'))
+    await waitFor(() => {
+      expect(screen.getByText('a-content')).not.toBeVisible()
+    })
+    // 仍为 hidden（引用计数 = 1）
+    expect(scrollParentEl.style.overflow).toBe('hidden')
+
+    // 关闭第二个 Dropdown，计数归零，恢复原始 overflow
+    fireEvent.click(screen.getByText('B'))
+    await waitFor(() => {
+      expect(screen.getByText('b-content')).not.toBeVisible()
+    })
+    expect(scrollParentEl.style.overflow).toBe('auto')
+
+    unmount()
+    document.body.removeChild(scrollParentEl)
+    mockedGetScrollParent.mockRestore()
+  })
+
   describe('onVisibleChange', () => {
     test('should fire onVisibleChange when opening and closing', async () => {
       const onVisibleChange = jest.fn()


### PR DESCRIPTION
fixed #6606 
- 当 Dropdown 打开时锁定父级滚动容器的滚动

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * 改进下拉菜单的滚动干扰处理：打开时会临时锁定真实滚动父容器的 `overflowY`，关闭后恢复；多个下拉共享同一滚动父容器时不会提前解锁。

* **Tests**
  * 新增/完善滚动锁定测试：覆盖嵌套滚动容器、`window` 场景（不修改 body 溢出样式），以及多个实例共享时的引用计数解锁与卸载恢复。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->