### PR TITLE
feat(input): 完善 enterKeyHint 类型定义

### DIFF
--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -180,6 +180,7 @@ export const Input = forwardRef<InputRef, InputProps>((props, ref) => {
         max={mergedProps.max}
         min={mergedProps.min}
         autoComplete={mergedProps.autoComplete}
+        /* https://github.com/ant-design/ant-design-mobile/issues/6636 */
         {...{ enterKeyHint: mergedProps.enterKeyHint }}
         autoFocus={mergedProps.autoFocus}
         pattern={mergedProps.pattern}

--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -52,8 +52,15 @@ export type InputProps = Pick<
   | 'placeholder'
   | 'readOnly'
   | 'disabled'
-  | 'enterKeyHint'
 > & {
+  enterKeyHint?:
+    | 'enter'
+    | 'done'
+    | 'go'
+    | 'next'
+    | 'previous'
+    | 'search'
+    | 'send'
   value?: string
   defaultValue?: string
   onChange?: (val: string) => void
@@ -173,7 +180,7 @@ export const Input = forwardRef<InputRef, InputProps>((props, ref) => {
         max={mergedProps.max}
         min={mergedProps.min}
         autoComplete={mergedProps.autoComplete}
-        enterKeyHint={mergedProps.enterKeyHint}
+        {...{ enterKeyHint: mergedProps.enterKeyHint }}
         autoFocus={mergedProps.autoFocus}
         pattern={mergedProps.pattern}
         inputMode={mergedProps.inputMode}

--- a/src/components/input/tests/input.test.tsx
+++ b/src/components/input/tests/input.test.tsx
@@ -149,6 +149,12 @@ describe('Input', () => {
     expect(input.step).toBe('0.01')
   })
 
+  test('should pass enterKeyHint to native input element', () => {
+    render(<Input enterKeyHint='search' />)
+    const input = document.querySelector('input')! as HTMLInputElement
+    expect(input.getAttribute('enterkeyhint')).toBe('search')
+  })
+
   test('should works with `onEnterPress`', async () => {
     const onEnterPress = jest.fn()
     render(<Input defaultValue={'testValue'} onEnterPress={onEnterPress} />)

--- a/src/components/text-area/tests/text-area.test.tsx
+++ b/src/components/text-area/tests/text-area.test.tsx
@@ -143,6 +143,12 @@ describe('TextArea', () => {
     expect(textarea).toHaveAttribute('rows', '1')
   })
 
+  test('should pass enterKeyHint to native textarea element', () => {
+    const { getByRole } = render(<TextArea enterKeyHint='done' />)
+    const textarea = getByRole('textbox') as HTMLTextAreaElement
+    expect(textarea.getAttribute('enterkeyhint')).toBe('done')
+  })
+
   test('should works with `onEnterPress`', async () => {
     const onEnterPress = jest.fn()
     const { getByRole } = render(

--- a/src/components/text-area/text-area.tsx
+++ b/src/components/text-area/text-area.tsx
@@ -199,7 +199,7 @@ export const TextArea = forwardRef<TextAreaRef, TextAreaProps>(
           onBlur={props.onBlur}
           onClick={props.onClick}
           onKeyDown={handleKeydown}
-          enterKeyHint={props.enterKeyHint}
+          {...{ enterKeyHint: props.enterKeyHint }}
         />
         {count}
 

--- a/src/components/text-area/text-area.tsx
+++ b/src/components/text-area/text-area.tsx
@@ -199,6 +199,7 @@ export const TextArea = forwardRef<TextAreaRef, TextAreaProps>(
           onBlur={props.onBlur}
           onClick={props.onClick}
           onKeyDown={handleKeydown}
+          /* https://github.com/ant-design/ant-design-mobile/issues/6636 */
           {...{ enterKeyHint: props.enterKeyHint }}
         />
         {count}


### PR DESCRIPTION
fixed #6636 保持对 `@types/react` 16 的兼容性

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 输入框与文本域新增 `enterKeyHint` 支持，用于设置原生回车键提示，可选 `enter`、`done`、`go`、`next`、`previous`、`search`、`send`。
* **测试**
  * 补充用例，验证 `enterKeyHint` 能正确传递到原生 `input` / `textarea` 的 `enterkeyhint` 属性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->