### PR TITLE
fix(popover): 修复点击外部触发 ref.show() 时弹窗关闭问题

### DIFF
--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -83,6 +83,7 @@ export const Popover = forwardRef<PopoverRef, PopoverProps>((p, ref) => {
     ref,
     () => ({
       show: () => {
+        // 标记进入 show() 触发链，避免同一次点击事件冒泡到 document 时被 useClickAway 立即关闭
         showingRef.current = true
         setVisible(true)
         if (showTimerRef.current) clearTimeout(showTimerRef.current)

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -76,10 +76,18 @@ export const Popover = forwardRef<PopoverRef, PopoverProps>((p, ref) => {
     onChange: props.onVisibleChange,
   })
 
+  const showingRef = useRef(false)
+
   useImperativeHandle(
     ref,
     () => ({
-      show: () => setVisible(true),
+      show: () => {
+        showingRef.current = true
+        setVisible(true)
+        setTimeout(() => {
+          showingRef.current = false
+        })
+      },
       hide: () => setVisible(false),
       visible,
     }),
@@ -196,6 +204,7 @@ export const Popover = forwardRef<PopoverRef, PopoverProps>((p, ref) => {
   useClickAway(
     () => {
       if (!props.trigger) return
+      if (showingRef.current) return // 跳过 show() 触发链上的 click-away
       setVisible(false)
     },
     [() => targetRef.current?.element, floatingRef],

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -77,6 +77,7 @@ export const Popover = forwardRef<PopoverRef, PopoverProps>((p, ref) => {
   })
 
   const showingRef = useRef(false)
+  const showTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useImperativeHandle(
     ref,
@@ -84,8 +85,10 @@ export const Popover = forwardRef<PopoverRef, PopoverProps>((p, ref) => {
       show: () => {
         showingRef.current = true
         setVisible(true)
-        setTimeout(() => {
+        if (showTimerRef.current) clearTimeout(showTimerRef.current)
+        showTimerRef.current = setTimeout(() => {
           showingRef.current = false
+          showTimerRef.current = null
         })
       },
       hide: () => setVisible(false),
@@ -93,6 +96,12 @@ export const Popover = forwardRef<PopoverRef, PopoverProps>((p, ref) => {
     }),
     [visible]
   )
+
+  useEffect(() => {
+    return () => {
+      if (showTimerRef.current) clearTimeout(showTimerRef.current)
+    }
+  }, [])
 
   const targetRef = useRef<WrapperRef>(null)
   const floatingRef = useRef<HTMLDivElement>(null)

--- a/src/components/popover/tests/popover.test.tsx
+++ b/src/components/popover/tests/popover.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
-import { fireEvent, render } from 'testing'
-import Popover from '..'
+import { act, fireEvent, render } from 'testing'
+import Popover, { PopoverRef } from '..'
 import Button from '../../button'
 
 describe('Popover', () => {
@@ -51,5 +51,87 @@ describe('Popover', () => {
     // close
     fireEvent.click(getByRole('button'))
     expect(document.querySelector('.adm-popover-hidden')).toBeTruthy()
+  })
+
+  // https://github.com/ant-design/ant-design-mobile/issues/6731
+  test('ref.show() should keep Popover open when already visible under trigger="click"', () => {
+    const Wrap = () => {
+      const ref = React.useRef<PopoverRef>(null)
+      return (
+        <>
+          <Popover content='Bamboo' trigger='click' ref={ref}>
+            <button id='inner'>Hi</button>
+          </Popover>
+          <button id='ext' onClick={() => ref.current?.show()}>
+            external
+          </button>
+        </>
+      )
+    }
+
+    const { container } = render(<Wrap />)
+    const inner = container.querySelector('#inner') as HTMLElement
+    const ext = container.querySelector('#ext') as HTMLElement
+
+    fireEvent.click(inner)
+    expect(document.querySelector('.adm-popover-hidden')).toBeFalsy()
+
+    fireEvent.click(ext)
+    expect(document.querySelector('.adm-popover-hidden')).toBeFalsy()
+  })
+
+  test('after ref.show(), clicking outside should still close Popover', async () => {
+    const Wrap = () => {
+      const ref = React.useRef<PopoverRef>(null)
+      return (
+        <>
+          <Popover content='Bamboo' trigger='click' ref={ref}>
+            <button id='inner'>Hi</button>
+          </Popover>
+          <button id='ext' onClick={() => ref.current?.show()}>
+            external
+          </button>
+        </>
+      )
+    }
+
+    const { container } = render(<Wrap />)
+    const inner = container.querySelector('#inner') as HTMLElement
+    const ext = container.querySelector('#ext') as HTMLElement
+
+    fireEvent.click(inner)
+    fireEvent.click(ext)
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 0))
+    })
+
+    fireEvent.touchMove(document.body)
+    expect(document.querySelector('.adm-popover-hidden')).toBeTruthy()
+  })
+
+  test('ref.show() should open Popover from closed state', () => {
+    const Wrap = () => {
+      const ref = React.useRef<PopoverRef>(null)
+      return (
+        <>
+          <Popover content='Bamboo' trigger='click' ref={ref}>
+            <button id='inner'>Hi</button>
+          </Popover>
+          <button id='ext' onClick={() => ref.current?.show()}>
+            external
+          </button>
+        </>
+      )
+    }
+
+    const { container } = render(<Wrap />)
+    const ext = container.querySelector('#ext') as HTMLElement
+
+    fireEvent.click(ext)
+    expect(
+      document.querySelector('.adm-popover-inner-content')?.textContent
+    ).toEqual('Bamboo')
+    expect(document.querySelector('.adm-popover-hidden')).toBeFalsy()
   })
 })


### PR DESCRIPTION
fixed #6731 修复 ref.show() 调用时弹窗会关闭

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化弹出层（Popover）显示与关闭交互：在通过 `show()` 的短时间触发链路内更稳定，避免同一点击导致的意外立即关闭。
  * 外部点击后仍可按预期关闭；从关闭状态再次显示时也能正常打开并展示内容。
* **Tests**
  * 增补了与 `PopoverRef.show()` 行为相关的测试用例，覆盖点击触发可见状态下的防抖关闭、外部点击关闭以及再次打开展示内容等场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->