### PR TITLE
fix(ci): align workflow Node.js version with package engines

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install pnpm
         id: pnpm-install
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 24
       - uses: pnpm/action-setup@v4
         with:
           version: 7

--- a/.github/workflows/doc-site.yml
+++ b/.github/workflows/doc-site.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '24'
 
       - name: Install pnpm
         id: pnpm-install

--- a/.github/workflows/doc-site.yml
+++ b/.github/workflows/doc-site.yml
@@ -12,10 +12,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Keep Node 16: dumi v1 (webpack/OpenSSL) does not support Node 17+
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '24'
+          node-version: '16'
 
       - name: Install pnpm
         id: pnpm-install

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install pnpm
         id: pnpm-install

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -20,9 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # Keep Node 16: dumi v1 (webpack/OpenSSL) does not support Node 17+
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 16
       - uses: pnpm/action-setup@v4
         with:
           version: 7

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 24
       - uses: pnpm/action-setup@v4
         with:
           version: 7


### PR DESCRIPTION
## Why
Package metadata declares `engines.node` / `volta.node` / `.nvmrc` as `24`, but CI workflows still pin `node-version` to a mismatched value.

That can make CI run on a runtime the project no longer supports (or skip the version the package actually targets).

## What changed
Align non-documentation workflows with Node 24, while keeping dumi v1 doc builds on Node 16.

- `.github/workflows/check.yml`
  - `node-version: 20` → `node-version: 24`
  - `node-version: 16` → `node-version: 24`
- `.github/workflows/pkg.pr.new.yml`
  - `node-version: 20` → `node-version: 24`
- `.github/workflows/doc-site.yml` / `.github/workflows/preview-build.yml`
  - Remain on Node `16` (dumi v1 / webpack OpenSSL incompatibility on Node 17+)

## Test plan
- [x] Package `engines.node` / `volta.node` / `.nvmrc` is still `24`
- [x] Non-doc workflows use Node 24
- [ ] Doc/preview workflows stay on Node 16 and `build preview` passes
- [ ] Relevant CI jobs on this branch look healthy

Found while auditing CI/package version consistency across popular repos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **维护**
  - 更新部分自动化检查、构建及发布流程使用的 Node.js 版本至 24。
  - 文档站点和预览构建流程继续使用 Node.js 16，以保持现有兼容性。
  - 优化持续集成与发布环境配置，应用功能、部署步骤及用户使用方式均无变化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->